### PR TITLE
Adds support for environment variables to sandboxes

### DIFF
--- a/src/blaxel/core/sandbox/sandbox.py
+++ b/src/blaxel/core/sandbox/sandbox.py
@@ -77,7 +77,7 @@ class SandboxInstance:
         default_image = "blaxel/prod-base:latest"
         default_memory = 4096
 
-        # Handle SandboxCreateConfiguration or simple dict with name/image/memory/ports keys
+        # Handle SandboxCreateConfiguration or simple dict with name/image/memory/ports/envs keys
         if (
             sandbox is None
             or isinstance(sandbox, SandboxCreateConfiguration | dict)
@@ -89,6 +89,7 @@ class SandboxInstance:
                     or "image" in (sandbox if isinstance(sandbox, dict) else sandbox.__dict__)
                     or "memory" in (sandbox if isinstance(sandbox, dict) else sandbox.__dict__)
                     or "ports" in (sandbox if isinstance(sandbox, dict) else sandbox.__dict__)
+                    or "envs" in (sandbox if isinstance(sandbox, dict) else sandbox.__dict__)
                 )
             )
         ):
@@ -102,12 +103,13 @@ class SandboxInstance:
             image = sandbox.image or default_image
             memory = sandbox.memory or default_memory
             ports = sandbox._normalize_ports() or UNSET
+            envs = sandbox._normalize_envs() or UNSET
 
             # Create full Sandbox object
             sandbox = Sandbox(
                 metadata=Metadata(name=name),
                 spec=SandboxSpec(
-                    runtime=Runtime(image=image, memory=memory, ports=ports, generation="mk3")
+                    runtime=Runtime(image=image, memory=memory, ports=ports, envs=envs, generation="mk3")
                 ),
             )
         else:

--- a/src/blaxel/core/sandbox/types.py
+++ b/src/blaxel/core/sandbox/types.py
@@ -113,11 +113,13 @@ class SandboxCreateConfiguration:
         image: Optional[str] = None,
         memory: Optional[int] = None,
         ports: Optional[Union[List[Port], List[Dict[str, Any]]]] = None,
+        envs: Optional[List[Dict[str, str]]] = None,
     ):
         self.name = name
         self.image = image
         self.memory = memory
         self.ports = ports
+        self.envs = envs
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SandboxCreateConfiguration":
@@ -126,6 +128,7 @@ class SandboxCreateConfiguration:
             image=data.get("image"),
             memory=data.get("memory"),
             ports=data.get("ports"),
+            envs=data.get("envs"),
         )
 
     def _normalize_ports(self) -> Optional[List[Port]]:
@@ -150,3 +153,20 @@ class SandboxCreateConfiguration:
                 raise ValueError(f"Invalid port type: {type(port)}. Expected Port object or dict.")
 
         return port_objects
+
+    def _normalize_envs(self) -> Optional[List[Dict[str, str]]]:
+        """Convert envs to list of dicts with name and value keys."""
+        if not self.envs:
+            return None
+
+        env_objects = []
+        for env in self.envs:
+            if isinstance(env, dict):
+                # Validate that the dict has the required keys
+                if "name" not in env or "value" not in env:
+                    raise ValueError(f"Environment variable dict must have 'name' and 'value' keys: {env}")
+                env_objects.append({"name": env["name"], "value": env["value"]})
+            else:
+                raise ValueError(f"Invalid env type: {type(env)}. Expected dict with 'name' and 'value' keys.")
+
+        return env_objects

--- a/tests/integration/sandbox/create.py
+++ b/tests/integration/sandbox/create.py
@@ -107,6 +107,57 @@ async def main():
         await SandboxInstance.delete(sandbox.metadata.name)
         print("✅ Deleted ports sandbox")
 
+        # Test 9: Create sandbox with environment variables
+        print("\nTest 9: Create sandbox with environment variables...")
+        envs_config = SandboxCreateConfiguration(
+            name="sandbox-with-envs",
+            image="blaxel/prod-base:latest",
+            memory=2048,
+            envs=[
+                {"name": "NODE_ENV", "value": "development"},
+                {"name": "DEBUG", "value": "true"},
+                {"name": "API_KEY", "value": "secret123"},
+                {"name": "PORT", "value": "3000"},
+            ],
+        )
+        sandbox = await SandboxInstance.create(envs_config)
+        await sandbox.wait()
+        print(f"✅ Created sandbox with envs: {sandbox.metadata.name}")
+        print(f"   Image: {sandbox.spec.runtime.image}")
+        print(f"   Memory: {sandbox.spec.runtime.memory}")
+        sandbox = await SandboxInstance.get(sandbox.metadata.name)
+        if sandbox.spec.runtime.envs:
+            print(f"   Envs: {len(sandbox.spec.runtime.envs)} configured")
+            for env in sandbox.spec.runtime.envs:
+                print(f"     - {env['name']}: {env['value']}")
+        print(await sandbox.fs.ls("/blaxel/"))
+        await SandboxInstance.delete(sandbox.metadata.name)
+        print("✅ Deleted envs sandbox")
+
+        # Test 10: Create sandbox with environment variables using dict syntax
+        print("\nTest 10: Create sandbox with envs using dict syntax...")
+        sandbox = await SandboxInstance.create({
+            "name": "sandbox-with-envs-dict",
+            "image": "blaxel/prod-base:latest",
+            "memory": 2048,
+            "envs": [
+                {"name": "ENVIRONMENT", "value": "test"},
+                {"name": "VERSION", "value": "1.0.0"},
+            ]
+        })
+        await sandbox.wait()
+        print(f"✅ Created sandbox with envs dict: {sandbox.metadata.name}")
+        print(f"   Image: {sandbox.spec.runtime.image}")
+        print(f"   Memory: {sandbox.spec.runtime.memory}")
+        sandbox = await SandboxInstance.get(sandbox.metadata.name)
+        if sandbox.spec.runtime.envs:
+            print(f"   Envs: {len(sandbox.spec.runtime.envs)} configured")
+            for env in sandbox.spec.runtime.envs:
+                print(f"     - {env['name']}: {env['value']}")
+        print(await sandbox.fs.ls("/blaxel/"))
+        await SandboxInstance.delete(sandbox.metadata.name)
+        print("✅ Deleted envs dict sandbox")
+
         print("\n🎉 All sandbox creation tests passed!")
 
     except Exception as e:


### PR DESCRIPTION
Enables the configuration of environment variables for sandbox instances.

This change introduces the ability to specify environment variables when creating sandboxes, enhancing their customizability and allowing for more flexible runtime configurations. It updates the SandboxCreateConfiguration to include an optional 'envs' parameter and modifies the SandboxInstance creation process to incorporate these environment variables into the sandbox specification.

Also adds integration tests to verify the functionality.
