### PR TITLE
fix: recreate async client on event loop mismatch and update SDK models

### DIFF
--- a/src/blaxel/core/client/api/images/create_image.py
+++ b/src/blaxel/core/client/api/images/create_image.py
@@ -1,0 +1,182 @@
+from http import HTTPStatus
+from typing import Any, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.create_image_body import CreateImageBody
+from ...models.create_image_response_200 import CreateImageResponse200
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: CreateImageBody,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/images",
+    }
+
+    if type(body) is dict:
+        _body = body
+    else:
+        _body = body.to_dict()
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Client, response: httpx.Response
+) -> Union[Any, CreateImageResponse200] | None:
+    if response.status_code == 200:
+        response_200 = CreateImageResponse200.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Client, response: httpx.Response
+) -> Response[Union[Any, CreateImageResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    body: CreateImageBody,
+) -> Response[Union[Any, CreateImageResponse200]]:
+    """Build a container image
+
+     Builds a container image without creating a deployment. Returns a presigned URL for uploading source
+    code. After upload, the image will be built and stored in the registry, but no agent, function,
+    sandbox, or job will be created or updated.
+
+    Args:
+        body (CreateImageBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CreateImageResponse200]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    body: CreateImageBody,
+) -> Union[Any, CreateImageResponse200] | None:
+    """Build a container image
+
+     Builds a container image without creating a deployment. Returns a presigned URL for uploading source
+    code. After upload, the image will be built and stored in the registry, but no agent, function,
+    sandbox, or job will be created or updated.
+
+    Args:
+        body (CreateImageBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CreateImageResponse200]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    body: CreateImageBody,
+) -> Response[Union[Any, CreateImageResponse200]]:
+    """Build a container image
+
+     Builds a container image without creating a deployment. Returns a presigned URL for uploading source
+    code. After upload, the image will be built and stored in the registry, but no agent, function,
+    sandbox, or job will be created or updated.
+
+    Args:
+        body (CreateImageBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CreateImageResponse200]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    body: CreateImageBody,
+) -> Union[Any, CreateImageResponse200] | None:
+    """Build a container image
+
+     Builds a container image without creating a deployment. Returns a presigned URL for uploading source
+    code. After upload, the image will be built and stored in the registry, but no agent, function,
+    sandbox, or job will be created or updated.
+
+    Args:
+        body (CreateImageBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CreateImageResponse200]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/src/blaxel/core/client/client.py
+++ b/src/blaxel/core/client/client.py
@@ -1,3 +1,4 @@
+import asyncio
 import ssl
 from typing import Any, Union
 
@@ -50,6 +51,7 @@ class Client:
     _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
     _client: httpx.Client | None = field(default=None, init=False)
     _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+    _async_client_loop: asyncio.AbstractEventLoop | None = field(default=None, init=False)
 
     def with_base_url(self, base_url: str) -> "Client":
         """Get a new client matching this one with a new base URL"""
@@ -138,6 +140,15 @@ class Client:
 
     def get_async_httpx_client(self) -> httpx.AsyncClient:
         """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+
+        if self._async_client is not None and current_loop is not self._async_client_loop:
+            self._async_client = None
+            self._async_client_loop = None
+
         if self._async_client is None:
             self._async_client = httpx.AsyncClient(
                 base_url=self._base_url,
@@ -149,6 +160,7 @@ class Client:
                 auth=self._auth,
                 **self._httpx_args,
             )
+            self._async_client_loop = current_loop
         return self._async_client
 
     async def __aenter__(self) -> "Client":

--- a/src/blaxel/core/client/models/__init__.py
+++ b/src/blaxel/core/client/models/__init__.py
@@ -13,6 +13,8 @@ from .core_event import CoreEvent
 from .country import Country
 from .create_api_key_for_service_account_body import CreateApiKeyForServiceAccountBody
 from .create_drive_access_token_response_200 import CreateDriveAccessTokenResponse200
+from .create_image_body import CreateImageBody
+from .create_image_response_200 import CreateImageResponse200
 from .create_job_execution_output import CreateJobExecutionOutput
 from .create_job_execution_output_tasks_item import CreateJobExecutionOutputTasksItem
 from .create_job_execution_request import CreateJobExecutionRequest
@@ -67,6 +69,7 @@ from .get_workspace_features_response_200_features import GetWorkspaceFeaturesRe
 from .get_workspace_service_accounts_response_200_item import (
     GetWorkspaceServiceAccountsResponse200Item,
 )
+from .github_runner_config import GithubRunnerConfig
 from .group_workspace_mapping import GroupWorkspaceMapping
 from .group_workspace_mapping_role import GroupWorkspaceMappingRole
 from .image import Image
@@ -104,6 +107,8 @@ from .job_execution_task_status import JobExecutionTaskStatus
 from .job_runtime import JobRuntime
 from .job_runtime_generation import JobRuntimeGeneration
 from .job_spec import JobSpec
+from .job_volume import JobVolume
+from .job_volume_type import JobVolumeType
 from .location_response import LocationResponse
 from .mcp_definition import MCPDefinition
 from .mcp_definition_categories_item import MCPDefinitionCategoriesItem
@@ -121,6 +126,7 @@ from .owner_fields import OwnerFields
 from .pending_invitation import PendingInvitation
 from .pending_invitation_accept import PendingInvitationAccept
 from .pending_invitation_render import PendingInvitationRender
+from .pending_invitation_render_account import PendingInvitationRenderAccount
 from .pending_invitation_render_invited_by import PendingInvitationRenderInvitedBy
 from .pending_invitation_render_workspace import PendingInvitationRenderWorkspace
 from .pending_invitation_workspace_details import PendingInvitationWorkspaceDetails
@@ -215,6 +221,8 @@ __all__ = (
     "Country",
     "CreateApiKeyForServiceAccountBody",
     "CreateDriveAccessTokenResponse200",
+    "CreateImageBody",
+    "CreateImageResponse200",
     "CreateJobExecutionOutput",
     "CreateJobExecutionOutputTasksItem",
     "CreateJobExecutionRequest",
@@ -267,6 +275,7 @@ __all__ = (
     "GetWorkspaceFeaturesResponse200",
     "GetWorkspaceFeaturesResponse200Features",
     "GetWorkspaceServiceAccountsResponse200Item",
+    "GithubRunnerConfig",
     "GroupWorkspaceMapping",
     "GroupWorkspaceMappingRole",
     "Image",
@@ -304,6 +313,8 @@ __all__ = (
     "JobRuntime",
     "JobRuntimeGeneration",
     "JobSpec",
+    "JobVolume",
+    "JobVolumeType",
     "LocationResponse",
     "MCPDefinition",
     "MCPDefinitionCategoriesItem",
@@ -321,6 +332,7 @@ __all__ = (
     "PendingInvitation",
     "PendingInvitationAccept",
     "PendingInvitationRender",
+    "PendingInvitationRenderAccount",
     "PendingInvitationRenderInvitedBy",
     "PendingInvitationRenderWorkspace",
     "PendingInvitationWorkspaceDetails",

--- a/src/blaxel/core/client/models/create_image_body.py
+++ b/src/blaxel/core/client/models/create_image_body.py
@@ -1,0 +1,89 @@
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CreateImageBody")
+
+
+@_attrs_define
+class CreateImageBody:
+    """
+    Attributes:
+        name (str): Name of the image to build
+        resource_type (str): Resource type (agent, function, sandbox, job)
+        generation (Union[Unset, str]): Runtime generation (e.g., mk3). Defaults to mk3 if not specified.
+        image (Union[Unset, str]): A pre-built Docker image reference (e.g., docker.io/myorg/myimage:latest). When
+            provided, the build step is skipped and the image is used directly as the source for the resource runtime.
+    """
+
+    name: str
+    resource_type: str
+    generation: Union[Unset, str] = UNSET
+    image: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        resource_type = self.resource_type
+
+        generation = self.generation
+
+        image = self.image
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+                "resourceType": resource_type,
+            }
+        )
+        if generation is not UNSET:
+            field_dict["generation"] = generation
+        if image is not UNSET:
+            field_dict["image"] = image
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        name = d.pop("name")
+
+        resource_type = d.pop("resourceType") if "resourceType" in d else d.pop("resource_type")
+
+        generation = d.pop("generation", UNSET)
+
+        image = d.pop("image", UNSET)
+
+        create_image_body = cls(
+            name=name,
+            resource_type=resource_type,
+            generation=generation,
+            image=image,
+        )
+
+        create_image_body.additional_properties = d
+        return create_image_body
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/create_image_response_200.py
+++ b/src/blaxel/core/client/models/create_image_response_200.py
@@ -5,42 +5,45 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="VolumeAttachment")
+T = TypeVar("T", bound="CreateImageResponse200")
 
 
 @_attrs_define
-class VolumeAttachment:
-    """Configuration for attaching a persistent volume to a sandbox at a specific filesystem path
-
+class CreateImageResponse200:
+    """
     Attributes:
-        mount_path (Union[Unset, str]): Absolute filesystem path where the volume will be mounted inside the sandbox
-            Example: /mnt/data.
-        name (Union[Unset, str]): Name of the volume resource to attach (must exist in the same workspace and region)
-            Example: my-volume.
-        read_only (Union[Unset, bool]): If true, the volume is mounted read-only and cannot be modified by the sandbox
+        image (Union[Unset, str]): The registered image reference (only present when image was provided in request)
+        message (Union[Unset, str]): Status message
+        name (Union[Unset, str]): Name of the image
+        resource_type (Union[Unset, str]): Resource type
     """
 
-    mount_path: Union[Unset, str] = UNSET
+    image: Union[Unset, str] = UNSET
+    message: Union[Unset, str] = UNSET
     name: Union[Unset, str] = UNSET
-    read_only: Union[Unset, bool] = UNSET
+    resource_type: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        mount_path = self.mount_path
+        image = self.image
+
+        message = self.message
 
         name = self.name
 
-        read_only = self.read_only
+        resource_type = self.resource_type
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if mount_path is not UNSET:
-            field_dict["mountPath"] = mount_path
+        if image is not UNSET:
+            field_dict["image"] = image
+        if message is not UNSET:
+            field_dict["message"] = message
         if name is not UNSET:
             field_dict["name"] = name
-        if read_only is not UNSET:
-            field_dict["readOnly"] = read_only
+        if resource_type is not UNSET:
+            field_dict["resourceType"] = resource_type
 
         return field_dict
 
@@ -49,20 +52,23 @@ class VolumeAttachment:
         if not src_dict:
             return None
         d = src_dict.copy()
-        mount_path = d.pop("mountPath", d.pop("mount_path", UNSET))
+        image = d.pop("image", UNSET)
+
+        message = d.pop("message", UNSET)
 
         name = d.pop("name", UNSET)
 
-        read_only = d.pop("readOnly", d.pop("read_only", UNSET))
+        resource_type = d.pop("resourceType", d.pop("resource_type", UNSET))
 
-        volume_attachment = cls(
-            mount_path=mount_path,
+        create_image_response_200 = cls(
+            image=image,
+            message=message,
             name=name,
-            read_only=read_only,
+            resource_type=resource_type,
         )
 
-        volume_attachment.additional_properties = d
-        return volume_attachment
+        create_image_response_200.additional_properties = d
+        return create_image_response_200
 
     @property
     def additional_keys(self) -> list[str]:

--- a/src/blaxel/core/client/models/github_runner_config.py
+++ b/src/blaxel/core/client/models/github_runner_config.py
@@ -1,0 +1,67 @@
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GithubRunnerConfig")
+
+
+@_attrs_define
+class GithubRunnerConfig:
+    """Configuration for running GitHub Actions workflow jobs on Blaxel infrastructure. When repositories are configured,
+    the job acts as a self-hosted GitHub Actions runner. Workflow jobs use runs-on with the Blaxel job name to target a
+    specific runner.
+
+        Attributes:
+            repositories (Union[Unset, list[str]]): Repositories in owner/repo format that this runner is associated with.
+                The runner will pick up workflow jobs from any of these repositories. If non-empty, the runner is considered
+                enabled. Example: ["my-org/repo-a", "my-org/repo-b"].
+    """
+
+    repositories: Union[Unset, list[str]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        repositories: Union[Unset, list[str]] = UNSET
+        if not isinstance(self.repositories, Unset):
+            repositories = self.repositories
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if repositories is not UNSET:
+            field_dict["repositories"] = repositories
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        repositories = cast(list[str], d.pop("repositories", UNSET))
+
+        github_runner_config = cls(
+            repositories=repositories,
+        )
+
+        github_runner_config.additional_properties = d
+        return github_runner_config
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/image_metadata.py
+++ b/src/blaxel/core/client/models/image_metadata.py
@@ -1,9 +1,14 @@
-from typing import Any, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..models.status import Status
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.core_event import CoreEvent
+
 
 T = TypeVar("T", bound="ImageMetadata")
 
@@ -14,19 +19,23 @@ class ImageMetadata:
     Attributes:
         created_at (Union[Unset, str]): The date and time when the image was created.
         display_name (Union[Unset, str]): The display name of the image (registry/workspace/repository).
+        events (Union[Unset, list['CoreEvent']]): Events happening on a resource deployed on Blaxel
         last_deployed_at (Union[Unset, str]): The date and time when the image was last deployed (most recent across all
             tags).
         name (Union[Unset, str]): The name of the image (repository name).
         resource_type (Union[Unset, str]): The resource type of the image.
+        status (Union[Unset, Status]): Deployment status of a resource deployed on Blaxel
         updated_at (Union[Unset, str]): The date and time when the image was last updated.
         workspace (Union[Unset, str]): The workspace of the image.
     """
 
     created_at: Union[Unset, str] = UNSET
     display_name: Union[Unset, str] = UNSET
+    events: Union[Unset, list["CoreEvent"]] = UNSET
     last_deployed_at: Union[Unset, str] = UNSET
     name: Union[Unset, str] = UNSET
     resource_type: Union[Unset, str] = UNSET
+    status: Union[Unset, Status] = UNSET
     updated_at: Union[Unset, str] = UNSET
     workspace: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -36,11 +45,27 @@ class ImageMetadata:
 
         display_name = self.display_name
 
+        events: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.events, Unset):
+            events = []
+            for componentsschemas_core_events_item_data in self.events:
+                if type(componentsschemas_core_events_item_data) is dict:
+                    componentsschemas_core_events_item = componentsschemas_core_events_item_data
+                else:
+                    componentsschemas_core_events_item = (
+                        componentsschemas_core_events_item_data.to_dict()
+                    )
+                events.append(componentsschemas_core_events_item)
+
         last_deployed_at = self.last_deployed_at
 
         name = self.name
 
         resource_type = self.resource_type
+
+        status: Union[Unset, str] = UNSET
+        if not isinstance(self.status, Unset):
+            status = self.status.value
 
         updated_at = self.updated_at
 
@@ -53,12 +78,16 @@ class ImageMetadata:
             field_dict["createdAt"] = created_at
         if display_name is not UNSET:
             field_dict["displayName"] = display_name
+        if events is not UNSET:
+            field_dict["events"] = events
         if last_deployed_at is not UNSET:
             field_dict["lastDeployedAt"] = last_deployed_at
         if name is not UNSET:
             field_dict["name"] = name
         if resource_type is not UNSET:
             field_dict["resourceType"] = resource_type
+        if status is not UNSET:
+            field_dict["status"] = status
         if updated_at is not UNSET:
             field_dict["updatedAt"] = updated_at
         if workspace is not UNSET:
@@ -68,6 +97,8 @@ class ImageMetadata:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.core_event import CoreEvent
+
         if not src_dict:
             return None
         d = src_dict.copy()
@@ -75,11 +106,27 @@ class ImageMetadata:
 
         display_name = d.pop("displayName", d.pop("display_name", UNSET))
 
+        events = []
+        _events = d.pop("events", UNSET)
+        for componentsschemas_core_events_item_data in _events or []:
+            componentsschemas_core_events_item = CoreEvent.from_dict(
+                componentsschemas_core_events_item_data
+            )
+
+            events.append(componentsschemas_core_events_item)
+
         last_deployed_at = d.pop("lastDeployedAt", d.pop("last_deployed_at", UNSET))
 
         name = d.pop("name", UNSET)
 
         resource_type = d.pop("resourceType", d.pop("resource_type", UNSET))
+
+        _status = d.pop("status", UNSET)
+        status: Union[Unset, Status]
+        if isinstance(_status, Unset):
+            status = UNSET
+        else:
+            status = Status(_status)
 
         updated_at = d.pop("updatedAt", d.pop("updated_at", UNSET))
 
@@ -88,9 +135,11 @@ class ImageMetadata:
         image_metadata = cls(
             created_at=created_at,
             display_name=display_name,
+            events=events,
             last_deployed_at=last_deployed_at,
             name=name,
             resource_type=resource_type,
+            status=status,
             updated_at=updated_at,
             workspace=workspace,
         )

--- a/src/blaxel/core/client/models/job_spec.py
+++ b/src/blaxel/core/client/models/job_spec.py
@@ -6,7 +6,9 @@ from attrs import field as _attrs_field
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
+    from ..models.github_runner_config import GithubRunnerConfig
     from ..models.job_runtime import JobRuntime
+    from ..models.job_volume import JobVolume
     from ..models.revision_configuration import RevisionConfiguration
     from ..models.trigger import Trigger
 
@@ -21,24 +23,40 @@ class JobSpec:
     Attributes:
         enabled (Union[Unset, bool]): When false, the job is disabled and new executions cannot be triggered Default:
             True. Example: True.
+        github_runner (Union[Unset, GithubRunnerConfig]): Configuration for running GitHub Actions workflow jobs on
+            Blaxel infrastructure. When repositories are configured, the job acts as a self-hosted GitHub Actions runner.
+            Workflow jobs use runs-on with the Blaxel job name to target a specific runner.
         policies (Union[Unset, list[str]]):
         region (Union[Unset, str]): Region where the job should be created (e.g. us-was-1, eu-lon-1) Example: us-was-1.
         revision (Union[Unset, RevisionConfiguration]): Revision configuration
         runtime (Union[Unset, JobRuntime]): Runtime configuration defining how batch job tasks are executed with
             parallelism and retry settings
         triggers (Union[Unset, list['Trigger']]): Triggers to use your agent
+        volumes (Union[Unset, list['JobVolume']]):
     """
 
     enabled: Union[Unset, bool] = True
+    github_runner: Union[Unset, "GithubRunnerConfig"] = UNSET
     policies: Union[Unset, list[str]] = UNSET
     region: Union[Unset, str] = UNSET
     revision: Union[Unset, "RevisionConfiguration"] = UNSET
     runtime: Union[Unset, "JobRuntime"] = UNSET
     triggers: Union[Unset, list["Trigger"]] = UNSET
+    volumes: Union[Unset, list["JobVolume"]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         enabled = self.enabled
+
+        github_runner: Union[Unset, dict[str, Any]] = UNSET
+        if (
+            self.github_runner
+            and not isinstance(self.github_runner, Unset)
+            and not isinstance(self.github_runner, dict)
+        ):
+            github_runner = self.github_runner.to_dict()
+        elif self.github_runner and isinstance(self.github_runner, dict):
+            github_runner = self.github_runner
 
         policies: Union[Unset, list[str]] = UNSET
         if not isinstance(self.policies, Unset):
@@ -76,11 +94,25 @@ class JobSpec:
                     componentsschemas_triggers_item = componentsschemas_triggers_item_data.to_dict()
                 triggers.append(componentsschemas_triggers_item)
 
+        volumes: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.volumes, Unset):
+            volumes = []
+            for componentsschemas_job_volumes_item_data in self.volumes:
+                if type(componentsschemas_job_volumes_item_data) is dict:
+                    componentsschemas_job_volumes_item = componentsschemas_job_volumes_item_data
+                else:
+                    componentsschemas_job_volumes_item = (
+                        componentsschemas_job_volumes_item_data.to_dict()
+                    )
+                volumes.append(componentsschemas_job_volumes_item)
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if enabled is not UNSET:
             field_dict["enabled"] = enabled
+        if github_runner is not UNSET:
+            field_dict["githubRunner"] = github_runner
         if policies is not UNSET:
             field_dict["policies"] = policies
         if region is not UNSET:
@@ -91,12 +123,16 @@ class JobSpec:
             field_dict["runtime"] = runtime
         if triggers is not UNSET:
             field_dict["triggers"] = triggers
+        if volumes is not UNSET:
+            field_dict["volumes"] = volumes
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.github_runner_config import GithubRunnerConfig
         from ..models.job_runtime import JobRuntime
+        from ..models.job_volume import JobVolume
         from ..models.revision_configuration import RevisionConfiguration
         from ..models.trigger import Trigger
 
@@ -104,6 +140,13 @@ class JobSpec:
             return None
         d = src_dict.copy()
         enabled = d.pop("enabled", UNSET)
+
+        _github_runner = d.pop("githubRunner", d.pop("github_runner", UNSET))
+        github_runner: Union[Unset, GithubRunnerConfig]
+        if isinstance(_github_runner, Unset):
+            github_runner = UNSET
+        else:
+            github_runner = GithubRunnerConfig.from_dict(_github_runner)
 
         policies = cast(list[str], d.pop("policies", UNSET))
 
@@ -132,13 +175,24 @@ class JobSpec:
 
             triggers.append(componentsschemas_triggers_item)
 
+        volumes = []
+        _volumes = d.pop("volumes", UNSET)
+        for componentsschemas_job_volumes_item_data in _volumes or []:
+            componentsschemas_job_volumes_item = JobVolume.from_dict(
+                componentsschemas_job_volumes_item_data
+            )
+
+            volumes.append(componentsschemas_job_volumes_item)
+
         job_spec = cls(
             enabled=enabled,
+            github_runner=github_runner,
             policies=policies,
             region=region,
             revision=revision,
             runtime=runtime,
             triggers=triggers,
+            volumes=volumes,
         )
 
         job_spec.additional_properties = d

--- a/src/blaxel/core/client/models/job_volume.py
+++ b/src/blaxel/core/client/models/job_volume.py
@@ -1,0 +1,99 @@
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.job_volume_type import JobVolumeType
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="JobVolume")
+
+
+@_attrs_define
+class JobVolume:
+    """Ephemeral volume for a job. Temporary disk-backed storage that is created when the job starts and destroyed when it
+    completes.
+
+        Attributes:
+            mount_path (str): Absolute filesystem path where the volume will be mounted inside the container Example:
+                /mnt/data.
+            name (str): Identifier for the volume, used to reference it internally Example: scratch.
+            size_mb (int): Storage capacity in megabytes Example: 102400.
+            type_ (JobVolumeType): Type of volume. Currently only "ephemeral" is supported. Example: ephemeral.
+            read_only (Union[Unset, bool]): If true, the volume is mounted read-only
+    """
+
+    mount_path: str
+    name: str
+    size_mb: int
+    type_: JobVolumeType
+    read_only: Union[Unset, bool] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        mount_path = self.mount_path
+
+        name = self.name
+
+        size_mb = self.size_mb
+
+        type_ = self.type_.value
+
+        read_only = self.read_only
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "mountPath": mount_path,
+                "name": name,
+                "sizeMb": size_mb,
+                "type": type_,
+            }
+        )
+        if read_only is not UNSET:
+            field_dict["readOnly"] = read_only
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        mount_path = d.pop("mountPath") if "mountPath" in d else d.pop("mount_path")
+
+        name = d.pop("name")
+
+        size_mb = d.pop("sizeMb") if "sizeMb" in d else d.pop("size_mb")
+
+        type_ = JobVolumeType(d.pop("type") if "type" in d else d.pop("type_"))
+
+        read_only = d.pop("readOnly", d.pop("read_only", UNSET))
+
+        job_volume = cls(
+            mount_path=mount_path,
+            name=name,
+            size_mb=size_mb,
+            type_=type_,
+            read_only=read_only,
+        )
+
+        job_volume.additional_properties = d
+        return job_volume
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/job_volume_type.py
+++ b/src/blaxel/core/client/models/job_volume_type.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class JobVolumeType(str, Enum):
+    EPHEMERAL = "ephemeral"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "JobVolumeType | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/pending_invitation_render.py
+++ b/src/blaxel/core/client/models/pending_invitation_render.py
@@ -6,6 +6,7 @@ from attrs import field as _attrs_field
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
+    from ..models.pending_invitation_render_account import PendingInvitationRenderAccount
     from ..models.pending_invitation_render_invited_by import PendingInvitationRenderInvitedBy
     from ..models.pending_invitation_render_workspace import PendingInvitationRenderWorkspace
     from ..models.pending_invitation_workspace_details import PendingInvitationWorkspaceDetails
@@ -19,25 +20,40 @@ class PendingInvitationRender:
     """Pending invitation in workspace
 
     Attributes:
+        account (Union[Unset, PendingInvitationRenderAccount]): Account info in pending invitation render (for
+            account_admin type)
         email (Union[Unset, str]): User email
         expires_at (Union[Unset, str]): The date and time when the invitation expires
         invited_at (Union[Unset, str]): Invitation date
         invited_by (Union[Unset, PendingInvitationRenderInvitedBy]): Invited by
         role (Union[Unset, str]): ACL role
+        type_ (Union[Unset, str]): Invitation type: "workspace" or "account_admin"
         workspace (Union[Unset, PendingInvitationRenderWorkspace]): Workspace
         workspace_details (Union[Unset, PendingInvitationWorkspaceDetails]): Workspace details
     """
 
+    account: Union[Unset, "PendingInvitationRenderAccount"] = UNSET
     email: Union[Unset, str] = UNSET
     expires_at: Union[Unset, str] = UNSET
     invited_at: Union[Unset, str] = UNSET
     invited_by: Union[Unset, "PendingInvitationRenderInvitedBy"] = UNSET
     role: Union[Unset, str] = UNSET
+    type_: Union[Unset, str] = UNSET
     workspace: Union[Unset, "PendingInvitationRenderWorkspace"] = UNSET
     workspace_details: Union[Unset, "PendingInvitationWorkspaceDetails"] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        account: Union[Unset, dict[str, Any]] = UNSET
+        if (
+            self.account
+            and not isinstance(self.account, Unset)
+            and not isinstance(self.account, dict)
+        ):
+            account = self.account.to_dict()
+        elif self.account and isinstance(self.account, dict):
+            account = self.account
+
         email = self.email
 
         expires_at = self.expires_at
@@ -55,6 +71,8 @@ class PendingInvitationRender:
             invited_by = self.invited_by
 
         role = self.role
+
+        type_ = self.type_
 
         workspace: Union[Unset, dict[str, Any]] = UNSET
         if (
@@ -79,6 +97,8 @@ class PendingInvitationRender:
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
+        if account is not UNSET:
+            field_dict["account"] = account
         if email is not UNSET:
             field_dict["email"] = email
         if expires_at is not UNSET:
@@ -89,6 +109,8 @@ class PendingInvitationRender:
             field_dict["invitedBy"] = invited_by
         if role is not UNSET:
             field_dict["role"] = role
+        if type_ is not UNSET:
+            field_dict["type"] = type_
         if workspace is not UNSET:
             field_dict["workspace"] = workspace
         if workspace_details is not UNSET:
@@ -98,6 +120,7 @@ class PendingInvitationRender:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.pending_invitation_render_account import PendingInvitationRenderAccount
         from ..models.pending_invitation_render_invited_by import PendingInvitationRenderInvitedBy
         from ..models.pending_invitation_render_workspace import PendingInvitationRenderWorkspace
         from ..models.pending_invitation_workspace_details import PendingInvitationWorkspaceDetails
@@ -105,6 +128,13 @@ class PendingInvitationRender:
         if not src_dict:
             return None
         d = src_dict.copy()
+        _account = d.pop("account", UNSET)
+        account: Union[Unset, PendingInvitationRenderAccount]
+        if isinstance(_account, Unset):
+            account = UNSET
+        else:
+            account = PendingInvitationRenderAccount.from_dict(_account)
+
         email = d.pop("email", UNSET)
 
         expires_at = d.pop("expiresAt", d.pop("expires_at", UNSET))
@@ -119,6 +149,8 @@ class PendingInvitationRender:
             invited_by = PendingInvitationRenderInvitedBy.from_dict(_invited_by)
 
         role = d.pop("role", UNSET)
+
+        type_ = d.pop("type", d.pop("type_", UNSET))
 
         _workspace = d.pop("workspace", UNSET)
         workspace: Union[Unset, PendingInvitationRenderWorkspace]
@@ -135,11 +167,13 @@ class PendingInvitationRender:
             workspace_details = PendingInvitationWorkspaceDetails.from_dict(_workspace_details)
 
         pending_invitation_render = cls(
+            account=account,
             email=email,
             expires_at=expires_at,
             invited_at=invited_at,
             invited_by=invited_by,
             role=role,
+            type_=type_,
             workspace=workspace,
             workspace_details=workspace_details,
         )

--- a/src/blaxel/core/client/models/pending_invitation_render_account.py
+++ b/src/blaxel/core/client/models/pending_invitation_render_account.py
@@ -1,0 +1,70 @@
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="PendingInvitationRenderAccount")
+
+
+@_attrs_define
+class PendingInvitationRenderAccount:
+    """Account info in pending invitation render (for account_admin type)
+
+    Attributes:
+        display_name (Union[Unset, str]): Account display name or owner email
+        id (Union[Unset, str]): Account ID
+    """
+
+    display_name: Union[Unset, str] = UNSET
+    id: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        display_name = self.display_name
+
+        id = self.id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if display_name is not UNSET:
+            field_dict["displayName"] = display_name
+        if id is not UNSET:
+            field_dict["id"] = id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        display_name = d.pop("displayName", d.pop("display_name", UNSET))
+
+        id = d.pop("id", UNSET)
+
+        pending_invitation_render_account = cls(
+            display_name=display_name,
+            id=id,
+        )
+
+        pending_invitation_render_account.additional_properties = d
+        return pending_invitation_render_account
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/status.py
+++ b/src/blaxel/core/client/models/status.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class Status(str, Enum):
     BUILDING = "BUILDING"
+    BUILT = "BUILT"
     DEACTIVATED = "DEACTIVATED"
     DEACTIVATING = "DEACTIVATING"
     DELETING = "DELETING"

--- a/src/blaxel/core/sandbox/client/client.py
+++ b/src/blaxel/core/sandbox/client/client.py
@@ -1,3 +1,4 @@
+import asyncio
 import ssl
 from typing import Any, Union
 
@@ -50,6 +51,7 @@ class Client:
     _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
     _client: httpx.Client | None = field(default=None, init=False)
     _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+    _async_client_loop: asyncio.AbstractEventLoop | None = field(default=None, init=False)
 
     def with_base_url(self, base_url: str) -> "Client":
         """Get a new client matching this one with a new base URL"""
@@ -138,6 +140,15 @@ class Client:
 
     def get_async_httpx_client(self) -> httpx.AsyncClient:
         """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+
+        if self._async_client is not None and current_loop is not self._async_client_loop:
+            self._async_client = None
+            self._async_client_loop = None
+
         if self._async_client is None:
             self._async_client = httpx.AsyncClient(
                 base_url=self._base_url,
@@ -149,6 +160,7 @@ class Client:
                 auth=self._auth,
                 **self._httpx_args,
             )
+            self._async_client_loop = current_loop
         return self._async_client
 
     async def __aenter__(self) -> "Client":

--- a/templates/client.py.jinja
+++ b/templates/client.py.jinja
@@ -1,3 +1,4 @@
+import asyncio
 import ssl
 from typing import Any, Optional, Union
 
@@ -48,6 +49,7 @@ class Client:
     _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
     _client: httpx.Client | None = field(default=None, init=False)
     _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+    _async_client_loop: asyncio.AbstractEventLoop | None = field(default=None, init=False)
 
     def with_base_url(self, base_url: str) -> "Client":
         """Get a new client matching this one with a new base URL"""
@@ -136,6 +138,15 @@ class Client:
 
     def get_async_httpx_client(self) -> httpx.AsyncClient:
         """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+
+        if self._async_client is not None and current_loop is not self._async_client_loop:
+            self._async_client = None
+            self._async_client_loop = None
+
         if self._async_client is None:
             self._async_client = httpx.AsyncClient(
                 base_url=self._base_url,
@@ -147,6 +158,7 @@ class Client:
                 auth=self._auth,
                 **self._httpx_args,
             )
+            self._async_client_loop = current_loop
         return self._async_client
 
     async def __aenter__(self) -> "Client":

--- a/tests/integration/core/sandbox/test_proxy.py
+++ b/tests/integration/core/sandbox/test_proxy.py
@@ -140,28 +140,30 @@ class TestCreateWithProxy:
 
     async def test_creates_sandbox_with_proxy_routing_and_header_injection(self):
         name = unique_name("proxy-hdr")
-        sandbox = await SandboxInstance.create({
-            "name": name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["api.stripe.com"],
-                            "headers": {
-                                "Authorization": "Bearer {{SECRET:stripe-key}}",
-                                "Stripe-Version": "2024-12-18.acacia",
+        sandbox = await SandboxInstance.create(
+            {
+                "name": name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["api.stripe.com"],
+                                "headers": {
+                                    "Authorization": "Bearer {{SECRET:stripe-key}}",
+                                    "Stripe-Version": "2024-12-18.acacia",
+                                },
+                                "secrets": {
+                                    "stripe-key": "sk-live-test123",
+                                },
                             },
-                            "secrets": {
-                                "stripe-key": "sk-live-test123",
-                            },
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
 
         try:
             assert sandbox.metadata.name == name
@@ -179,30 +181,32 @@ class TestCreateWithProxy:
 
     async def test_creates_sandbox_with_proxy_body_injection(self):
         name = unique_name("proxy-body")
-        sandbox = await SandboxInstance.create({
-            "name": name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["api.stripe.com"],
-                            "headers": {
-                                "Authorization": "Bearer {{SECRET:stripe-key}}",
+        sandbox = await SandboxInstance.create(
+            {
+                "name": name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["api.stripe.com"],
+                                "headers": {
+                                    "Authorization": "Bearer {{SECRET:stripe-key}}",
+                                },
+                                "body": {
+                                    "api_key": "{{SECRET:stripe-key}}",
+                                },
+                                "secrets": {
+                                    "stripe-key": "sk-live-test123",
+                                },
                             },
-                            "body": {
-                                "api_key": "{{SECRET:stripe-key}}",
-                            },
-                            "secrets": {
-                                "stripe-key": "sk-live-test123",
-                            },
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
 
         try:
             network = sandbox.spec.network
@@ -215,43 +219,45 @@ class TestCreateWithProxy:
 
     async def test_creates_sandbox_with_multiple_proxy_routing_rules(self):
         name = unique_name("proxy-multi")
-        sandbox = await SandboxInstance.create({
-            "name": name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["api.stripe.com"],
-                            "headers": {
-                                "Authorization": "Bearer {{SECRET:stripe-key}}",
-                                "Stripe-Version": "2024-12-18.acacia",
-                                "X-Request-Source": "blaxel-sandbox",
+        sandbox = await SandboxInstance.create(
+            {
+                "name": name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["api.stripe.com"],
+                                "headers": {
+                                    "Authorization": "Bearer {{SECRET:stripe-key}}",
+                                    "Stripe-Version": "2024-12-18.acacia",
+                                    "X-Request-Source": "blaxel-sandbox",
+                                },
+                                "body": {
+                                    "api_key": "{{SECRET:stripe-key}}",
+                                },
+                                "secrets": {
+                                    "stripe-key": "sk-live-test123",
+                                },
                             },
-                            "body": {
-                                "api_key": "{{SECRET:stripe-key}}",
+                            {
+                                "destinations": ["api.openai.com"],
+                                "headers": {
+                                    "Authorization": "Bearer {{SECRET:openai-key}}",
+                                    "OpenAI-Organization": "org-abc123",
+                                },
+                                "secrets": {
+                                    "openai-key": "sk-proj-test789",
+                                },
                             },
-                            "secrets": {
-                                "stripe-key": "sk-live-test123",
-                            },
-                        },
-                        {
-                            "destinations": ["api.openai.com"],
-                            "headers": {
-                                "Authorization": "Bearer {{SECRET:openai-key}}",
-                                "OpenAI-Organization": "org-abc123",
-                            },
-                            "secrets": {
-                                "openai-key": "sk-proj-test789",
-                            },
-                        },
-                    ],
-                    "bypass": ["*.s3.amazonaws.com"],
+                        ],
+                        "bypass": ["*.s3.amazonaws.com"],
+                    },
                 },
-            },
-        })
+            }
+        )
 
         try:
             network = sandbox.spec.network
@@ -280,17 +286,19 @@ class TestCreateWithProxy:
 
     async def test_creates_sandbox_with_proxy_bypass_only(self):
         name = unique_name("proxy-bypass")
-        sandbox = await SandboxInstance.create({
-            "name": name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "bypass": ["*.s3.amazonaws.com", "169.254.169.254"],
+        sandbox = await SandboxInstance.create(
+            {
+                "name": name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "bypass": ["*.s3.amazonaws.com", "169.254.169.254"],
+                    },
                 },
-            },
-        })
+            }
+        )
 
         try:
             network = sandbox.spec.network
@@ -302,25 +310,27 @@ class TestCreateWithProxy:
 
     async def test_creates_sandbox_with_proxy_and_allowed_domains_combined(self):
         name = unique_name("proxy-fw")
-        sandbox = await SandboxInstance.create({
-            "name": name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "allowedDomains": ["api.stripe.com", "api.openai.com", "*.s3.amazonaws.com"],
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["api.stripe.com"],
-                            "headers": {"Authorization": "Bearer {{SECRET:stripe-key}}"},
-                            "secrets": {"stripe-key": "sk-live-test123"},
-                        },
-                    ],
-                    "bypass": ["*.s3.amazonaws.com"],
+        sandbox = await SandboxInstance.create(
+            {
+                "name": name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "allowedDomains": ["api.stripe.com", "api.openai.com", "*.s3.amazonaws.com"],
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["api.stripe.com"],
+                                "headers": {"Authorization": "Bearer {{SECRET:stripe-key}}"},
+                                "secrets": {"stripe-key": "sk-live-test123"},
+                            },
+                        ],
+                        "bypass": ["*.s3.amazonaws.com"],
+                    },
                 },
-            },
-        })
+            }
+        )
 
         try:
             network = sandbox.spec.network
@@ -343,29 +353,31 @@ class TestGetProxyConfig:
 
     async def test_retrieves_sandbox_with_proxy_and_validates_config(self):
         name = unique_name("proxy-get")
-        await SandboxInstance.create({
-            "name": name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["api.openai.com"],
-                            "headers": {
-                                "Authorization": "Bearer {{SECRET:openai-key}}",
-                                "OpenAI-Organization": "org-abc123",
+        await SandboxInstance.create(
+            {
+                "name": name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["api.openai.com"],
+                                "headers": {
+                                    "Authorization": "Bearer {{SECRET:openai-key}}",
+                                    "OpenAI-Organization": "org-abc123",
+                                },
+                                "secrets": {
+                                    "openai-key": "sk-proj-test789",
+                                },
                             },
-                            "secrets": {
-                                "openai-key": "sk-proj-test789",
-                            },
-                        },
-                    ],
-                    "bypass": ["169.254.169.254"],
+                        ],
+                        "bypass": ["169.254.169.254"],
+                    },
                 },
-            },
-        })
+            }
+        )
 
         try:
             retrieved = await SandboxInstance.get(name)
@@ -384,12 +396,14 @@ class TestGetProxyConfig:
 
     async def test_returns_no_proxy_config_when_sandbox_has_none(self):
         name = unique_name("proxy-none")
-        await SandboxInstance.create({
-            "name": name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-        })
+        await SandboxInstance.create(
+            {
+                "name": name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+            }
+        )
 
         try:
             retrieved = await SandboxInstance.get(name)
@@ -411,23 +425,25 @@ class TestDeleteSandboxWithProxy:
 
     async def test_deletes_sandbox_with_proxy_configuration(self):
         name = unique_name("proxy-del")
-        await SandboxInstance.create({
-            "name": name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["api.stripe.com"],
-                            "headers": {"Authorization": "Bearer {{SECRET:stripe-key}}"},
-                            "secrets": {"stripe-key": "sk-live-test123"},
-                        },
-                    ],
+        await SandboxInstance.create(
+            {
+                "name": name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["api.stripe.com"],
+                                "headers": {"Authorization": "Bearer {{SECRET:stripe-key}}"},
+                                "secrets": {"stripe-key": "sk-live-test123"},
+                            },
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
 
         await SandboxInstance.delete(name)
         deleted = await wait_for_sandbox_deletion(name, max_attempts=60)
@@ -449,16 +465,18 @@ class TestFirewallAllowedDomains:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("fw-allow")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "allowedDomains": ["httpbin.org"],
-                "proxy": {"routing": []},
-            },
-        })
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "allowedDomains": ["httpbin.org"],
+                    "proxy": {"routing": []},
+                },
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -467,19 +485,23 @@ class TestFirewallAllowedDomains:
             pass
 
     async def test_allows_requests_to_allowlisted_domain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/get",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/get",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         response = _parse_json_output(result.logs)
         assert response.get("url") == "https://httpbin.org/get"
 
     async def test_blocks_requests_to_non_allowlisted_domain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://example.com",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://example.com",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code != 0
 
 
@@ -493,16 +515,18 @@ class TestFirewallForbiddenDomains:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("fw-deny")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "forbiddenDomains": ["example.com"],
-                "proxy": {"routing": []},
-            },
-        })
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "forbiddenDomains": ["example.com"],
+                    "proxy": {"routing": []},
+                },
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -511,19 +535,23 @@ class TestFirewallForbiddenDomains:
             pass
 
     async def test_allows_requests_to_non_forbidden_domain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/get",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/get",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         response = _parse_json_output(result.logs)
         assert response.get("url") == "https://httpbin.org/get"
 
     async def test_blocks_requests_to_forbidden_domain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://example.com",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://example.com",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code != 0
 
 
@@ -537,17 +565,19 @@ class TestFirewallCombined:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("fw-combo")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "allowedDomains": ["httpbin.org", "example.com"],
-                "forbiddenDomains": ["example.com"],
-                "proxy": {"routing": []},
-            },
-        })
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "allowedDomains": ["httpbin.org", "example.com"],
+                    "forbiddenDomains": ["example.com"],
+                    "proxy": {"routing": []},
+                },
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -556,10 +586,12 @@ class TestFirewallCombined:
             pass
 
     async def test_allowed_domains_takes_precedence_over_forbidden_domains(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/get",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/get",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         response = _parse_json_output(result.logs)
         assert response.get("url") == "https://httpbin.org/get"
@@ -575,23 +607,25 @@ class TestFirewallWithProxyRouting:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("fw-proxy")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "allowedDomains": ["httpbin.org"],
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["httpbin.org"],
-                            "headers": {"X-Firewall-Test": "allowed-and-injected"},
-                        },
-                    ],
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "allowedDomains": ["httpbin.org"],
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["httpbin.org"],
+                                "headers": {"X-Firewall-Test": "allowed-and-injected"},
+                            },
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -600,10 +634,12 @@ class TestFirewallWithProxyRouting:
             pass
 
     async def test_injects_headers_for_allowlisted_and_routed_domain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -611,10 +647,12 @@ class TestFirewallWithProxyRouting:
         assert headers["x-firewall-test"] == "allowed-and-injected"
 
     async def test_blocks_non_allowlisted_domain_even_without_routing(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://example.com",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://example.com",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code != 0
 
 
@@ -633,44 +671,46 @@ class TestSecretsReplacementValidation:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("proxy-sec")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["httpbin.org"],
-                            "headers": {
-                                "X-Token": "Bearer {{SECRET:api-token}}",
-                                "X-Multi": "{{SECRET:part-a}}-{{SECRET:part-b}}",
-                                "X-Plain": "no-secret-here",
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["httpbin.org"],
+                                "headers": {
+                                    "X-Token": "Bearer {{SECRET:api-token}}",
+                                    "X-Multi": "{{SECRET:part-a}}-{{SECRET:part-b}}",
+                                    "X-Plain": "no-secret-here",
+                                },
+                                "body": {
+                                    "secret_key": "{{SECRET:api-token}}",
+                                    "composite": "prefix-{{SECRET:part-a}}-suffix",
+                                },
+                                "secrets": {
+                                    "api-token": "tok_live_abc123",
+                                    "part-a": "ALPHA",
+                                    "part-b": "BETA",
+                                },
                             },
-                            "body": {
-                                "secret_key": "{{SECRET:api-token}}",
-                                "composite": "prefix-{{SECRET:part-a}}-suffix",
+                            {
+                                "destinations": ["*.example.com"],
+                                "headers": {
+                                    "X-Other-Secret": "{{SECRET:other-key}}",
+                                },
+                                "secrets": {
+                                    "other-key": "other-value-999",
+                                },
                             },
-                            "secrets": {
-                                "api-token": "tok_live_abc123",
-                                "part-a": "ALPHA",
-                                "part-b": "BETA",
-                            },
-                        },
-                        {
-                            "destinations": ["*.example.com"],
-                            "headers": {
-                                "X-Other-Secret": "{{SECRET:other-key}}",
-                            },
-                            "secrets": {
-                                "other-key": "other-value-999",
-                            },
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -679,10 +719,12 @@ class TestSecretsReplacementValidation:
             pass
 
     async def test_resolves_secret_in_headers_to_actual_value(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -691,10 +733,12 @@ class TestSecretsReplacementValidation:
         assert headers["x-plain"] == "no-secret-here"
 
     async def test_resolves_multiple_secret_placeholders_in_single_header(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -702,10 +746,12 @@ class TestSecretsReplacementValidation:
         assert headers["x-multi"] == "ALPHA-BETA"
 
     async def test_resolves_secret_in_post_body_fields(self):
-        result = await self.sandbox.process.exec({
-            "command": """node /tmp/proxy-test.js POST https://httpbin.org/post '{}' '{"user_field":"untouched"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """node /tmp/proxy-test.js POST https://httpbin.org/post '{}' '{"user_field":"untouched"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -714,10 +760,12 @@ class TestSecretsReplacementValidation:
         assert response["json"]["composite"] == "prefix-ALPHA-suffix"
 
     async def test_does_not_leak_secrets_from_one_route_to_another(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -725,21 +773,25 @@ class TestSecretsReplacementValidation:
         assert headers.get("x-other-secret") is None
 
     async def test_does_not_expose_raw_secret_template_on_the_wire(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert "{{SECRET:" not in (result.logs or "")
 
     async def test_resolves_secret_in_user_sent_headers(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "node /tmp/proxy-test.js GET https://httpbin.org/headers "
-                """'{"X-User-Token":"{{SECRET:api-token}}","X-User-Combo":"pre-{{SECRET:part-a}}-post"}'"""
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "node /tmp/proxy-test.js GET https://httpbin.org/headers "
+                    """'{"X-User-Token":"{{SECRET:api-token}}","X-User-Combo":"pre-{{SECRET:part-a}}-post"}'"""
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -748,13 +800,15 @@ class TestSecretsReplacementValidation:
         assert headers["x-user-combo"] == "pre-ALPHA-post"
 
     async def test_resolves_secret_in_user_sent_post_body(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "node /tmp/proxy-test.js POST https://httpbin.org/post "
-                """'{}' '{"api_key":"{{SECRET:api-token}}","mixed":"hello-{{SECRET:part-b}}-world"}'"""
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "node /tmp/proxy-test.js POST https://httpbin.org/post "
+                    """'{}' '{"api_key":"{{SECRET:api-token}}","mixed":"hello-{{SECRET:part-b}}-world"}'"""
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -762,13 +816,15 @@ class TestSecretsReplacementValidation:
         assert response["json"]["mixed"] == "hello-BETA-world"
 
     async def test_does_not_resolve_secrets_from_different_route_in_user_headers(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "node /tmp/proxy-test.js GET https://httpbin.org/headers "
-                """'{"X-Wrong-Route":"{{SECRET:other-key}}"}'"""
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "node /tmp/proxy-test.js GET https://httpbin.org/headers "
+                    """'{"X-Wrong-Route":"{{SECRET:other-key}}"}'"""
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -791,27 +847,29 @@ class TestProxyWildcardDestination:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("proxy-wild")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["*"],
-                            "headers": {
-                                "X-Global-Auth": "Bearer {{SECRET:global-key}}",
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["*"],
+                                "headers": {
+                                    "X-Global-Auth": "Bearer {{SECRET:global-key}}",
+                                },
+                                "secrets": {
+                                    "global-key": "global-token-xyz",
+                                },
                             },
-                            "secrets": {
-                                "global-key": "global-token-xyz",
-                            },
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -820,10 +878,12 @@ class TestProxyWildcardDestination:
             pass
 
     async def test_applies_global_rule_to_httpbin(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -846,38 +906,40 @@ class TestProxyEndToEnd:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("proxy-e2e")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["httpbin.org"],
-                            "headers": {
-                                "X-Proxy-Test": "header-injected",
-                                "X-Api-Key": "{{SECRET:test-api-key}}",
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["httpbin.org"],
+                                "headers": {
+                                    "X-Proxy-Test": "header-injected",
+                                    "X-Api-Key": "{{SECRET:test-api-key}}",
+                                },
+                                "body": {
+                                    "injected_field": "body-injected",
+                                    "secret_body": "{{SECRET:test-api-key}}",
+                                },
+                                "secrets": {
+                                    "test-api-key": "resolved-secret-42",
+                                },
                             },
-                            "body": {
-                                "injected_field": "body-injected",
-                                "secret_body": "{{SECRET:test-api-key}}",
+                            {
+                                "destinations": ["*.example.com"],
+                                "headers": {
+                                    "X-Wildcard-Match": "wildcard-injected",
+                                },
                             },
-                            "secrets": {
-                                "test-api-key": "resolved-secret-42",
-                            },
-                        },
-                        {
-                            "destinations": ["*.example.com"],
-                            "headers": {
-                                "X-Wildcard-Match": "wildcard-injected",
-                            },
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -886,10 +948,12 @@ class TestProxyEndToEnd:
             pass
 
     async def test_routes_https_requests_through_proxy_with_header_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -899,10 +963,12 @@ class TestProxyEndToEnd:
         assert headers["x-api-key"] == "resolved-secret-42"
 
     async def test_routes_post_requests_through_proxy_with_body_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": """node /tmp/proxy-test.js POST https://httpbin.org/post '{}' '{"user_data":"original"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """node /tmp/proxy-test.js POST https://httpbin.org/post '{}' '{"user_data":"original"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -917,10 +983,12 @@ class TestProxyEndToEnd:
         assert response["json"]["secret_body"] == "resolved-secret-42"
 
     async def test_preserves_user_sent_headers_when_routing(self):
-        result = await self.sandbox.process.exec({
-            "command": """node /tmp/proxy-test.js GET https://httpbin.org/headers '{"X-User-Custom":"my-value"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """node /tmp/proxy-test.js GET https://httpbin.org/headers '{"X-User-Custom":"my-value"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -930,23 +998,25 @@ class TestProxyEndToEnd:
         assert headers["x-proxy-test"] == "header-injected"
 
     async def test_does_not_route_local_requests_through_proxy(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "node -e '"
-                'const http = require("http");'
-                "const srv = http.createServer((req, res) => {"
-                'res.writeHead(200, {"Content-Type": "application/json"});'
-                "res.end(JSON.stringify(req.headers));"
-                "});"
-                "srv.listen(19876, () => {"
-                'http.get("http://localhost:19876", (r) => {'
-                'let d = ""; r.on("data", c => d += c);'
-                'r.on("end", () => { console.log(d); srv.close(); });'
-                "});"
-                "});'"
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "node -e '"
+                    'const http = require("http");'
+                    "const srv = http.createServer((req, res) => {"
+                    'res.writeHead(200, {"Content-Type": "application/json"});'
+                    "res.end(JSON.stringify(req.headers));"
+                    "});"
+                    "srv.listen(19876, () => {"
+                    'http.get("http://localhost:19876", (r) => {'
+                    'let d = ""; r.on("data", c => d += c);'
+                    'r.on("end", () => { console.log(d); srv.close(); });'
+                    "});"
+                    "});'"
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         headers = _parse_json_output(result.logs)
@@ -954,19 +1024,23 @@ class TestProxyEndToEnd:
         assert headers.get("x-proxy-test") is None
 
     async def test_does_not_inject_headers_for_non_routed_destinations(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://www.example.com",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://www.example.com",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         body = (result.logs or "").strip()
         assert len(body) > 0
 
     async def test_wildcard_route_matches_subdomain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://sub.example.com",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://sub.example.com",
+                "wait_for_completion": True,
+            }
+        )
 
         if result.exit_code != 0:
             assert result.exit_code == 0
@@ -979,26 +1053,30 @@ class TestProxyEndToEnd:
             assert headers.get("x-wildcard-match") == "wildcard-injected"
 
     async def test_wildcard_route_does_not_match_bare_domain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://example.com",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://example.com",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         body = (result.logs or "").strip()
         assert len(body) > 0
         assert "wildcard-injected" not in body
 
     async def test_verifies_proxy_env_vars_are_set(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "node -e '"
-                'const vars = ["HTTP_PROXY","HTTPS_PROXY","NO_PROXY","NODE_EXTRA_CA_CERTS","SSL_CERT_FILE"];'
-                "const result = {};"
-                'vars.forEach(v => result[v] = process.env[v] ? "set" : "unset");'
-                "console.log(JSON.stringify(result));'"
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "node -e '"
+                    'const vars = ["HTTP_PROXY","HTTPS_PROXY","NO_PROXY","NODE_EXTRA_CA_CERTS","SSL_CERT_FILE"];'
+                    "const result = {};"
+                    'vars.forEach(v => result[v] = process.env[v] ? "set" : "unset");'
+                    "console.log(JSON.stringify(result));'"
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         envs = _parse_json_output(result.logs)
         assert envs["HTTP_PROXY"] == "set"
@@ -1023,37 +1101,41 @@ class TestProxyCLITools:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("proxy-cli")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["httpbin.org"],
-                            "headers": {
-                                "X-Proxy-Test": "header-injected",
-                                "X-Api-Key": "{{SECRET:test-api-key}}",
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["httpbin.org"],
+                                "headers": {
+                                    "X-Proxy-Test": "header-injected",
+                                    "X-Api-Key": "{{SECRET:test-api-key}}",
+                                },
+                                "body": {
+                                    "injected_field": "body-injected",
+                                    "secret_body": "{{SECRET:test-api-key}}",
+                                },
+                                "secrets": {
+                                    "test-api-key": "resolved-secret-42",
+                                },
                             },
-                            "body": {
-                                "injected_field": "body-injected",
-                                "secret_body": "{{SECRET:test-api-key}}",
-                            },
-                            "secrets": {
-                                "test-api-key": "resolved-secret-42",
-                            },
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
 
-        install = await request.cls.sandbox.process.exec({
-            "command": "apk add --no-cache curl wget git python3 py3-pip 2>&1",
-            "wait_for_completion": True,
-        })
+        install = await request.cls.sandbox.process.exec(
+            {
+                "command": "apk add --no-cache curl wget git python3 py3-pip 2>&1",
+                "wait_for_completion": True,
+            }
+        )
         if install.exit_code != 0:
             raise RuntimeError(f"apk install failed: {(install.logs or '')[:500]}")
 
@@ -1069,10 +1151,12 @@ class TestProxyCurl(TestProxyCLITools):
     """Test curl through the proxy."""
 
     async def test_curl_get_with_header_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": "curl -s https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "curl -s https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -1082,10 +1166,12 @@ class TestProxyCurl(TestProxyCLITools):
         assert headers["x-api-key"] == "resolved-secret-42"
 
     async def test_curl_post_with_body_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": """curl -s -X POST https://httpbin.org/post -H "Content-Type: application/json" -d '{"user_data":"from-curl"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """curl -s -X POST https://httpbin.org/post -H "Content-Type: application/json" -d '{"user_data":"from-curl"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -1098,10 +1184,12 @@ class TestProxyCurl(TestProxyCLITools):
         assert headers["x-proxy-test"] == "header-injected"
 
     async def test_curl_preserves_user_headers(self):
-        result = await self.sandbox.process.exec({
-            "command": 'curl -s -H "X-User-Custom: from-curl" https://httpbin.org/headers',
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": 'curl -s -H "X-User-Custom: from-curl" https://httpbin.org/headers',
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -1111,18 +1199,22 @@ class TestProxyCurl(TestProxyCLITools):
         assert headers["x-api-key"] == "resolved-secret-42"
 
     async def test_curl_follows_redirects(self):
-        result = await self.sandbox.process.exec({
-            "command": 'curl -s -L -o /dev/null -w "%{http_code}" https://httpbin.org/redirect/1',
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": 'curl -s -L -o /dev/null -w "%{http_code}" https://httpbin.org/redirect/1',
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert (result.logs or "").strip() == "200"
 
     async def test_curl_put_through_proxy(self):
-        result = await self.sandbox.process.exec({
-            "command": """curl -s -X PUT https://httpbin.org/put -H "Content-Type: application/json" -d '{"update":"from-curl"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """curl -s -X PUT https://httpbin.org/put -H "Content-Type: application/json" -d '{"update":"from-curl"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -1132,10 +1224,12 @@ class TestProxyCurl(TestProxyCLITools):
         assert headers["x-proxy-test"] == "header-injected"
 
     async def test_curl_delete_through_proxy(self):
-        result = await self.sandbox.process.exec({
-            "command": "curl -s -X DELETE https://httpbin.org/delete",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "curl -s -X DELETE https://httpbin.org/delete",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -1143,10 +1237,12 @@ class TestProxyCurl(TestProxyCLITools):
         assert headers["x-proxy-test"] == "header-injected"
 
     async def test_curl_handles_large_response(self):
-        result = await self.sandbox.process.exec({
-            "command": 'curl -s -o /dev/null -w "%{http_code} %{size_download}" https://httpbin.org/bytes/10240',
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": 'curl -s -o /dev/null -w "%{http_code} %{size_download}" https://httpbin.org/bytes/10240',
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         parts = (result.logs or "").strip().split(" ")
         assert parts[0] == "200"
@@ -1158,39 +1254,47 @@ class TestProxyGit(TestProxyCLITools):
     """Test git through the proxy."""
 
     async def test_git_clone_public_repo(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "export https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY && "
-                "GIT_SSL_CAINFO=$SSL_CERT_FILE git -c http.proxyAuthMethod=basic "
-                "clone --depth 1 https://github.com/octocat/Hello-World.git /tmp/git-test-repo 2>&1"
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "export https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY && "
+                    "GIT_SSL_CAINFO=$SSL_CERT_FILE git -c http.proxyAuthMethod=basic "
+                    "clone --depth 1 https://github.com/octocat/Hello-World.git /tmp/git-test-repo 2>&1"
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
-        verify = await self.sandbox.process.exec({
-            "command": "ls /tmp/git-test-repo/README",
-            "wait_for_completion": True,
-        })
+        verify = await self.sandbox.process.exec(
+            {
+                "command": "ls /tmp/git-test-repo/README",
+                "wait_for_completion": True,
+            }
+        )
         assert verify.exit_code == 0
 
     async def test_git_ls_remote_through_proxy(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "export https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY && "
-                "GIT_SSL_CAINFO=$SSL_CERT_FILE git -c http.proxyAuthMethod=basic "
-                "ls-remote --heads https://github.com/octocat/Hello-World.git 2>&1"
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "export https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY && "
+                    "GIT_SSL_CAINFO=$SSL_CERT_FILE git -c http.proxyAuthMethod=basic "
+                    "ls-remote --heads https://github.com/octocat/Hello-World.git 2>&1"
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert "refs/heads/" in (result.logs or "")
 
     async def test_proxy_env_vars_visible_to_git(self):
-        result = await self.sandbox.process.exec({
-            "command": "git config --global --list 2>&1; echo '---'; env | grep -i proxy || true",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "git config --global --list 2>&1; echo '---'; env | grep -i proxy || true",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         logs = (result.logs or "").lower()
         assert "proxy" in logs or "https_proxy" in logs
@@ -1201,13 +1305,15 @@ class TestProxyPip(TestProxyCLITools):
     """Test pip through the proxy."""
 
     async def test_pip_install_through_proxy(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "pip3 install --break-system-packages --quiet six 2>&1 && "
-                'python3 -c "import six; print(six.__version__)"'
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "pip3 install --break-system-packages --quiet six 2>&1 && "
+                    'python3 -c "import six; print(six.__version__)"'
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert len((result.logs or "").strip()) > 0
 
@@ -1219,23 +1325,29 @@ class TestProxyNpm(TestProxyCLITools):
     async def test_npm_install_through_proxy(self):
         await self.sandbox.fs.write(
             "/tmp/npm-test/package.json",
-            json.dumps({
-                "name": "proxy-npm-test",
-                "version": "1.0.0",
-                "dependencies": {"is-odd": "^3.0.1"},
-            }),
+            json.dumps(
+                {
+                    "name": "proxy-npm-test",
+                    "version": "1.0.0",
+                    "dependencies": {"is-odd": "^3.0.1"},
+                }
+            ),
         )
 
-        result = await self.sandbox.process.exec({
-            "command": "cd /tmp/npm-test && npm install --no-audit --no-fund 2>&1",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "cd /tmp/npm-test && npm install --no-audit --no-fund 2>&1",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
-        verify = await self.sandbox.process.exec({
-            "command": """node -e "console.log(require('/tmp/npm-test/node_modules/is-odd')(3))" """,
-            "wait_for_completion": True,
-        })
+        verify = await self.sandbox.process.exec(
+            {
+                "command": """node -e "console.log(require('/tmp/npm-test/node_modules/is-odd')(3))" """,
+                "wait_for_completion": True,
+            }
+        )
         assert verify.exit_code == 0
         assert (verify.logs or "").strip() == "true"
 
@@ -1255,39 +1367,43 @@ class TestProxyPythonRequests:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("proxy-py")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": "blaxel/py-app:latest",
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["httpbin.org"],
-                            "headers": {
-                                "X-Proxy-Test": "header-injected",
-                                "X-Api-Key": "{{SECRET:test-api-key}}",
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": "blaxel/py-app:latest",
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["httpbin.org"],
+                                "headers": {
+                                    "X-Proxy-Test": "header-injected",
+                                    "X-Api-Key": "{{SECRET:test-api-key}}",
+                                },
+                                "body": {
+                                    "injected_field": "body-injected",
+                                    "secret_body": "{{SECRET:test-api-key}}",
+                                },
+                                "secrets": {
+                                    "test-api-key": "resolved-secret-42",
+                                },
                             },
-                            "body": {
-                                "injected_field": "body-injected",
-                                "secret_body": "{{SECRET:test-api-key}}",
-                            },
-                            "secrets": {
-                                "test-api-key": "resolved-secret-42",
-                            },
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
 
         await request.cls.sandbox.fs.write("/tmp/proxy-test.py", PYTHON_HELPER_SCRIPT)
 
-        pip_result = await request.cls.sandbox.process.exec({
-            "command": "pip install --break-system-packages requests 2>&1",
-            "wait_for_completion": True,
-        })
+        pip_result = await request.cls.sandbox.process.exec(
+            {
+                "command": "pip install --break-system-packages requests 2>&1",
+                "wait_for_completion": True,
+            }
+        )
         if pip_result.exit_code != 0:
             raise RuntimeError(f"pip install failed: {(pip_result.logs or '')[:500]}")
 
@@ -1298,10 +1414,12 @@ class TestProxyPythonRequests:
             pass
 
     async def test_python_requests_get_with_header_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": "python3 /tmp/proxy-test.py GET https://httpbin.org/headers 2>&1",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "python3 /tmp/proxy-test.py GET https://httpbin.org/headers 2>&1",
+                "wait_for_completion": True,
+            }
+        )
         if result.exit_code != 0:
             raise RuntimeError(f"python3 exited {result.exit_code}: {(result.logs or '')[:1500]}")
 
@@ -1312,10 +1430,12 @@ class TestProxyPythonRequests:
         assert headers["x-api-key"] == "resolved-secret-42"
 
     async def test_python_requests_post_with_body_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": """python3 /tmp/proxy-test.py POST https://httpbin.org/post '{}' '{"user_data":"from-python"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """python3 /tmp/proxy-test.py POST https://httpbin.org/post '{}' '{"user_data":"from-python"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -1324,10 +1444,12 @@ class TestProxyPythonRequests:
         assert response["json"]["secret_body"] == "resolved-secret-42"
 
     async def test_python_requests_preserves_user_headers(self):
-        result = await self.sandbox.process.exec({
-            "command": """python3 /tmp/proxy-test.py GET https://httpbin.org/headers '{"X-User-Custom":"from-python"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """python3 /tmp/proxy-test.py GET https://httpbin.org/headers '{"X-User-Custom":"from-python"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
         response = _parse_json_output(result.logs)
@@ -1355,32 +1477,36 @@ class TestProxyClaudeCode:
             pytest.skip("requires ANTHROPIC_API_KEY")
 
         request.cls.sandbox_name = unique_name("proxy-claude")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "envs": [
-                {"name": "ANTHROPIC_API_KEY", "value": api_key},
-            ],
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["httpbin.org"],
-                            "headers": {
-                                "X-Agent-Test": "claude-injected",
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "envs": [
+                    {"name": "ANTHROPIC_API_KEY", "value": api_key},
+                ],
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["httpbin.org"],
+                                "headers": {
+                                    "X-Agent-Test": "claude-injected",
+                                },
                             },
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
 
-        setup = await request.cls.sandbox.process.exec({
-            "command": "apk add --no-cache curl bash 2>&1 && npm install -g @anthropic-ai/claude-code 2>&1 && adduser -D -s /bin/bash agent 2>&1",
-            "wait_for_completion": True,
-        })
+        setup = await request.cls.sandbox.process.exec(
+            {
+                "command": "apk add --no-cache curl bash 2>&1 && npm install -g @anthropic-ai/claude-code 2>&1 && adduser -D -s /bin/bash agent 2>&1",
+                "wait_for_completion": True,
+            }
+        )
         if setup.exit_code != 0:
             raise RuntimeError(f"setup failed: {(setup.logs or '')[:500]}")
 
@@ -1400,15 +1526,17 @@ class TestProxyClaudeCode:
             "NODE_EXTRA_CA_CERTS=$NODE_EXTRA_CA_CERTS "
             "SSL_CERT_FILE=$SSL_CERT_FILE"
         )
-        result = await self.sandbox.process.exec({
-            "command": (
-                f'su - agent -c "{claude_env} && '
-                "claude --dangerously-skip-permissions -p "
-                '\\"What is 2+2? Reply with ONLY the number.\\" '
-                '--output-format text" 2>&1'
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    f'su - agent -c "{claude_env} && '
+                    "claude --dangerously-skip-permissions -p "
+                    '\\"What is 2+2? Reply with ONLY the number.\\" '
+                    '--output-format text" 2>&1'
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert "4" in (result.logs or "")
 
@@ -1422,15 +1550,17 @@ class TestProxyClaudeCode:
             "NODE_EXTRA_CA_CERTS=$NODE_EXTRA_CA_CERTS "
             "SSL_CERT_FILE=$SSL_CERT_FILE"
         )
-        result = await self.sandbox.process.exec({
-            "command": (
-                f'su - agent -c "{claude_env} && '
-                "claude --dangerously-skip-permissions -p "
-                '\\"Run: curl -s https://httpbin.org/headers — then print the full JSON output.\\" '
-                '--output-format text" 2>&1'
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    f'su - agent -c "{claude_env} && '
+                    "claude --dangerously-skip-permissions -p "
+                    '\\"Run: curl -s https://httpbin.org/headers — then print the full JSON output.\\" '
+                    '--output-format text" 2>&1'
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert "X-Agent-Test" in (result.logs or "")
         assert "claude-injected" in (result.logs or "")


### PR DESCRIPTION
- Track the event loop used to create the `httpx.AsyncClient` and recreate it if the running loop changes.
- Add support for image creation APIs and models.
- Introduce `GithubRunnerConfig` and ephemeral `JobVolume` support in job specifications.
- Update `ImageMetadata` and `PendingInvitation` models with additional fields.
- Reformat proxy integration tests for improved readability.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-python/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR fixes async client recreation on event loop mismatch and adds new SDK models for image creation, GitHub runner config, job volumes, and updated ImageMetadata/PendingInvitation fields.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit dd4547da8b34b5aca00a14e80f2d3f38b877a01e.</sup>
<!-- /MENDRAL_SUMMARY -->