### PR TITLE
Adds log stream closing to sandbox processes

### DIFF
--- a/src/blaxel/core/sandbox/__init__.py
+++ b/src/blaxel/core/sandbox/__init__.py
@@ -8,6 +8,7 @@ from .sandbox import (
 from .types import (
     CopyResponse,
     ProcessRequestWithLog,
+    ProcessResponseWithLog,
     SandboxConfiguration,
     SandboxCreateConfiguration,
     SandboxFilesystemFile,
@@ -30,4 +31,5 @@ __all__ = [
     "SandboxPreviews",
     "SandboxProcess",
     "ProcessRequestWithLog",
+    "ProcessResponseWithLog",
 ]


### PR DESCRIPTION
Introduces the ability to close the log stream of a sandbox process
without terminating the process itself. This is achieved by returning
a `ProcessResponseWithLog` object that encapsulates the original
response and a `close()` function, allowing users to stop the stream
programmatically. Also adds a new integration test to verify this
functionality.
