### PR TITLE
Refactors process request to include logging

### DIFF
--- a/src/blaxel/core/sandbox/__init__.py
+++ b/src/blaxel/core/sandbox/__init__.py
@@ -7,6 +7,7 @@ from .sandbox import (
 )
 from .types import (
     CopyResponse,
+    ProcessRequestWithLog,
     SandboxConfiguration,
     SandboxCreateConfiguration,
     SandboxFilesystemFile,
@@ -28,4 +29,5 @@ __all__ = [
     "SandboxFileSystem",
     "SandboxPreviews",
     "SandboxProcess",
+    "ProcessRequestWithLog",
 ]

--- a/src/blaxel/core/sandbox/process.py
+++ b/src/blaxel/core/sandbox/process.py
@@ -7,7 +7,7 @@ from ..common.settings import settings
 from .action import SandboxAction
 from .client.models import ProcessResponse, SuccessResponse
 from .client.models.process_request import ProcessRequest
-from .types import SandboxConfiguration
+from .types import ProcessRequestWithLog, SandboxConfiguration
 
 
 class SandboxProcess(SandboxAction):
@@ -76,11 +76,17 @@ class SandboxProcess(SandboxAction):
         return {"close": close}
 
     async def exec(
-        self,
-        process: Union[ProcessRequest, Dict[str, Any]],
-        on_log: Optional[Callable[[str], None]] = None,
+        self, process: Union[ProcessRequest, ProcessRequestWithLog, Dict[str, Any]]
     ) -> ProcessResponse:
+        on_log = None
+        if isinstance(process, ProcessRequestWithLog):
+            on_log = process.on_log
+            process = process.to_dict()
+
         if isinstance(process, dict):
+            if "on_log" in process:
+                on_log = process["on_log"]
+                del process["on_log"]
             process = ProcessRequest.from_dict(process)
 
         # Store original wait_for_completion setting

--- a/src/blaxel/core/sandbox/types.py
+++ b/src/blaxel/core/sandbox/types.py
@@ -1,8 +1,11 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from attrs import define as _attrs_define
 
 from ..client.models import Port, Sandbox
 from ..client.types import UNSET
+from .client.models.process_request import ProcessRequest
 
 
 class SessionCreateOptions:
@@ -164,9 +167,18 @@ class SandboxCreateConfiguration:
             if isinstance(env, dict):
                 # Validate that the dict has the required keys
                 if "name" not in env or "value" not in env:
-                    raise ValueError(f"Environment variable dict must have 'name' and 'value' keys: {env}")
+                    raise ValueError(
+                        f"Environment variable dict must have 'name' and 'value' keys: {env}"
+                    )
                 env_objects.append({"name": env["name"], "value": env["value"]})
             else:
-                raise ValueError(f"Invalid env type: {type(env)}. Expected dict with 'name' and 'value' keys.")
+                raise ValueError(
+                    f"Invalid env type: {type(env)}. Expected dict with 'name' and 'value' keys."
+                )
 
         return env_objects
+
+
+@_attrs_define
+class ProcessRequestWithLog(ProcessRequest):
+    on_log: Callable[[str], None] = None

--- a/tests/integration/sandbox/utils.py
+++ b/tests/integration/sandbox/utils.py
@@ -163,11 +163,21 @@ async def check_usage(sandbox: SandboxInstance) -> None:
 
     # Check disk space
     disk_space = await sandbox.process.exec(
-        name="disk-space", command="df -m", working_dir="/home/user"
+        {
+            "name": "disk-space",
+            "command": "df -m",
+            "working_dir": "/home/user",
+        }
     )
 
     # Check memory usage
-    memory = await sandbox.process.exec(name="memory", command="free -m", working_dir="/home/user")
+    memory = await sandbox.process.exec(
+        {
+            "name": "memory",
+            "command": "free -m",
+            "working_dir": "/home/user",
+        }
+    )
 
     # Get logs
     memory_logs = await sandbox.process.logs(memory.pid, "all")


### PR DESCRIPTION
Moves the `on_log` callback from the `exec` method to the `ProcessRequest` object.
This simplifies the `exec` method signature and provides a more structured way to handle real-time logging during process execution.
Now, logging configuration is encapsulated within the `ProcessRequestWithLog` type.

Remove on_log from dict for serialization
