### PR TITLE
test(sandbox): loosen volume resize assertion for async propagation

### DIFF
--- a/tests/integration/core/sandbox/test_volumes.py
+++ b/tests/integration/core/sandbox/test_volumes.py
@@ -253,6 +253,17 @@ class TestVolumeResize(TestVolumeOperations):
         )
         assert "large-file-1.bin" in check_result1.logs
 
+        # Capture disk usage on the 512MB volume so we can later assert the
+        # resize actually took effect (usage should drop on the 1GB volume).
+        disk_check1 = await sandbox1.process.exec(
+            {
+                "command": "df /data | tail -1 | awk '{print $5}' | sed 's/%//'",
+                "wait_for_completion": True,
+            }
+        )
+        usage_percent1 = int(disk_check1.logs.strip())
+        assert usage_percent1 > 60
+
         # Delete first sandbox
         await SandboxInstance.delete(sandbox1_name)
         await wait_for_sandbox_deletion(sandbox1_name)
@@ -282,6 +293,33 @@ class TestVolumeResize(TestVolumeOperations):
             }
         )
         assert "large-file-1.bin" in check_result2.logs
+
+        # Poll disk usage until the resize is visible in the mounted filesystem.
+        # Volume resize is event-based on the backend, so reconciliation can take
+        # noticeably longer than a few seconds. Wait up to 3 minutes for usage to
+        # drop below the pre-resize value before asserting.
+        resize_deadline = time.time() + 180
+        usage_percent2 = usage_percent1
+        while time.time() < resize_deadline:
+            disk_check2 = await sandbox2.process.exec(
+                {
+                    "command": "df /data | tail -1 | awk '{print $5}' | sed 's/%//'",
+                    "wait_for_completion": True,
+                }
+            )
+            try:
+                usage_percent2 = int(disk_check2.logs.strip())
+            except ValueError:
+                # Empty or malformed df output: retry rather than spin idle.
+                await asyncio.sleep(5)
+                continue
+            if usage_percent2 < usage_percent1:
+                break
+            await asyncio.sleep(5)
+        # After resize from 512MB to 1024MB, usage should drop meaningfully.
+        # Use a relative comparison rather than a fixed threshold to tolerate
+        # filesystem overhead and async reconciliation timing.
+        assert usage_percent2 < usage_percent1
 
         # Write another ~400MB file (would fail if volume wasn't resized)
         write_result = await sandbox2.process.exec(

--- a/tests/integration/core/sandbox/test_volumes.py
+++ b/tests/integration/core/sandbox/test_volumes.py
@@ -261,7 +261,12 @@ class TestVolumeResize(TestVolumeOperations):
                 "wait_for_completion": True,
             }
         )
-        usage_percent1 = int(disk_check1.logs.strip())
+        try:
+            usage_percent1 = int(disk_check1.logs.strip())
+        except ValueError as e:
+            raise AssertionError(
+                f"Could not parse df output for baseline disk usage: {disk_check1.logs!r}"
+            ) from e
         assert usage_percent1 > 60
 
         # Delete first sandbox


### PR DESCRIPTION
## Summary
- Port of [sdk-typescript#292](https://github.com/blaxel-ai/sdk-typescript/pull/292) to the Python integration test.
- Volume resize is event-based on the backend, so the mounted filesystem view can take longer than a few seconds to reconcile, making the assertion flaky.
- Capture pre-resize disk usage on the 512MB volume, then poll `df /data` inside the new sandbox for up to 3 minutes waiting for usage to drop below the pre-resize value.
- Guard against `ValueError` on empty/malformed `df` output so the loop retries instead of spinning idle.

## Test plan
- [x] `uv run pytest tests/integration/core/sandbox/test_volumes.py::TestVolumeResize::test_resizes_volume_and_preserves_data -v -s` (requires `BL_WORKSPACE` + `BL_API_KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Ports the TypeScript SDK fix for flaky volume resize assertions to Python. Captures pre-resize disk usage on the 512MB volume, then polls `df /data` in the new sandbox for up to 3 minutes until usage drops below the pre-resize baseline. Guards against malformed `df` output in both the baseline capture and the polling loop.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ec91d3faa265e631bdadcc01546ba06ab8239047.</sup>
<!-- /MENDRAL_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-python/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
