### PR TITLE
feat: add Python 3.14 support and upgrade framework dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,7 @@ jobs:
       BL_API_KEY: fake_api_key
       BL_WORKSPACE: fake_workspace
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
@@ -35,6 +36,7 @@ jobs:
           python -c "import blaxel.core; print('✅ blaxel.core imports successfully')"
 
       - name: Test package installation (with extras)
+        if: matrix.python-version != '3.14'
         run: |
           source .venv/bin/activate
           uv pip install -e ".[telemetry,crewai]"
@@ -43,6 +45,17 @@ jobs:
           import blaxel.telemetry
           import blaxel.crewai
           print('✅ blaxel with extras imports successfully')
+          "
+
+      - name: Test package installation (with telemetry)
+        if: matrix.python-version == '3.14'
+        run: |
+          source .venv/bin/activate
+          uv pip install -e ".[telemetry]"
+          python -c "
+          import blaxel.core
+          import blaxel.telemetry
+          print('✅ blaxel with telemetry imports successfully on Python 3.14')
           "
 
       - name: Test package build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       BL_WORKSPACE: fake_workspace
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 description = "Blaxel - AI development platform SDK"
 readme = "README.md"
 authors = [{ name = "cploujoux", email = "cploujoux@blaxel.ai" }]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 dependencies = [
   # Core dependencies that are always needed
   "pydantic>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,18 +27,18 @@ core = []
 # Telemetry module
 telemetry = [
   "opentelemetry-exporter-otlp>=1.28.0",
-  "opentelemetry-instrumentation-anthropic==0.41.0",
-  "opentelemetry-instrumentation-cohere==0.41.0",
-  "opentelemetry-instrumentation-fastapi==0.55b0",
-  "opentelemetry-instrumentation-google-generativeai==0.41.0",
-  "opentelemetry-instrumentation-ollama==0.41.0",
-  "opentelemetry-instrumentation-openai==0.41.0",
+  "opentelemetry-instrumentation-anthropic>=0.41.0",
+  "opentelemetry-instrumentation-cohere>=0.41.0",
+  "opentelemetry-instrumentation-fastapi>=0.55b0",
+  "opentelemetry-instrumentation-google-generativeai>=0.41.0",
+  "opentelemetry-instrumentation-ollama>=0.41.0",
+  "opentelemetry-instrumentation-openai>=0.41.0",
 ]
 
 # CrewAI module
 crewai = [
-  "crewai[litellm]==1.9.3",
-  "opentelemetry-instrumentation-crewai==0.41.0",
+  "crewai[litellm]>=1.9.3",
+  "opentelemetry-instrumentation-crewai>=0.41.0",
 ]
 
 # OpenAI module
@@ -46,15 +46,13 @@ openai = ["openai-agents>=0.0.19"]
 
 # LangGraph module
 langgraph = [
-  "langgraph>=0.2.40,<0.3.0",
+  "langgraph>=0.2.40",
   "langchain-cohere>=0.4.3",
-  "langchain-community>=0.3.3,<0.4.0",
-  "langchain-core>=0.3.13,<0.4.0",
-  "langchain-deepseek-official>=0.1.0.post1",
+  "langchain-community>=0.3.3",
+  "langchain-core>=0.3.13",
   "langchain-openai>=0.3.10",
   "langchain-xai>=0.2.2",
   "langchain-anthropic>=0.3.10",
-  "langchain-cerebras>=0.5.0,<0.6.0",
   "opentelemetry-instrumentation-langchain>=0.35.0",
   "pillow>=10.0.0",
 ]
@@ -74,7 +72,7 @@ llamaindex = [
   "llama-index-llms-deepseek>=0.1.1",
   "llama-index-llms-google-genai>=0.1.13",
   "llama-index-llms-groq>=0.3.1",
-  "llama-index-llms-mistralai>=0.4.0",
+  "llama-index-llms-mistralai>=0.4.0,<0.10.0",
   "llama-index-llms-openai>=0.3.42",
   "opentelemetry-instrumentation-llamaindex>=0.40.7",
 ]

--- a/src/blaxel/core/sandbox/default/process.py
+++ b/src/blaxel/core/sandbox/default/process.py
@@ -105,7 +105,7 @@ class SandboxProcess(SandboxAction):
                     if is_running:
                         start_stream()
 
-                reconnect_timer = asyncio.get_event_loop().call_later(
+                reconnect_timer = asyncio.get_running_loop().call_later(
                     reconnect_interval, schedule_reconnect
                 )
 
@@ -397,7 +397,7 @@ class SandboxProcess(SandboxAction):
         self, identifier: str, max_wait: int = 60000, interval: int = 1000
     ) -> ProcessResponse:
         """Wait for a process to complete."""
-        start_time = asyncio.get_event_loop().time() * 1000  # Convert to milliseconds
+        start_time = asyncio.get_running_loop().time() * 1000  # Convert to milliseconds
         status = "running"
         data = await self.get(identifier)
 
@@ -409,7 +409,7 @@ class SandboxProcess(SandboxAction):
             except:
                 break
 
-            if (asyncio.get_event_loop().time() * 1000) - start_time > max_wait:
+            if (asyncio.get_running_loop().time() * 1000) - start_time > max_wait:
                 raise Exception("Process did not finish in time")
 
         return data

--- a/src/blaxel/langgraph/model.py
+++ b/src/blaxel/langgraph/model.py
@@ -63,14 +63,12 @@ class TokenRefreshingWrapper:
                 **kwargs,
             )
         elif model_type == "deepseek":
-            from langchain_deepseek import (  # type: ignore[import-not-found]
-                ChatDeepSeek,
-            )
+            from langchain_openai import ChatOpenAI  # type: ignore[import-not-found]
 
-            return ChatDeepSeek(
+            return ChatOpenAI(
                 api_key=settings.auth.token,
                 model=model,
-                api_base=f"{url}/v1",
+                base_url=f"{url}/v1",
                 **kwargs,
             )
         elif model_type == "anthropic":
@@ -98,11 +96,9 @@ class TokenRefreshingWrapper:
                 **kwargs,
             )
         elif model_type == "cerebras":
-            from langchain_cerebras import (  # type: ignore[import-not-found]
-                ChatCerebras,
-            )
+            from langchain_openai import ChatOpenAI  # type: ignore[import-not-found]
 
-            return ChatCerebras(
+            return ChatOpenAI(
                 api_key=settings.auth.token,
                 model=model,
                 base_url=f"{url}/v1",

--- a/src/blaxel/llamaindex/model.py
+++ b/src/blaxel/llamaindex/model.py
@@ -40,6 +40,32 @@ DEFAULT_CONTEXT_WINDOW = 128000
 DEFAULT_NUM_OUTPUT = 4096
 
 
+def _make_safe_openai_class():
+    """Create an OpenAI subclass that gracefully handles unknown model names.
+
+    LlamaIndex's OpenAI class validates model names against a hardcoded list
+    in its metadata property. When using Blaxel gateway models, the model name
+    may not be in that list, causing ValueError inside the LLM's internal methods.
+    """
+    from llama_index.llms.openai import OpenAI  # type: ignore[import-not-found]
+
+    class SafeOpenAI(OpenAI):
+        @property
+        def metadata(self) -> LLMMetadata:
+            try:
+                return super().metadata
+            except (ValueError, KeyError):
+                return LLMMetadata(
+                    context_window=DEFAULT_CONTEXT_WINDOW,
+                    num_output=self.max_tokens or DEFAULT_NUM_OUTPUT,
+                    is_chat_model=True,
+                    is_function_calling_model=True,
+                    model_name=self.model,
+                )
+
+    return SafeOpenAI
+
+
 class TokenRefreshingLLM(FunctionCallingLLM):
     """Wrapper for LlamaIndex LLMs that refreshes token before each call.
 
@@ -156,14 +182,13 @@ class TokenRefreshingLLM(FunctionCallingLLM):
                 **kwargs,
             )
         else:
-            from llama_index.llms.openai import OpenAI  # type: ignore[import-not-found]
-
             if model_type != "openai":
                 logger.warning(
                     f"Model {model} is not supported by LlamaIndex, defaulting to OpenAI"
                 )
 
-            return OpenAI(
+            SafeOpenAI = _make_safe_openai_class()
+            return SafeOpenAI(
                 model=model,
                 api_key=settings.auth.token,
                 api_base=f"{url}/v1",

--- a/src/blaxel/telemetry/log/log.py
+++ b/src/blaxel/telemetry/log/log.py
@@ -3,16 +3,25 @@ import queue
 import threading
 
 from opentelemetry.context import attach, create_key, detach, set_value
-from opentelemetry.sdk._logs import LogData, LogRecordProcessor
+from opentelemetry.sdk._logs import LogRecordProcessor
 from opentelemetry.sdk._logs._internal.export import LogExporter
 
 _logger = logging.getLogger(__name__)
 
+# opentelemetry-sdk >=1.35 renamed emit(LogData) to on_emit(ReadWriteLogRecord)
+# and removed the LogData class. Detect which API to use.
+try:
+    from opentelemetry.sdk._logs import LogData as _LogData
+
+    _USE_LEGACY_EMIT = True
+except ImportError:
+    _USE_LEGACY_EMIT = False
+
 
 class AsyncLogRecordProcessor(LogRecordProcessor):
     """This is an implementation of LogRecordProcessor which passes
-    received logs in the export-friendly LogData representation to the
-    configured LogExporter asynchronously using a background thread.
+    received logs to the configured LogExporter asynchronously using
+    a background thread.
     """
 
     def __init__(self, exporter: LogExporter):
@@ -33,10 +42,10 @@ class AsyncLogRecordProcessor(LogRecordProcessor):
         """Process logs from the queue in the background thread."""
         while not self._shutdown:
             try:
-                log_data = self._queue.get(timeout=1.0)
+                log_record = self._queue.get(timeout=1.0)
                 token = attach(set_value(create_key("suppress_instrumentation"), True))
                 try:
-                    self._exporter.export((log_data,))
+                    self._exporter.export((log_record,))
                 except Exception:  # pylint: disable=broad-exception-caught
                     _logger.exception("Exception while exporting logs.")
                 finally:
@@ -45,10 +54,20 @@ class AsyncLogRecordProcessor(LogRecordProcessor):
             except queue.Empty:
                 continue
 
-    def emit(self, log_data: LogData):
+    def _enqueue(self, record):
         if self._shutdown:
             return
-        self._queue.put(log_data)
+        self._queue.put(record)
+
+    if _USE_LEGACY_EMIT:
+
+        def emit(self, log_data: "_LogData"):
+            self._enqueue(log_data)
+
+    else:
+
+        def on_emit(self, log_record, *args, **kwargs):
+            self._enqueue(log_record)
 
     def shutdown(self):
         """Shutdown the processor and wait for pending exports to complete."""

--- a/tests/integration/core/sandbox/test_proxy.py
+++ b/tests/integration/core/sandbox/test_proxy.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 
@@ -1035,22 +1036,33 @@ class TestProxyEndToEnd:
         assert len(body) > 0
 
     async def test_wildcard_route_matches_subdomain(self):
-        result = await self.sandbox.process.exec(
-            {
-                "command": "node /tmp/proxy-test.js GET https://sub.example.com",
-                "wait_for_completion": True,
-            }
-        )
+        # Wildcard proxy routing can be slow to propagate; retry a few times
+        last_error = None
+        for attempt in range(3):
+            result = await self.sandbox.process.exec(
+                {
+                    "command": "node /tmp/proxy-test.js GET https://sub.example.com",
+                    "wait_for_completion": True,
+                }
+            )
 
-        if result.exit_code != 0:
-            assert result.exit_code == 0
-            return
+            if result.exit_code != 0:
+                last_error = f"exit_code={result.exit_code}"
+                await asyncio.sleep(2)
+                continue
 
-        body = (result.logs or "").strip()
-        if "{" in body:
-            response = _parse_json_output(result.logs)
-            headers = _lowercase_keys(response.get("headers", {}))
-            assert headers.get("x-wildcard-match") == "wildcard-injected"
+            body = (result.logs or "").strip()
+            if "{" in body:
+                response = _parse_json_output(result.logs)
+                headers = _lowercase_keys(response.get("headers", {}))
+                if headers.get("x-wildcard-match") == "wildcard-injected":
+                    return  # success
+                last_error = f"x-wildcard-match={headers.get('x-wildcard-match')}"
+            else:
+                last_error = "no JSON in response body"
+            await asyncio.sleep(2)
+
+        pytest.fail(f"Wildcard route did not match after 3 attempts: {last_error}")
 
     async def test_wildcard_route_does_not_match_bare_domain(self):
         result = await self.sandbox.process.exec(

--- a/tests/integration/core/sandbox/test_system.py
+++ b/tests/integration/core/sandbox/test_system.py
@@ -27,13 +27,13 @@ async def wait_for_upgrade_complete(
     poll_interval = 0.5
     retries = 0
     health_data = None
-    deadline = asyncio.get_event_loop().time() + max_wait_time
+    deadline = asyncio.get_running_loop().time() + max_wait_time
 
-    while asyncio.get_event_loop().time() < deadline:
+    while asyncio.get_running_loop().time() < deadline:
         try:
             health_data = await sandbox.system.health()
             upgrade_count = health_data.upgrade_count or 0
-            elapsed = max_wait_time - (deadline - asyncio.get_event_loop().time())
+            elapsed = max_wait_time - (deadline - asyncio.get_running_loop().time())
             print(
                 f"[TEST] Health check - upgradeCount: {upgrade_count} (elapsed: {elapsed * 1000:.0f}ms)"
             )

--- a/tests/integration/core/sandbox/test_system.py
+++ b/tests/integration/core/sandbox/test_system.py
@@ -14,22 +14,26 @@ VERSION = "develop" if os.environ.get("BL_ENV") == "dev" else "latest"
 
 
 async def wait_for_upgrade_complete(
-    sandbox: SandboxInstance, max_wait_time: float = 30.0
+    sandbox: SandboxInstance,
+    max_wait_time: float = 60.0,
+    max_retries: int = 3,
 ) -> HealthResponse:
     """
     Wait for sandbox upgrade to complete by polling the health endpoint.
-    Uses the SDK's health method which includes proper authentication.
-    Returns the health data when upgrade count > 0, raises if upgrade failed.
+    Retries the upgrade automatically on transient failures, matching the
+    Go SDK's UpgradeAndWait behaviour.
     """
     print("[TEST] Waiting for health upgrade count > 0...")
-    elapsed = 0.0
     poll_interval = 0.5
+    retries = 0
     health_data = None
+    deadline = asyncio.get_event_loop().time() + max_wait_time
 
-    while elapsed < max_wait_time:
+    while asyncio.get_event_loop().time() < deadline:
         try:
             health_data = await sandbox.system.health()
             upgrade_count = health_data.upgrade_count or 0
+            elapsed = max_wait_time - (deadline - asyncio.get_event_loop().time())
             print(
                 f"[TEST] Health check - upgradeCount: {upgrade_count} (elapsed: {elapsed * 1000:.0f}ms)"
             )
@@ -37,19 +41,24 @@ async def wait_for_upgrade_complete(
                 print(f"[TEST] Upgrade completed (took {elapsed * 1000:.0f}ms)")
                 return health_data
             if health_data.last_upgrade and health_data.last_upgrade.status == "failed":
-                print(f"[TEST] Health check - last upgrade failed, health data: {health_data}")
-                raise Exception(f"Upgrade failed: {health_data}")
+                if retries >= max_retries:
+                    raise Exception(
+                        f"Upgrade failed after {retries} retries: {health_data.last_upgrade.error}"
+                    )
+                retries += 1
+                print(
+                    f"[TEST] Upgrade failed, retrying ({retries}/{max_retries})..."
+                )
+                await sandbox.system.upgrade(version=VERSION)
         except Exception as e:
-            # Re-throw upgrade failures
-            if str(e).startswith("Upgrade failed:"):
+            if "Upgrade failed after" in str(e):
                 raise
-            print(f"[TEST] Health check error: {e} (elapsed: {elapsed * 1000:.0f}ms)")
+            print(f"[TEST] Health check error: {e}")
 
         await asyncio.sleep(poll_interval)
-        elapsed += poll_interval
 
     raise Exception(
-        f"Upgrade did not complete within {max_wait_time * 1000}ms. Last health data: {health_data}"
+        f"Upgrade did not complete within {max_wait_time}s. Last health data: {health_data}"
     )
 
 


### PR DESCRIPTION
## Summary
**Python 3.14 support:**
- Extend requires-python from >=3.10,<3.14 to >=3.10,<3.15
- Replace 3 uses of asyncio.get_event_loop() with asyncio.get_running_loop() for Python 3.14 compatibility
- Add Python 3.13 and 3.14 to CI test matrix with fail-fast: false
- Skip crewai extras on Python 3.14 in CI (tokenizers transitive dep doesn't support 3.14 yet)

**Framework dependency upgrades:**
- Remove restrictive upper bounds on langgraph (<0.3.0), langchain-core (<0.4.0), langchain-community (<0.4.0), langchain-cerebras (<0.6.0) to allow resolving to latest 1.x versions
- Replace langchain-deepseek-official and langchain-cerebras with ChatOpenAI using base_url (both expose OpenAI-compatible APIs), removing deps that pinned langchain-openai to conflicting 0.3.x ranges
- Unpin crewai from ==1.9.3 to >=1.9.3
- Unpin OpenTelemetry instrumentations from ==0.41.0 to >=0.41.0
- Cap llama-index-llms-mistralai <0.10.0 (0.10.x has broken mistralai_azure dependency)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds Python 3.13/3.14 support by updating `requires-python`, replacing deprecated `asyncio.get_event_loop()` with `get_running_loop()` throughout the SDK and tests, expanding the CI matrix with `fail-fast: false`, skipping crewai extras on 3.14, removing restrictive upper bounds on langchain/langgraph deps, consolidating deepseek and cerebras onto `ChatOpenAI`, adapting to the opentelemetry-sdk >=1.35 `LogRecordProcessor` API rename, adding a `SafeOpenAI` subclass for unknown model names, and adding retry logic to integration tests.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit aae36012a49c77a58ac27c6e73a0a30c6ef339aa.</sup>
<!-- /MENDRAL_SUMMARY -->