### PR TITLE
Refactors Sandbox Preview Management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 	uv sync --all-groups --all-packages --all-extras
 
 sdk-sandbox:
-	cp ../sandbox/sandbox-api/docs/openapi.yml ./definition.yml
+	cp ../../sandbox/sandbox-api/docs/openapi.yml ./definition.yml
 	rm -rf src/blaxel/core/sandbox/client/api src/blaxel/core/sandbox/client/models
 	openapi-python-client generate \
 		--path=definition.yml \
@@ -17,7 +17,7 @@ sdk-sandbox:
 	uv run ruff check --fix
 
 sdk-controlplane:
-	cp ../controlplane/api/api/definitions/controlplane.yml ./definition.yml
+	cp ../../controlplane/api/api/definitions/controlplane.yml ./definition.yml
 	rm -rf src/blaxel/core/client/api src/blaxel/core/client/models
 	openapi-python-client generate \
 		--path=definition.yml \

--- a/src/blaxel/core/client/models/job_spec.py
+++ b/src/blaxel/core/client/models/job_spec.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from ..models.model_private_cluster import ModelPrivateCluster
     from ..models.revision_configuration import RevisionConfiguration
     from ..models.runtime import Runtime
+    from ..models.trigger import Trigger
 
 
 T = TypeVar("T", bound="JobSpec")
@@ -30,6 +31,7 @@ class JobSpec:
         revision (Union[Unset, RevisionConfiguration]): Revision configuration
         runtime (Union[Unset, Runtime]): Set of configurations for a deployment
         sandbox (Union[Unset, bool]): Sandbox mode
+        triggers (Union[Unset, list['Trigger']]): Triggers to use your agent
     """
 
     configurations: Union[Unset, "CoreSpecConfigurations"] = UNSET
@@ -41,6 +43,7 @@ class JobSpec:
     revision: Union[Unset, "RevisionConfiguration"] = UNSET
     runtime: Union[Unset, "Runtime"] = UNSET
     sandbox: Union[Unset, bool] = UNSET
+    triggers: Union[Unset, list["Trigger"]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -98,6 +101,16 @@ class JobSpec:
 
         sandbox = self.sandbox
 
+        triggers: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.triggers, Unset):
+            triggers = []
+            for componentsschemas_triggers_item_data in self.triggers:
+                if type(componentsschemas_triggers_item_data) is dict:
+                    componentsschemas_triggers_item = componentsschemas_triggers_item_data
+                else:
+                    componentsschemas_triggers_item = componentsschemas_triggers_item_data.to_dict()
+                triggers.append(componentsschemas_triggers_item)
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -119,6 +132,8 @@ class JobSpec:
             field_dict["runtime"] = runtime
         if sandbox is not UNSET:
             field_dict["sandbox"] = sandbox
+        if triggers is not UNSET:
+            field_dict["triggers"] = triggers
 
         return field_dict
 
@@ -129,6 +144,7 @@ class JobSpec:
         from ..models.model_private_cluster import ModelPrivateCluster
         from ..models.revision_configuration import RevisionConfiguration
         from ..models.runtime import Runtime
+        from ..models.trigger import Trigger
 
         if not src_dict:
             return None
@@ -176,6 +192,13 @@ class JobSpec:
 
         sandbox = d.pop("sandbox", UNSET)
 
+        triggers = []
+        _triggers = d.pop("triggers", UNSET)
+        for componentsschemas_triggers_item_data in _triggers or []:
+            componentsschemas_triggers_item = Trigger.from_dict(componentsschemas_triggers_item_data)
+
+            triggers.append(componentsschemas_triggers_item)
+
         job_spec = cls(
             configurations=configurations,
             enabled=enabled,
@@ -186,6 +209,7 @@ class JobSpec:
             revision=revision,
             runtime=runtime,
             sandbox=sandbox,
+            triggers=triggers,
         )
 
         job_spec.additional_properties = d

--- a/src/blaxel/core/client/models/trigger.py
+++ b/src/blaxel/core/client/models/trigger.py
@@ -17,7 +17,7 @@ class Trigger:
     """Trigger configuration
 
     Attributes:
-        configuration (Union[Unset, TriggerConfiguration]): The configuration of the trigger
+        configuration (Union[Unset, TriggerConfiguration]): Trigger configuration
         id (Union[Unset, str]): The id of the trigger
         type_ (Union[Unset, str]): The type of trigger, can be http or http-async
     """

--- a/src/blaxel/core/client/models/trigger_configuration.py
+++ b/src/blaxel/core/client/models/trigger_configuration.py
@@ -1,20 +1,50 @@
-from typing import Any, TypeVar
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="TriggerConfiguration")
 
 
 @_attrs_define
 class TriggerConfiguration:
-    """The configuration of the trigger"""
+    """Trigger configuration
 
+    Attributes:
+        authentication_type (Union[Unset, str]): The authentication type of the trigger
+        path (Union[Unset, str]): The path of the trigger
+        retry (Union[Unset, int]): The retry of the trigger
+        schedule (Union[Unset, str]): The schedule of the trigger, cron expression * * * * *
+    """
+
+    authentication_type: Union[Unset, str] = UNSET
+    path: Union[Unset, str] = UNSET
+    retry: Union[Unset, int] = UNSET
+    schedule: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        authentication_type = self.authentication_type
+
+        path = self.path
+
+        retry = self.retry
+
+        schedule = self.schedule
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if authentication_type is not UNSET:
+            field_dict["authenticationType"] = authentication_type
+        if path is not UNSET:
+            field_dict["path"] = path
+        if retry is not UNSET:
+            field_dict["retry"] = retry
+        if schedule is not UNSET:
+            field_dict["schedule"] = schedule
 
         return field_dict
 
@@ -23,7 +53,20 @@ class TriggerConfiguration:
         if not src_dict:
             return None
         d = src_dict.copy()
-        trigger_configuration = cls()
+        authentication_type = d.pop("authenticationType", UNSET)
+
+        path = d.pop("path", UNSET)
+
+        retry = d.pop("retry", UNSET)
+
+        schedule = d.pop("schedule", UNSET)
+
+        trigger_configuration = cls(
+            authentication_type=authentication_type,
+            path=path,
+            retry=retry,
+            schedule=schedule,
+        )
 
         trigger_configuration.additional_properties = d
         return trigger_configuration

--- a/src/blaxel/core/sandbox/client/models/success_response.py
+++ b/src/blaxel/core/sandbox/client/models/success_response.py
@@ -1,7 +1,9 @@
-from typing import Any, TypeVar
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="SuccessResponse")
 
@@ -11,11 +13,11 @@ class SuccessResponse:
     """
     Attributes:
         message (str):  Example: File created successfully.
-        path (str):  Example: /path/to/file.
+        path (Union[Unset, str]):  Example: /path/to/file.
     """
 
     message: str
-    path: str
+    path: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -28,9 +30,10 @@ class SuccessResponse:
         field_dict.update(
             {
                 "message": message,
-                "path": path,
             }
         )
+        if path is not UNSET:
+            field_dict["path"] = path
 
         return field_dict
 
@@ -41,7 +44,7 @@ class SuccessResponse:
         d = src_dict.copy()
         message = d.pop("message")
 
-        path = d.pop("path")
+        path = d.pop("path", UNSET)
 
         success_response = cls(
             message=message,

--- a/src/blaxel/core/sandbox/preview.py
+++ b/src/blaxel/core/sandbox/preview.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from ..client import errors
 from ..client.api.compute.create_sandbox_preview import (
     asyncio as create_sandbox_preview,
 )
@@ -47,18 +48,21 @@ class SandboxPreviewToken:
 class SandboxPreviewTokens:
     """Manages preview tokens for a sandbox preview."""
 
-    def __init__(self, preview: Preview, sandbox_name: str):
+    def __init__(self, preview: Preview):
         self.preview = preview
-        self.sandbox_name = sandbox_name
 
     @property
     def preview_name(self) -> str:
         return self.preview.metadata.name if self.preview.metadata else ""
 
+    @property
+    def resource_name(self) -> str:
+        return self.preview.metadata.resource_name if self.preview.metadata else ""
+
     async def create(self, expires_at: datetime) -> SandboxPreviewToken:
         """Create a new preview token."""
         response: PreviewToken = await create_sandbox_preview_token(
-            self.sandbox_name,
+            self.resource_name,
             self.preview_name,
             body=PreviewToken(
                 spec=PreviewTokenSpec(
@@ -72,7 +76,7 @@ class SandboxPreviewTokens:
     async def list(self) -> List[SandboxPreviewToken]:
         """List all preview tokens."""
         response: List[PreviewToken] = await list_sandbox_preview_tokens(
-            self.sandbox_name,
+            self.resource_name,
             self.preview_name,
             client=client,
         )
@@ -81,7 +85,7 @@ class SandboxPreviewTokens:
     async def delete(self, token_name: str) -> dict:
         """Delete a preview token."""
         response: PreviewToken = await delete_sandbox_preview_token(
-            self.sandbox_name,
+            self.resource_name,
             self.preview_name,
             token_name,
             client=client,
@@ -92,10 +96,9 @@ class SandboxPreviewTokens:
 class SandboxPreview:
     """Represents a sandbox preview with its metadata and tokens."""
 
-    def __init__(self, preview: Preview, sandbox_name: str = ""):
+    def __init__(self, preview: Preview):
         self.preview = preview
-        self.sandbox_name = sandbox_name
-        self.tokens = SandboxPreviewTokens(preview, sandbox_name)
+        self.tokens = SandboxPreviewTokens(preview)
 
     @property
     def name(self) -> str:
@@ -139,6 +142,24 @@ class SandboxPreviews:
             client=client,
         )
         return SandboxPreview(response)
+
+    async def create_if_not_exists(self, preview: Union[Preview, Dict[str, Any]]) -> SandboxPreview:
+        """Create a preview if it doesn't exist, otherwise return the existing one."""
+        if isinstance(preview, dict):
+            preview = Preview.from_dict(preview)
+
+        preview_name = preview.metadata.name if preview.metadata else ""
+
+        try:
+            # Try to get existing preview
+            existing_preview = await self.get(preview_name)
+            return existing_preview
+        except errors.UnexpectedStatus as e:
+            # If 404, create the preview
+            if e.status_code == 404:
+                return await self.create(preview)
+            # For any other error, re-raise
+            raise e
 
     async def get(self, preview_name: str) -> SandboxPreview:
         """Get a specific preview by name."""

--- a/src/blaxel/core/sandbox/session.py
+++ b/src/blaxel/core/sandbox/session.py
@@ -46,7 +46,7 @@ class SandboxSessions:
             self.sandbox_name, client=client, body=preview_body
         )
 
-        preview = SandboxPreview(preview_response, self.sandbox_name)
+        preview = SandboxPreview(preview_response)
         token_obj = await preview.tokens.create(expires_at)
 
         return SessionWithToken(


### PR DESCRIPTION
- Simplifies sandbox preview token management by removing the need to pass the sandbox name to the `SandboxPreviewTokens` and `SandboxPreview` classes. It now relies on the `resource_name` property of the `Preview` object.

- Implements a `create_if_not_exists` method for `SandboxPreviews` which allows creation of a sandbox preview only if it doesn't already exist. This provides a convenient way to ensure a preview exists without raising an exception if it already exists.