### PR TITLE
feat(versioning): send Blaxel-Version header on every request (ENG-2068)

### DIFF
--- a/src/blaxel/core/common/settings.py
+++ b/src/blaxel/core/common/settings.py
@@ -8,6 +8,8 @@ import yaml
 from ..authentication import BlaxelAuth, auth
 from .logger import init_logger
 
+BLAXEL_API_VERSION = "2026-04-16"
+
 
 def _get_os_arch() -> str:
     """Get OS and architecture information."""
@@ -91,11 +93,17 @@ class Settings:
         return blaxel.__commit__ or "unknown"
 
     @property
+    def api_version(self) -> str:
+        """Get the API version sent in the Blaxel-Version header."""
+        return os.environ.get("BL_API_VERSION", BLAXEL_API_VERSION)
+
+    @property
     def headers(self) -> Dict[str, str]:
         """Get the headers for API requests."""
         headers = self.auth.get_headers()
         os_arch = _get_os_arch()
         headers["User-Agent"] = f"blaxel/sdk/python/{self.version} ({os_arch}) blaxel/{self.commit}"
+        headers["Blaxel-Version"] = self.api_version
         return headers
 
     @property

--- a/tests/core/test_settings_api_version.py
+++ b/tests/core/test_settings_api_version.py
@@ -1,0 +1,28 @@
+"""Tests for the Blaxel-Version header in Settings."""
+import os
+
+from blaxel.core.common.settings import BLAXEL_API_VERSION, settings
+
+
+def test_default_api_version():
+    """Blaxel-Version defaults to the module constant when BL_API_VERSION is unset."""
+    os.environ.pop("BL_API_VERSION", None)
+    assert settings.api_version == BLAXEL_API_VERSION
+    assert settings.api_version == "2026-04-16"
+
+
+def test_env_override_api_version():
+    """BL_API_VERSION env var overrides the default."""
+    os.environ["BL_API_VERSION"] = "2026-99-99"
+    try:
+        assert settings.api_version == "2026-99-99"
+    finally:
+        del os.environ["BL_API_VERSION"]
+
+
+def test_headers_contain_blaxel_version():
+    """headers dict includes Blaxel-Version set to the api_version value."""
+    os.environ.pop("BL_API_VERSION", None)
+    h = settings.headers
+    assert "Blaxel-Version" in h
+    assert h["Blaxel-Version"] == BLAXEL_API_VERSION


### PR DESCRIPTION
## Summary
- Adds `BLAXEL_API_VERSION = "2026-04-16"` constant + `api_version` property (with `BL_API_VERSION` env override) to `Settings`.
- The `headers` dict now includes `Blaxel-Version` on every outgoing request.
- Tests cover default, env override, and headers presence.

## Linear
Tracking ENG-2068. Pairs with controlplane PR (server-side middleware) and docs PR.

## Test plan
- [x] `uv run pytest tests/core/test_settings_api_version.py -v` (3/3 pass)
- [ ] Manual integration with controlplane (header echoed back in response)

## Notes
- This is a temporary hand-written addition. Once the SDK migrates to Stainless, the constant + headers entry will move to `client_settings.opts.api_version` in `stainless.yml`.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `Blaxel-Version` header to every outgoing API request using a new `BLAXEL_API_VERSION` constant and `api_version` property on `Settings`, with an optional `BL_API_VERSION` env override. Tests cover default, override, and header presence.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit af92f9f0e062ec2fd9e5ef83fac03e109e032238.</sup>
<!-- /MENDRAL_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-python/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
