### PR TITLE
Ensures token is available for authentication

### DIFF
--- a/integrationtest/global_hash.py
+++ b/integrationtest/global_hash.py
@@ -1,3 +1,5 @@
 from blaxel.common.internal import get_alphanumeric_limited_hash
 
 print(get_alphanumeric_limited_hash("charlou-function-blaxel-search", 48))
+
+print(get_alphanumeric_limited_hash("main-function-explorer-mcp", 48))

--- a/src/blaxel/authentication/clientcredentials.py
+++ b/src/blaxel/authentication/clientcredentials.py
@@ -111,4 +111,6 @@ class ClientCredentials(BlaxelAuth):
 
     @property
     def token(self):
+        if not self.credentials.access_token:
+            self.get_token()
         return self.credentials.access_token

--- a/src/blaxel/authentication/devicemode.py
+++ b/src/blaxel/authentication/devicemode.py
@@ -183,4 +183,5 @@ class DeviceMode(BlaxelAuth):
 
     @property
     def token(self):
+        self.refresh_if_needed()
         return self.credentials.access_token


### PR DESCRIPTION
Ensures that the access token is available before it is returned by refreshing or retrieving it if it's missing.
This prevents authentication failures when the token is not present.
