### PR TITLE
Removes unnecessary sandbox wait

### DIFF
--- a/tests/integration/sandbox/binary_write.py
+++ b/tests/integration/sandbox/binary_write.py
@@ -19,10 +19,6 @@ async def main():
         sandbox = await create_or_get_sandbox(SANDBOX_NAME)
         print(f"✅ Sandbox ready: {sandbox.metadata.name}")
 
-        # Wait for sandbox to be deployed
-        await sandbox.wait()
-        print("✅ Sandbox deployed successfully")
-
         # Create test binary data
         print("🔧 Creating test binary data...")
         test_binary_data = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\tpHYs\x00\x00\x0b\x13\x00\x00\x0b\x13\x01\x00\x9a\x9c\x18\x00\x00\x00\nIDATx\x9cc\xf8\x00\x00\x00\x01\x00\x01\x00\x00\x00\x00IEND\xaeB`\x82"

--- a/tests/integration/sandbox/comprehensive.py
+++ b/tests/integration/sandbox/comprehensive.py
@@ -286,10 +286,6 @@ async def main():
         sandbox = await create_or_get_sandbox(SANDBOX_NAME)
         print(f"✅ Sandbox ready: {sandbox.metadata.name}")
 
-        # Wait for sandbox to be deployed
-        await sandbox.wait()
-        print("✅ Sandbox deployed successfully")
-
         # Run all test suites
         await test_filesystem(sandbox)
         print()

--- a/tests/integration/sandbox/create.py
+++ b/tests/integration/sandbox/create.py
@@ -10,7 +10,6 @@ async def main():
         # Test 1: Create sandbox with no parameters (should use defaults)
         print("Test 1: Create sandbox with default parameters...")
         sandbox = await SandboxInstance.create()
-        await sandbox.wait()
         print(f"✅ Created sandbox with default name: {sandbox.metadata.name}")
         print(await sandbox.fs.ls("/blaxel"))
         await SandboxInstance.delete(sandbox.metadata.name)
@@ -21,7 +20,6 @@ async def main():
         sandbox = await SandboxInstance.create(
             {"spec": {"runtime": {"image": "blaxel/prod-base:latest"}}}
         )
-        await sandbox.wait()
         print(f"✅ Created sandbox with spec: {sandbox.metadata.name}")
         print(await sandbox.fs.ls("/blaxel"))
         await SandboxInstance.delete(sandbox.metadata.name)
@@ -30,7 +28,6 @@ async def main():
         # Test 3: Create sandbox with simplified name configuration
         print("\nTest 3: Create sandbox with name configuration...")
         sandbox = await SandboxInstance.create({"name": "sandbox-with-name"})
-        await sandbox.wait()
         print(f"✅ Created sandbox with name: {sandbox.metadata.name}")
         print(await sandbox.fs.ls("/blaxel/"))
         await SandboxInstance.delete(sandbox.metadata.name)
@@ -40,7 +37,6 @@ async def main():
         print("\nTest 4: Create sandbox with SandboxCreateConfiguration...")
         config = SandboxCreateConfiguration(name="sandbox-config-test")
         sandbox = await SandboxInstance.create(config)
-        await sandbox.wait()
         print(f"✅ Created sandbox with config: {sandbox.metadata.name}")
         print(await sandbox.fs.ls("/blaxel/"))
         await SandboxInstance.delete(sandbox.metadata.name)
@@ -49,7 +45,6 @@ async def main():
         # Test 5: Create sandbox if not exists with name
         print("\nTest 5: Create sandbox if not exists with name...")
         sandbox = await SandboxInstance.create_if_not_exists({"name": "sandbox-cine-name"})
-        await sandbox.wait()
         print(f"✅ Created/found sandbox: {sandbox.metadata.name}")
         print(await sandbox.fs.ls("/blaxel/"))
         await SandboxInstance.delete(sandbox.metadata.name)
@@ -60,7 +55,6 @@ async def main():
         sandbox = await SandboxInstance.create_if_not_exists(
             {"metadata": {"name": "sandbox-cine-metadata"}}
         )
-        await sandbox.wait()
         print(f"✅ Created/found sandbox with metadata: {sandbox.metadata.name}")
         print(await sandbox.fs.ls("/blaxel/"))
         await SandboxInstance.delete(sandbox.metadata.name)
@@ -74,7 +68,6 @@ async def main():
             memory=2048,
         )
         sandbox = await SandboxInstance.create(custom_config)
-        await sandbox.wait()
         print(f"✅ Created custom sandbox: {sandbox.metadata.name}")
         print(f"   Image: {sandbox.spec.runtime.image}")
         print(f"   Memory: {sandbox.spec.runtime.memory}")
@@ -94,7 +87,6 @@ async def main():
             ],
         )
         sandbox = await SandboxInstance.create(ports_config)
-        await sandbox.wait()
         print(f"✅ Created sandbox with ports: {sandbox.metadata.name}")
         print(f"   Image: {sandbox.spec.runtime.image}")
         print(f"   Memory: {sandbox.spec.runtime.memory}")
@@ -121,7 +113,6 @@ async def main():
             ],
         )
         sandbox = await SandboxInstance.create(envs_config)
-        await sandbox.wait()
         print(f"✅ Created sandbox with envs: {sandbox.metadata.name}")
         print(f"   Image: {sandbox.spec.runtime.image}")
         print(f"   Memory: {sandbox.spec.runtime.memory}")
@@ -136,16 +127,17 @@ async def main():
 
         # Test 10: Create sandbox with environment variables using dict syntax
         print("\nTest 10: Create sandbox with envs using dict syntax...")
-        sandbox = await SandboxInstance.create({
-            "name": "sandbox-with-envs-dict",
-            "image": "blaxel/prod-base:latest",
-            "memory": 2048,
-            "envs": [
-                {"name": "ENVIRONMENT", "value": "test"},
-                {"name": "VERSION", "value": "1.0.0"},
-            ]
-        })
-        await sandbox.wait()
+        sandbox = await SandboxInstance.create(
+            {
+                "name": "sandbox-with-envs-dict",
+                "image": "blaxel/prod-base:latest",
+                "memory": 2048,
+                "envs": [
+                    {"name": "ENVIRONMENT", "value": "test"},
+                    {"name": "VERSION", "value": "1.0.0"},
+                ],
+            }
+        )
         print(f"✅ Created sandbox with envs dict: {sandbox.metadata.name}")
         print(f"   Image: {sandbox.spec.runtime.image}")
         print(f"   Memory: {sandbox.spec.runtime.memory}")

--- a/tests/integration/sandbox/process_kill.py
+++ b/tests/integration/sandbox/process_kill.py
@@ -120,10 +120,6 @@ async def main():
         sandbox = await create_or_get_sandbox(SANDBOX_NAME)
         print(f"✅ Sandbox ready: {sandbox.metadata.name}")
 
-        # Wait for sandbox to be deployed
-        await sandbox.wait()
-        print("✅ Sandbox deployed successfully")
-
         # Run different kill tests
         await test_quick_process_kill(sandbox)
         print()

--- a/tests/integration/sandbox/read_multiple_files.py
+++ b/tests/integration/sandbox/read_multiple_files.py
@@ -20,10 +20,6 @@ async def main():
         sandbox = await create_or_get_sandbox(SANDBOX_NAME)
         print(f"✅ Sandbox ready: {sandbox.metadata.name}")
 
-        # Wait for sandbox to be deployed
-        await sandbox.wait()
-        print("✅ Sandbox deployed successfully")
-
         # Setup test directory
         user = os.environ.get("USER", "testuser")
         test_dir = f"/Users/{user}/Downloads/read_test"

--- a/tests/integration/sandbox/small.py
+++ b/tests/integration/sandbox/small.py
@@ -1,70 +1,28 @@
 import asyncio
+import time
 from logging import getLogger
 
 from utils import create_or_get_sandbox
 
-from blaxel.core.sandbox import SandboxInstance
-from blaxel.core.sandbox.client.models.process_request import ProcessRequest
-
 logger = getLogger(__name__)
 
-SANDBOX_NAME = "sandbox-test-python-small"
+SANDBOX_NAME = "next-js-7"
 
 
 async def main():
     """Main small sandbox test function."""
-    print("🚀 Starting small sandbox test...")
 
-    try:
-        # Create or get sandbox
-        sandbox = await create_or_get_sandbox(SANDBOX_NAME)
-        print(f"✅ Sandbox ready: {sandbox.metadata.name}")
+    # Test with controlplane
+    start = time.time()
+    sandbox = await create_or_get_sandbox(SANDBOX_NAME)
+    duration_ms = int((time.time() - start) * 1000)
+    print(f"Time taken for create_or_get_sandbox: {duration_ms}ms")
 
-        # Wait for sandbox to be deployed
-        await sandbox.wait()
-        print("✅ Sandbox deployed successfully")
-
-        # Quick filesystem test
-        print("🔧 Quick filesystem test...")
-        test_file = "/tmp/small_test.txt"
-        test_content = "Hello from small test!"
-
-        # Write and read
-        await sandbox.fs.write(test_file, test_content)
-        content = await sandbox.fs.read(test_file)
-
-        assert content == test_content, f"Content mismatch: {content}"
-        print("✅ Filesystem read/write working")
-
-        # Quick process test
-        print("🔧 Quick process test...")
-        process_request = ProcessRequest(name="small-test", command="echo 'Small test process'")
-        await sandbox.process.exec(process_request)
-
-        # Wait for completion
-        await sandbox.process.wait("small-test", max_wait=10000)
-        logs = await sandbox.process.logs("small-test")
-
-        assert "Small test process" in logs, f"Process output unexpected: {logs}"
-        print("✅ Process execution working")
-
-        # Quick cleanup
-        await sandbox.fs.rm(test_file)
-        print("✅ Cleanup completed")
-
-        print("🎉 Small sandbox test completed successfully!")
-
-    except Exception as e:
-        print(f"❌ Small sandbox test failed with error: {e}")
-        logger.exception("Small sandbox test error")
-        raise
-    finally:
-        print("🧹 Final cleanup...")
-        try:
-            await SandboxInstance.delete(SANDBOX_NAME)
-            print("✅ Sandbox deleted")
-        except Exception as e:
-            print(f"⚠️ Failed to delete sandbox: {e}")
+    # Verify with a simple process execution
+    result = await sandbox.process.exec(
+        {"command": "echo 'Hello, world!'", "waitForCompletion": True}
+    )
+    print(result)
 
 
 if __name__ == "__main__":

--- a/tests/integration/sandbox/utils.py
+++ b/tests/integration/sandbox/utils.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional
 from blaxel.core.client.models import Metadata, Port, Runtime, Sandbox, SandboxSpec
 from blaxel.core.sandbox import SandboxInstance
 
+env = os.environ.get("BL_ENV", "prod")
+
 sep = "--------------------------------"
 
 
@@ -16,16 +18,14 @@ def info(msg: str) -> None:
 
 async def local_sandbox(sandbox_name: str) -> SandboxInstance:
     """Create a local sandbox instance for testing."""
-    env_var = f"BL_SANDBOXES_{sandbox_name.replace('-', '_').upper()}_URL"
-    os.environ[env_var] = "http://localhost:8080"
-
+    info(f"Using local sandbox {sandbox_name}")
     sandbox = SandboxInstance(Sandbox(metadata=Metadata(name=sandbox_name)))
     return sandbox
 
 
 async def create_or_get_sandbox(
     sandbox_name: str,
-    image: str = "blaxel/prod-nextjs:latest",
+    image: str = f"blaxel/{env}-nextjs:latest",
     ports: Optional[List[Dict[str, Any]]] = None,
     memory: int = 4096,
     envs: Optional[List[Dict[str, str]]] = None,
@@ -66,7 +66,6 @@ async def create_or_get_sandbox(
     sandbox_model = Sandbox(metadata=metadata, spec=spec)
 
     sandbox = await SandboxInstance.create_if_not_exists(sandbox_model)
-    await sandbox.wait(max_wait=120000, interval=1000)
     return sandbox
 
 

--- a/tests/integration/sandbox/watch_folder.py
+++ b/tests/integration/sandbox/watch_folder.py
@@ -20,10 +20,6 @@ async def main():
         sandbox = await create_or_get_sandbox(SANDBOX_NAME)
         print(f"✅ Sandbox ready: {sandbox.metadata.name}")
 
-        # Wait for sandbox to be deployed
-        await sandbox.wait()
-        print("✅ Sandbox deployed successfully")
-
         # Setup test directory
         user = os.environ.get("USER", "testuser")
         test_dir = f"/Users/{user}/Downloads/watch_test"

--- a/tests/integration/sandbox/write_tree.py
+++ b/tests/integration/sandbox/write_tree.py
@@ -21,10 +21,6 @@ async def main():
         sandbox = await create_or_get_sandbox(SANDBOX_NAME)
         print(f"✅ Sandbox ready: {sandbox.metadata.name}")
 
-        # Wait for sandbox to be deployed
-        await sandbox.wait()
-        print("✅ Sandbox deployed successfully")
-
         # Setup test directory
         user = os.environ.get("USER", "testuser")
         test_dir = f"/Users/{user}/Downloads/write_tree_test"


### PR DESCRIPTION
Removes the explicit wait for sandbox deployment in `SandboxInstance.wait()`.

- Sandbox deployment is now handled asynchronously, so the `wait()` method is no longer required.
- This change simplifies the sandbox creation process and improves the overall efficiency of integration tests.
- Adds a warning log to notify users `sandbox.wait()` is deprecated.