### PR TITLE
feat: enhance API responses with pagination support and model updates

### DIFF
--- a/src/blaxel/core/client/api/agents/create_agent.py
+++ b/src/blaxel/core/client/api/agents/create_agent.py
@@ -35,27 +35,87 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Agent, Error] | None:
     if response.status_code == 200:
-        response_200 = Agent.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Agent.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = Error.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 409:
-        response_409 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_409 = Error.from_dict(_response_content)
 
         return response_409
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -91,6 +151,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -126,6 +187,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -156,6 +218,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -189,6 +252,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/agents/delete_agent.py
+++ b/src/blaxel/core/client/api/agents/delete_agent.py
@@ -23,23 +23,73 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Agent, Error] | None:
     if response.status_code == 200:
-        response_200 = Agent.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Agent.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -72,6 +122,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,6 +155,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -131,6 +183,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -161,6 +214,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/agents/get_agent.py
+++ b/src/blaxel/core/client/api/agents/get_agent.py
@@ -32,23 +32,73 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Agent, Error] | None:
     if response.status_code == 200:
-        response_200 = Agent.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Agent.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -83,6 +133,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -118,6 +169,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -148,6 +200,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -181,6 +234,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/agents/list_agent_revisions.py
+++ b/src/blaxel/core/client/api/agents/list_agent_revisions.py
@@ -22,8 +22,18 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["RevisionMetadata"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = RevisionMetadata.from_dict(response_200_item_data)
 
@@ -59,6 +69,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -88,6 +99,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -112,6 +124,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -139,6 +152,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/agents/list_agents.py
+++ b/src/blaxel/core/client/api/agents/list_agents.py
@@ -53,19 +53,59 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[AgentList, Error] | None:
     if response.status_code == 200:
-        response_200 = AgentList.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = AgentList.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -110,6 +150,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -156,6 +197,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -197,6 +239,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -241,6 +284,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/agents/list_agents.py
+++ b/src/blaxel/core/client/api/agents/list_agents.py
@@ -5,30 +5,55 @@ import httpx
 
 from ... import errors
 from ...client import Client
-from ...models.agent import Agent
+from ...models.agent_list import AgentList
 from ...models.error import Error
-from ...types import Response
+from ...models.list_agents_anchor import ListAgentsAnchor
+from ...models.list_agents_sort import ListAgentsSort
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListAgentsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListAgentsAnchor] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    json_sort: Union[Unset, str] = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort.value
+
+    params["sort"] = json_sort
+
+    params["q"] = q
+
+    json_anchor: Union[Unset, str] = UNSET
+    if not isinstance(anchor, Unset):
+        json_anchor = anchor.value
+
+    params["anchor"] = json_anchor
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/agents",
+        "params": params,
     }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Client, response: httpx.Response
-) -> Union[Error, list["Agent"]] | None:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[AgentList, Error] | None:
     if response.status_code == 200:
-        response_200 = []
-        _response_200 = response.json()
-        for response_200_item_data in _response_200:
-            response_200_item = Agent.from_dict(response_200_item_data)
-
-            response_200.append(response_200_item)
+        response_200 = AgentList.from_dict(response.json())
 
         return response_200
     if response.status_code == 401:
@@ -51,7 +76,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[Error, list["Agent"]]]:
+) -> Response[Union[AgentList, Error]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,21 +88,41 @@ def _build_response(
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[Error, list["Agent"]]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListAgentsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListAgentsAnchor] = UNSET,
+) -> Response[Union[AgentList, Error]]:
     """List all agents
 
-     Returns all AI agents deployed in the workspace. Each agent includes its deployment status, runtime
-    configuration, and global inference endpoint URL.
+     Returns AI agents deployed in the workspace. Each agent includes its deployment status, runtime
+    configuration, and global inference endpoint URL. Starting with API version 2026-04-28 the response
+    is wrapped in `{data, meta}` and supports cursor pagination via the `cursor` and `limit` query
+    parameters; older versions keep returning a bare array with all agents.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListAgentsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListAgentsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, list['Agent']]]
+        Response[Union[AgentList, Error]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -89,43 +134,82 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Union[Error, list["Agent"]] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListAgentsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListAgentsAnchor] = UNSET,
+) -> Union[AgentList, Error] | None:
     """List all agents
 
-     Returns all AI agents deployed in the workspace. Each agent includes its deployment status, runtime
-    configuration, and global inference endpoint URL.
+     Returns AI agents deployed in the workspace. Each agent includes its deployment status, runtime
+    configuration, and global inference endpoint URL. Starting with API version 2026-04-28 the response
+    is wrapped in `{data, meta}` and supports cursor pagination via the `cursor` and `limit` query
+    parameters; older versions keep returning a bare array with all agents.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListAgentsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListAgentsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, list['Agent']]
+        Union[AgentList, Error]
     """
 
     return sync_detailed(
         client=client,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[Error, list["Agent"]]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListAgentsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListAgentsAnchor] = UNSET,
+) -> Response[Union[AgentList, Error]]:
     """List all agents
 
-     Returns all AI agents deployed in the workspace. Each agent includes its deployment status, runtime
-    configuration, and global inference endpoint URL.
+     Returns AI agents deployed in the workspace. Each agent includes its deployment status, runtime
+    configuration, and global inference endpoint URL. Starting with API version 2026-04-28 the response
+    is wrapped in `{data, meta}` and supports cursor pagination via the `cursor` and `limit` query
+    parameters; older versions keep returning a bare array with all agents.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListAgentsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListAgentsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, list['Agent']]]
+        Response[Union[AgentList, Error]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -135,22 +219,41 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Union[Error, list["Agent"]] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListAgentsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListAgentsAnchor] = UNSET,
+) -> Union[AgentList, Error] | None:
     """List all agents
 
-     Returns all AI agents deployed in the workspace. Each agent includes its deployment status, runtime
-    configuration, and global inference endpoint URL.
+     Returns AI agents deployed in the workspace. Each agent includes its deployment status, runtime
+    configuration, and global inference endpoint URL. Starting with API version 2026-04-28 the response
+    is wrapped in `{data, meta}` and supports cursor pagination via the `cursor` and `limit` query
+    parameters; older versions keep returning a bare array with all agents.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListAgentsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListAgentsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, list['Agent']]
+        Union[AgentList, Error]
     """
 
     return (
         await asyncio_detailed(
             client=client,
+            cursor=cursor,
+            limit=limit,
+            sort=sort,
+            q=q,
+            anchor=anchor,
         )
     ).parsed

--- a/src/blaxel/core/client/api/agents/list_agents.py
+++ b/src/blaxel/core/client/api/agents/list_agents.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Union
+from typing import Any, Union, cast
 
 import httpx
 
@@ -51,7 +51,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[AgentList, Error] | None:
+def _parse_response(
+    *, client: Client, response: httpx.Response
+) -> Union[list[Any], AgentList, Error] | None:
     if response.status_code == 200:
         try:
             _response_content = response.json()
@@ -65,6 +67,12 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[AgentL
             return None
         response_200 = AgentList.from_dict(_response_content)
 
+        if isinstance(_response_content, list):
+            if response_200 is None:
+                return []
+            if response_200.data is UNSET or response_200.data is None:
+                return []
+            return cast(list[Any], response_200.data)
         return response_200
     if response.status_code == 401:
         try:
@@ -116,7 +124,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[AgentL
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[AgentList, Error]]:
+) -> Response[Union[list[Any], AgentList, Error]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -133,7 +141,7 @@ def sync_detailed(
     sort: Union[Unset, ListAgentsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListAgentsAnchor] = UNSET,
-) -> Response[Union[AgentList, Error]]:
+) -> Response[Union[list[Any], AgentList, Error]]:
     """List all agents
 
      Returns AI agents deployed in the workspace. Each agent includes its deployment status, runtime
@@ -154,7 +162,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[AgentList, Error]]
+        Response[Union[list[Any], AgentList, Error]]
     """
 
     kwargs = _get_kwargs(
@@ -180,7 +188,7 @@ def sync(
     sort: Union[Unset, ListAgentsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListAgentsAnchor] = UNSET,
-) -> Union[AgentList, Error] | None:
+) -> Union[list[Any], AgentList, Error] | None:
     """List all agents
 
      Returns AI agents deployed in the workspace. Each agent includes its deployment status, runtime
@@ -201,7 +209,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[AgentList, Error]
+        Union[list[Any], AgentList, Error]
     """
 
     return sync_detailed(
@@ -222,7 +230,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListAgentsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListAgentsAnchor] = UNSET,
-) -> Response[Union[AgentList, Error]]:
+) -> Response[Union[list[Any], AgentList, Error]]:
     """List all agents
 
      Returns AI agents deployed in the workspace. Each agent includes its deployment status, runtime
@@ -243,7 +251,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[AgentList, Error]]
+        Response[Union[list[Any], AgentList, Error]]
     """
 
     kwargs = _get_kwargs(
@@ -267,7 +275,7 @@ async def asyncio(
     sort: Union[Unset, ListAgentsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListAgentsAnchor] = UNSET,
-) -> Union[AgentList, Error] | None:
+) -> Union[list[Any], AgentList, Error] | None:
     """List all agents
 
      Returns AI agents deployed in the workspace. Each agent includes its deployment status, runtime
@@ -288,7 +296,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[AgentList, Error]
+        Union[list[Any], AgentList, Error]
     """
 
     return (

--- a/src/blaxel/core/client/api/agents/update_agent.py
+++ b/src/blaxel/core/client/api/agents/update_agent.py
@@ -36,27 +36,87 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Agent, Error] | None:
     if response.status_code == 200:
-        response_200 = Agent.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Agent.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = Error.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -93,6 +153,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -130,6 +191,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -162,6 +224,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -197,6 +260,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/compute/create_sandbox.py
+++ b/src/blaxel/core/client/api/compute/create_sandbox.py
@@ -45,27 +45,87 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Sandbox, SandboxError] | None:
     if response.status_code == 200:
-        response_200 = Sandbox.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Sandbox.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = SandboxError.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = SandboxError.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = SandboxError.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = SandboxError.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = SandboxError.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = SandboxError.from_dict(_response_content)
 
         return response_403
     if response.status_code == 409:
-        response_409 = SandboxError.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_409 = SandboxError.from_dict(_response_content)
 
         return response_409
     if response.status_code == 500:
-        response_500 = SandboxError.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = SandboxError.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -104,6 +164,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -141,6 +202,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -173,6 +235,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -208,6 +271,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/compute/create_sandbox_preview.py
+++ b/src/blaxel/core/client/api/compute/create_sandbox_preview.py
@@ -1,24 +1,32 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, Union
 
 import httpx
 
 from ... import errors
 from ...client import Client
 from ...models.preview import Preview
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     sandbox_name: str,
     *,
     body: Preview,
+    force: Union[Unset, bool] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+
+    params: dict[str, Any] = {}
+
+    params["force"] = force
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     _kwargs: dict[str, Any] = {
         "method": "post",
         "url": f"/sandboxes/{sandbox_name}/previews",
+        "params": params,
     }
 
     if type(body) is dict:
@@ -35,7 +43,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Preview | None:
     if response.status_code == 200:
-        response_200 = Preview.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Preview.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -58,6 +76,7 @@ def sync_detailed(
     *,
     client: Client,
     body: Preview,
+    force: Union[Unset, bool] = UNSET,
 ) -> Response[Preview]:
     """Create Sandbox Preview
 
@@ -65,10 +84,12 @@ def sync_detailed(
 
     Args:
         sandbox_name (str):
+        force (Union[Unset, bool]):
         body (Preview): Preview of a Resource
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -78,6 +99,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         sandbox_name=sandbox_name,
         body=body,
+        force=force,
     )
 
     response = client.get_httpx_client().request(
@@ -92,6 +114,7 @@ def sync(
     *,
     client: Client,
     body: Preview,
+    force: Union[Unset, bool] = UNSET,
 ) -> Preview | None:
     """Create Sandbox Preview
 
@@ -99,10 +122,12 @@ def sync(
 
     Args:
         sandbox_name (str):
+        force (Union[Unset, bool]):
         body (Preview): Preview of a Resource
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -113,6 +138,7 @@ def sync(
         sandbox_name=sandbox_name,
         client=client,
         body=body,
+        force=force,
     ).parsed
 
 
@@ -121,6 +147,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     body: Preview,
+    force: Union[Unset, bool] = UNSET,
 ) -> Response[Preview]:
     """Create Sandbox Preview
 
@@ -128,10 +155,12 @@ async def asyncio_detailed(
 
     Args:
         sandbox_name (str):
+        force (Union[Unset, bool]):
         body (Preview): Preview of a Resource
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -141,6 +170,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         sandbox_name=sandbox_name,
         body=body,
+        force=force,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -153,6 +183,7 @@ async def asyncio(
     *,
     client: Client,
     body: Preview,
+    force: Union[Unset, bool] = UNSET,
 ) -> Preview | None:
     """Create Sandbox Preview
 
@@ -160,10 +191,12 @@ async def asyncio(
 
     Args:
         sandbox_name (str):
+        force (Union[Unset, bool]):
         body (Preview): Preview of a Resource
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -175,5 +208,6 @@ async def asyncio(
             sandbox_name=sandbox_name,
             client=client,
             body=body,
+            force=force,
         )
     ).parsed

--- a/src/blaxel/core/client/api/compute/create_sandbox_preview_token.py
+++ b/src/blaxel/core/client/api/compute/create_sandbox_preview_token.py
@@ -36,7 +36,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> PreviewToken | None:
     if response.status_code == 200:
-        response_200 = PreviewToken.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = PreviewToken.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -72,6 +82,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -109,6 +120,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -141,6 +153,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -176,6 +189,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/compute/delete_sandbox.py
+++ b/src/blaxel/core/client/api/compute/delete_sandbox.py
@@ -23,23 +23,73 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Sandbox] | None:
     if response.status_code == 200:
-        response_200 = Sandbox.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Sandbox.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -72,6 +122,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,6 +155,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -131,6 +183,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -161,6 +214,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/compute/delete_sandbox_preview.py
+++ b/src/blaxel/core/client/api/compute/delete_sandbox_preview.py
@@ -23,7 +23,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Preview | None:
     if response.status_code == 200:
-        response_200 = Preview.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Preview.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -57,6 +67,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -91,6 +102,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -120,6 +132,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -152,6 +165,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/compute/delete_sandbox_preview_token.py
+++ b/src/blaxel/core/client/api/compute/delete_sandbox_preview_token.py
@@ -26,7 +26,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> DeleteSandboxPreviewTokenResponse200 | None:
     if response.status_code == 200:
-        response_200 = DeleteSandboxPreviewTokenResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = DeleteSandboxPreviewTokenResponse200.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -64,6 +74,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -101,6 +112,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -133,6 +145,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -168,6 +181,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/compute/get_sandbox.py
+++ b/src/blaxel/core/client/api/compute/get_sandbox.py
@@ -32,23 +32,73 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Sandbox] | None:
     if response.status_code == 200:
-        response_200 = Sandbox.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Sandbox.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -83,6 +133,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -118,6 +169,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -148,6 +200,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -181,6 +234,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/compute/get_sandbox_preview.py
+++ b/src/blaxel/core/client/api/compute/get_sandbox_preview.py
@@ -23,7 +23,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Preview | None:
     if response.status_code == 200:
-        response_200 = Preview.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Preview.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -57,6 +67,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -91,6 +102,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -120,6 +132,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -152,6 +165,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/compute/list_sandbox_preview_tokens.py
+++ b/src/blaxel/core/client/api/compute/list_sandbox_preview_tokens.py
@@ -23,8 +23,18 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["PreviewToken"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = PreviewToken.from_dict(response_200_item_data)
 
@@ -62,6 +72,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -96,6 +107,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -125,6 +137,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -157,6 +170,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/compute/list_sandbox_previews.py
+++ b/src/blaxel/core/client/api/compute/list_sandbox_previews.py
@@ -22,8 +22,18 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["Preview"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = Preview.from_dict(response_200_item_data)
 
@@ -59,6 +69,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -90,6 +101,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -116,6 +128,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -145,6 +158,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/compute/list_sandboxes.py
+++ b/src/blaxel/core/client/api/compute/list_sandboxes.py
@@ -6,14 +6,49 @@ import httpx
 from ... import errors
 from ...client import Client
 from ...models.error import Error
-from ...models.sandbox import Sandbox
-from ...types import Response
+from ...models.list_sandboxes_anchor import ListSandboxesAnchor
+from ...models.list_sandboxes_sort import ListSandboxesSort
+from ...models.sandbox_list import SandboxList
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    show_terminated: Union[Unset, bool] = False,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListSandboxesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListSandboxesAnchor] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["showTerminated"] = show_terminated
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    json_sort: Union[Unset, str] = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort.value
+
+    params["sort"] = json_sort
+
+    params["q"] = q
+
+    json_anchor: Union[Unset, str] = UNSET
+    if not isinstance(anchor, Unset):
+        json_anchor = anchor.value
+
+    params["anchor"] = json_anchor
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/sandboxes",
+        "params": params,
     }
 
     return _kwargs
@@ -21,14 +56,9 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Client, response: httpx.Response
-) -> Union[Error, list["Sandbox"]] | None:
+) -> Union[Error, SandboxList] | None:
     if response.status_code == 200:
-        response_200 = []
-        _response_200 = response.json()
-        for response_200_item_data in _response_200:
-            response_200_item = Sandbox.from_dict(response_200_item_data)
-
-            response_200.append(response_200_item)
+        response_200 = SandboxList.from_dict(response.json())
 
         return response_200
     if response.status_code == 401:
@@ -51,7 +81,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[Error, list["Sandbox"]]]:
+) -> Response[Union[Error, SandboxList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,21 +93,45 @@ def _build_response(
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[Error, list["Sandbox"]]]:
+    show_terminated: Union[Unset, bool] = False,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListSandboxesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListSandboxesAnchor] = UNSET,
+) -> Response[Union[Error, SandboxList]]:
     """List sandboxes
 
-     Returns all sandboxes in the workspace. Each sandbox includes its configuration, status, and
-    endpoint URL.
+     Returns sandboxes in the workspace. Each sandbox includes its configuration, status, and endpoint
+    URL. Terminated sandboxes are hidden by default; pass `showTerminated=true` to include them.
+    Starting with API version 2026-04-28 the response is wrapped in `{data, meta}` and supports cursor
+    pagination via the `cursor` and `limit` query parameters; older versions keep returning a bare array
+    of all sandboxes.
+
+    Args:
+        show_terminated (Union[Unset, bool]):  Default: False.
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListSandboxesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListSandboxesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, list['Sandbox']]]
+        Response[Union[Error, SandboxList]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        show_terminated=show_terminated,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -89,43 +143,90 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Union[Error, list["Sandbox"]] | None:
+    show_terminated: Union[Unset, bool] = False,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListSandboxesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListSandboxesAnchor] = UNSET,
+) -> Union[Error, SandboxList] | None:
     """List sandboxes
 
-     Returns all sandboxes in the workspace. Each sandbox includes its configuration, status, and
-    endpoint URL.
+     Returns sandboxes in the workspace. Each sandbox includes its configuration, status, and endpoint
+    URL. Terminated sandboxes are hidden by default; pass `showTerminated=true` to include them.
+    Starting with API version 2026-04-28 the response is wrapped in `{data, meta}` and supports cursor
+    pagination via the `cursor` and `limit` query parameters; older versions keep returning a bare array
+    of all sandboxes.
+
+    Args:
+        show_terminated (Union[Unset, bool]):  Default: False.
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListSandboxesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListSandboxesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, list['Sandbox']]
+        Union[Error, SandboxList]
     """
 
     return sync_detailed(
         client=client,
+        show_terminated=show_terminated,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[Error, list["Sandbox"]]]:
+    show_terminated: Union[Unset, bool] = False,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListSandboxesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListSandboxesAnchor] = UNSET,
+) -> Response[Union[Error, SandboxList]]:
     """List sandboxes
 
-     Returns all sandboxes in the workspace. Each sandbox includes its configuration, status, and
-    endpoint URL.
+     Returns sandboxes in the workspace. Each sandbox includes its configuration, status, and endpoint
+    URL. Terminated sandboxes are hidden by default; pass `showTerminated=true` to include them.
+    Starting with API version 2026-04-28 the response is wrapped in `{data, meta}` and supports cursor
+    pagination via the `cursor` and `limit` query parameters; older versions keep returning a bare array
+    of all sandboxes.
+
+    Args:
+        show_terminated (Union[Unset, bool]):  Default: False.
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListSandboxesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListSandboxesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, list['Sandbox']]]
+        Response[Union[Error, SandboxList]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        show_terminated=show_terminated,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -135,22 +236,45 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Union[Error, list["Sandbox"]] | None:
+    show_terminated: Union[Unset, bool] = False,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListSandboxesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListSandboxesAnchor] = UNSET,
+) -> Union[Error, SandboxList] | None:
     """List sandboxes
 
-     Returns all sandboxes in the workspace. Each sandbox includes its configuration, status, and
-    endpoint URL.
+     Returns sandboxes in the workspace. Each sandbox includes its configuration, status, and endpoint
+    URL. Terminated sandboxes are hidden by default; pass `showTerminated=true` to include them.
+    Starting with API version 2026-04-28 the response is wrapped in `{data, meta}` and supports cursor
+    pagination via the `cursor` and `limit` query parameters; older versions keep returning a bare array
+    of all sandboxes.
+
+    Args:
+        show_terminated (Union[Unset, bool]):  Default: False.
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListSandboxesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListSandboxesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, list['Sandbox']]
+        Union[Error, SandboxList]
     """
 
     return (
         await asyncio_detailed(
             client=client,
+            show_terminated=show_terminated,
+            cursor=cursor,
+            limit=limit,
+            sort=sort,
+            q=q,
+            anchor=anchor,
         )
     ).parsed

--- a/src/blaxel/core/client/api/compute/list_sandboxes.py
+++ b/src/blaxel/core/client/api/compute/list_sandboxes.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Union
+from typing import Any, Union, cast
 
 import httpx
 
@@ -56,7 +56,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Client, response: httpx.Response
-) -> Union[Error, SandboxList] | None:
+) -> Union[list[Any], Error, SandboxList] | None:
     if response.status_code == 200:
         try:
             _response_content = response.json()
@@ -70,6 +70,12 @@ def _parse_response(
             return None
         response_200 = SandboxList.from_dict(_response_content)
 
+        if isinstance(_response_content, list):
+            if response_200 is None:
+                return []
+            if response_200.data is UNSET or response_200.data is None:
+                return []
+            return cast(list[Any], response_200.data)
         return response_200
     if response.status_code == 401:
         try:
@@ -121,7 +127,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[Error, SandboxList]]:
+) -> Response[Union[list[Any], Error, SandboxList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -139,7 +145,7 @@ def sync_detailed(
     sort: Union[Unset, ListSandboxesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListSandboxesAnchor] = UNSET,
-) -> Response[Union[Error, SandboxList]]:
+) -> Response[Union[list[Any], Error, SandboxList]]:
     """List sandboxes
 
      Returns sandboxes in the workspace. Each sandbox includes its configuration, status, and endpoint
@@ -162,7 +168,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, SandboxList]]
+        Response[Union[list[Any], Error, SandboxList]]
     """
 
     kwargs = _get_kwargs(
@@ -190,7 +196,7 @@ def sync(
     sort: Union[Unset, ListSandboxesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListSandboxesAnchor] = UNSET,
-) -> Union[Error, SandboxList] | None:
+) -> Union[list[Any], Error, SandboxList] | None:
     """List sandboxes
 
      Returns sandboxes in the workspace. Each sandbox includes its configuration, status, and endpoint
@@ -213,7 +219,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, SandboxList]
+        Union[list[Any], Error, SandboxList]
     """
 
     return sync_detailed(
@@ -236,7 +242,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListSandboxesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListSandboxesAnchor] = UNSET,
-) -> Response[Union[Error, SandboxList]]:
+) -> Response[Union[list[Any], Error, SandboxList]]:
     """List sandboxes
 
      Returns sandboxes in the workspace. Each sandbox includes its configuration, status, and endpoint
@@ -259,7 +265,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, SandboxList]]
+        Response[Union[list[Any], Error, SandboxList]]
     """
 
     kwargs = _get_kwargs(
@@ -285,7 +291,7 @@ async def asyncio(
     sort: Union[Unset, ListSandboxesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListSandboxesAnchor] = UNSET,
-) -> Union[Error, SandboxList] | None:
+) -> Union[list[Any], Error, SandboxList] | None:
     """List sandboxes
 
      Returns sandboxes in the workspace. Each sandbox includes its configuration, status, and endpoint
@@ -308,7 +314,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, SandboxList]
+        Union[list[Any], Error, SandboxList]
     """
 
     return (

--- a/src/blaxel/core/client/api/compute/list_sandboxes.py
+++ b/src/blaxel/core/client/api/compute/list_sandboxes.py
@@ -58,19 +58,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Error, SandboxList] | None:
     if response.status_code == 200:
-        response_200 = SandboxList.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = SandboxList.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -118,6 +158,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -168,6 +209,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -213,6 +255,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -261,6 +304,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/compute/update_sandbox.py
+++ b/src/blaxel/core/client/api/compute/update_sandbox.py
@@ -36,27 +36,87 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Sandbox] | None:
     if response.status_code == 200:
-        response_200 = Sandbox.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Sandbox.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = Error.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -93,6 +153,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -130,6 +191,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -162,6 +224,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -197,6 +260,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/compute/update_sandbox_preview.py
+++ b/src/blaxel/core/client/api/compute/update_sandbox_preview.py
@@ -36,7 +36,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Preview | None:
     if response.status_code == 200:
-        response_200 = Preview.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Preview.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -72,6 +82,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -109,6 +120,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -141,6 +153,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -176,6 +189,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/configurations/get_configuration.py
+++ b/src/blaxel/core/client/api/configurations/get_configuration.py
@@ -20,7 +20,17 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Configuration | None:
     if response.status_code == 200:
-        response_200 = Configuration.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Configuration.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -49,6 +59,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -75,6 +86,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -97,6 +109,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -121,6 +134,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/customdomains/create_custom_domain.py
+++ b/src/blaxel/core/client/api/customdomains/create_custom_domain.py
@@ -34,7 +34,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> CustomDomain | None:
     if response.status_code == 200:
-        response_200 = CustomDomain.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = CustomDomain.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -70,6 +80,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -105,6 +116,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -135,6 +147,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -168,6 +181,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/customdomains/delete_custom_domain.py
+++ b/src/blaxel/core/client/api/customdomains/delete_custom_domain.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> CustomDomain | None:
     if response.status_code == 200:
-        response_200 = CustomDomain.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = CustomDomain.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -52,6 +62,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -81,6 +92,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -105,6 +117,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -132,6 +145,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/customdomains/get_custom_domain.py
+++ b/src/blaxel/core/client/api/customdomains/get_custom_domain.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> CustomDomain | None:
     if response.status_code == 200:
-        response_200 = CustomDomain.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = CustomDomain.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -52,6 +62,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -81,6 +92,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -105,6 +117,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -132,6 +145,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/customdomains/list_custom_domains.py
+++ b/src/blaxel/core/client/api/customdomains/list_custom_domains.py
@@ -20,8 +20,18 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["CustomDomain"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = CustomDomain.from_dict(response_200_item_data)
 
@@ -54,6 +64,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -80,6 +91,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -102,6 +114,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -126,6 +139,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/customdomains/update_custom_domain.py
+++ b/src/blaxel/core/client/api/customdomains/update_custom_domain.py
@@ -35,7 +35,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> CustomDomain | None:
     if response.status_code == 200:
-        response_200 = CustomDomain.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = CustomDomain.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -70,6 +80,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -105,6 +116,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -135,6 +147,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -168,6 +181,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/customdomains/verify_custom_domain.py
+++ b/src/blaxel/core/client/api/customdomains/verify_custom_domain.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> CustomDomain | None:
     if response.status_code == 200:
-        response_200 = CustomDomain.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = CustomDomain.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -52,6 +62,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -81,6 +92,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -105,6 +117,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -132,6 +145,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/default/get_template.py
+++ b/src/blaxel/core/client/api/default/get_template.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Template | None:
     if response.status_code == 200:
-        response_200 = Template.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Template.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -55,6 +65,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -87,6 +98,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +126,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +157,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/drives/create_drive.py
+++ b/src/blaxel/core/client/api/drives/create_drive.py
@@ -34,7 +34,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, Drive] | None:
     if response.status_code == 200:
-        response_200 = Drive.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Drive.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
@@ -71,6 +81,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,6 +115,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -132,6 +144,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -163,6 +176,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/drives/create_drive_access_token.py
+++ b/src/blaxel/core/client/api/drives/create_drive_access_token.py
@@ -24,7 +24,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Any, CreateDriveAccessTokenResponse200] | None:
     if response.status_code == 200:
-        response_200 = CreateDriveAccessTokenResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = CreateDriveAccessTokenResponse200.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
@@ -68,6 +78,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -100,6 +111,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -127,6 +139,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -157,6 +170,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/drives/delete_drive.py
+++ b/src/blaxel/core/client/api/drives/delete_drive.py
@@ -24,7 +24,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Any, DeleteDriveResponse200] | None:
     if response.status_code == 200:
-        response_200 = DeleteDriveResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = DeleteDriveResponse200.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
@@ -64,6 +74,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -95,6 +106,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -121,6 +133,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -150,6 +163,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/drives/get_drive.py
+++ b/src/blaxel/core/client/api/drives/get_drive.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, Drive] | None:
     if response.status_code == 200:
-        response_200 = Drive.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Drive.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
@@ -60,6 +70,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -91,6 +102,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -117,6 +129,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -146,6 +159,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/drives/get_drive_jwks.py
+++ b/src/blaxel/core/client/api/drives/get_drive_jwks.py
@@ -20,7 +20,17 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> GetDriveJWKSResponse200 | None:
     if response.status_code == 200:
-        response_200 = GetDriveJWKSResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = GetDriveJWKSResponse200.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -51,6 +61,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -77,6 +88,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -99,6 +111,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -123,6 +136,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/drives/list_drives.py
+++ b/src/blaxel/core/client/api/drives/list_drives.py
@@ -52,7 +52,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, DriveList] | None:
     if response.status_code == 200:
-        response_200 = DriveList.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = DriveList.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
@@ -98,6 +108,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +155,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -185,6 +197,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -229,6 +242,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/drives/list_drives.py
+++ b/src/blaxel/core/client/api/drives/list_drives.py
@@ -50,7 +50,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, DriveList] | None:
+def _parse_response(
+    *, client: Client, response: httpx.Response
+) -> Union[list[Any], Any, DriveList] | None:
     if response.status_code == 200:
         try:
             _response_content = response.json()
@@ -64,6 +66,12 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, D
             return None
         response_200 = DriveList.from_dict(_response_content)
 
+        if isinstance(_response_content, list):
+            if response_200 is None:
+                return []
+            if response_200.data is UNSET or response_200.data is None:
+                return []
+            return cast(list[Any], response_200.data)
         return response_200
     if response.status_code == 401:
         response_401 = cast(Any, None)
@@ -74,7 +82,9 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, D
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, DriveList]]:
+def _build_response(
+    *, client: Client, response: httpx.Response
+) -> Response[Union[list[Any], Any, DriveList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -91,7 +101,7 @@ def sync_detailed(
     sort: Union[Unset, ListDrivesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListDrivesAnchor] = UNSET,
-) -> Response[Union[Any, DriveList]]:
+) -> Response[Union[list[Any], Any, DriveList]]:
     """List drives
 
      Returns all drives in the workspace. Drives provide persistent storage that can be attached to
@@ -112,7 +122,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, DriveList]]
+        Response[Union[list[Any], Any, DriveList]]
     """
 
     kwargs = _get_kwargs(
@@ -138,7 +148,7 @@ def sync(
     sort: Union[Unset, ListDrivesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListDrivesAnchor] = UNSET,
-) -> Union[Any, DriveList] | None:
+) -> Union[list[Any], Any, DriveList] | None:
     """List drives
 
      Returns all drives in the workspace. Drives provide persistent storage that can be attached to
@@ -159,7 +169,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, DriveList]
+        Union[list[Any], Any, DriveList]
     """
 
     return sync_detailed(
@@ -180,7 +190,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListDrivesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListDrivesAnchor] = UNSET,
-) -> Response[Union[Any, DriveList]]:
+) -> Response[Union[list[Any], Any, DriveList]]:
     """List drives
 
      Returns all drives in the workspace. Drives provide persistent storage that can be attached to
@@ -201,7 +211,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, DriveList]]
+        Response[Union[list[Any], Any, DriveList]]
     """
 
     kwargs = _get_kwargs(
@@ -225,7 +235,7 @@ async def asyncio(
     sort: Union[Unset, ListDrivesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListDrivesAnchor] = UNSET,
-) -> Union[Any, DriveList] | None:
+) -> Union[list[Any], Any, DriveList] | None:
     """List drives
 
      Returns all drives in the workspace. Drives provide persistent storage that can be attached to
@@ -246,7 +256,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, DriveList]
+        Union[list[Any], Any, DriveList]
     """
 
     return (

--- a/src/blaxel/core/client/api/drives/list_drives.py
+++ b/src/blaxel/core/client/api/drives/list_drives.py
@@ -5,29 +5,54 @@ import httpx
 
 from ... import errors
 from ...client import Client
-from ...models.drive import Drive
-from ...types import Response
+from ...models.drive_list import DriveList
+from ...models.list_drives_anchor import ListDrivesAnchor
+from ...models.list_drives_sort import ListDrivesSort
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListDrivesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListDrivesAnchor] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    json_sort: Union[Unset, str] = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort.value
+
+    params["sort"] = json_sort
+
+    params["q"] = q
+
+    json_anchor: Union[Unset, str] = UNSET
+    if not isinstance(anchor, Unset):
+        json_anchor = anchor.value
+
+    params["anchor"] = json_anchor
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/drives",
+        "params": params,
     }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Client, response: httpx.Response
-) -> Union[Any, list["Drive"]] | None:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, DriveList] | None:
     if response.status_code == 200:
-        response_200 = []
-        _response_200 = response.json()
-        for response_200_item_data in _response_200:
-            response_200_item = Drive.from_dict(response_200_item_data)
-
-            response_200.append(response_200_item)
+        response_200 = DriveList.from_dict(response.json())
 
         return response_200
     if response.status_code == 401:
@@ -39,9 +64,7 @@ def _parse_response(
         return None
 
 
-def _build_response(
-    *, client: Client, response: httpx.Response
-) -> Response[Union[Any, list["Drive"]]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, DriveList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -53,21 +76,41 @@ def _build_response(
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[Any, list["Drive"]]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListDrivesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListDrivesAnchor] = UNSET,
+) -> Response[Union[Any, DriveList]]:
     """List drives
 
      Returns all drives in the workspace. Drives provide persistent storage that can be attached to
-    agents, functions, and sandboxes.
+    agents, functions, and sandboxes. Starting with API version 2026-04-28, the response wraps items in
+    `{data, meta}` and supports cursor pagination via the `cursor` and `limit` query parameters; older
+    versions keep returning a bare array with all drives.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListDrivesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListDrivesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, list['Drive']]]
+        Response[Union[Any, DriveList]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -79,43 +122,82 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Union[Any, list["Drive"]] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListDrivesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListDrivesAnchor] = UNSET,
+) -> Union[Any, DriveList] | None:
     """List drives
 
      Returns all drives in the workspace. Drives provide persistent storage that can be attached to
-    agents, functions, and sandboxes.
+    agents, functions, and sandboxes. Starting with API version 2026-04-28, the response wraps items in
+    `{data, meta}` and supports cursor pagination via the `cursor` and `limit` query parameters; older
+    versions keep returning a bare array with all drives.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListDrivesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListDrivesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, list['Drive']]
+        Union[Any, DriveList]
     """
 
     return sync_detailed(
         client=client,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[Any, list["Drive"]]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListDrivesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListDrivesAnchor] = UNSET,
+) -> Response[Union[Any, DriveList]]:
     """List drives
 
      Returns all drives in the workspace. Drives provide persistent storage that can be attached to
-    agents, functions, and sandboxes.
+    agents, functions, and sandboxes. Starting with API version 2026-04-28, the response wraps items in
+    `{data, meta}` and supports cursor pagination via the `cursor` and `limit` query parameters; older
+    versions keep returning a bare array with all drives.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListDrivesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListDrivesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, list['Drive']]]
+        Response[Union[Any, DriveList]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -125,22 +207,41 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Union[Any, list["Drive"]] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListDrivesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListDrivesAnchor] = UNSET,
+) -> Union[Any, DriveList] | None:
     """List drives
 
      Returns all drives in the workspace. Drives provide persistent storage that can be attached to
-    agents, functions, and sandboxes.
+    agents, functions, and sandboxes. Starting with API version 2026-04-28, the response wraps items in
+    `{data, meta}` and supports cursor pagination via the `cursor` and `limit` query parameters; older
+    versions keep returning a bare array with all drives.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListDrivesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListDrivesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, list['Drive']]
+        Union[Any, DriveList]
     """
 
     return (
         await asyncio_detailed(
             client=client,
+            cursor=cursor,
+            limit=limit,
+            sort=sort,
+            q=q,
+            anchor=anchor,
         )
     ).parsed

--- a/src/blaxel/core/client/api/drives/update_drive.py
+++ b/src/blaxel/core/client/api/drives/update_drive.py
@@ -35,7 +35,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, Drive] | None:
     if response.status_code == 200:
-        response_200 = Drive.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Drive.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
@@ -77,6 +87,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -113,6 +124,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +156,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -178,6 +191,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/feature_flags/test_feature_flag.py
+++ b/src/blaxel/core/client/api/feature_flags/test_feature_flag.py
@@ -34,19 +34,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Error, TestFeatureFlagResponse200] | None:
     if response.status_code == 200:
-        response_200 = TestFeatureFlagResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = TestFeatureFlagResponse200.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if client.raise_on_unexpected_status:
@@ -83,6 +123,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -118,6 +159,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -148,6 +190,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -181,6 +224,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/functions/create_function.py
+++ b/src/blaxel/core/client/api/functions/create_function.py
@@ -35,27 +35,87 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Function] | None:
     if response.status_code == 200:
-        response_200 = Function.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Function.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = Error.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 409:
-        response_409 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_409 = Error.from_dict(_response_content)
 
         return response_409
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -92,6 +152,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -126,6 +187,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -155,6 +217,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -187,6 +250,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/functions/delete_function.py
+++ b/src/blaxel/core/client/api/functions/delete_function.py
@@ -23,23 +23,73 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Function] | None:
     if response.status_code == 200:
-        response_200 = Function.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Function.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -74,6 +124,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -106,6 +157,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -133,6 +185,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -163,6 +216,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/functions/get_function.py
+++ b/src/blaxel/core/client/api/functions/get_function.py
@@ -32,23 +32,73 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Function] | None:
     if response.status_code == 200:
-        response_200 = Function.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Function.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -85,6 +135,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -120,6 +171,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -150,6 +202,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -183,6 +236,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/functions/list_function_revisions.py
+++ b/src/blaxel/core/client/api/functions/list_function_revisions.py
@@ -22,8 +22,18 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["RevisionMetadata"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = RevisionMetadata.from_dict(response_200_item_data)
 
@@ -61,6 +71,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -92,6 +103,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -118,6 +130,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -147,6 +160,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/functions/list_functions.py
+++ b/src/blaxel/core/client/api/functions/list_functions.py
@@ -6,14 +6,46 @@ import httpx
 from ... import errors
 from ...client import Client
 from ...models.error import Error
-from ...models.function import Function
-from ...types import Response
+from ...models.function_list import FunctionList
+from ...models.list_functions_anchor import ListFunctionsAnchor
+from ...models.list_functions_sort import ListFunctionsSort
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListFunctionsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    json_sort: Union[Unset, str] = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort.value
+
+    params["sort"] = json_sort
+
+    params["q"] = q
+
+    json_anchor: Union[Unset, str] = UNSET
+    if not isinstance(anchor, Unset):
+        json_anchor = anchor.value
+
+    params["anchor"] = json_anchor
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/functions",
+        "params": params,
     }
 
     return _kwargs
@@ -21,14 +53,9 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Client, response: httpx.Response
-) -> Union[Error, list["Function"]] | None:
+) -> Union[Error, FunctionList] | None:
     if response.status_code == 200:
-        response_200 = []
-        _response_200 = response.json()
-        for response_200_item_data in _response_200:
-            response_200_item = Function.from_dict(response_200_item_data)
-
-            response_200.append(response_200_item)
+        response_200 = FunctionList.from_dict(response.json())
 
         return response_200
     if response.status_code == 401:
@@ -51,7 +78,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[Error, list["Function"]]]:
+) -> Response[Union[Error, FunctionList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,21 +90,41 @@ def _build_response(
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[Error, list["Function"]]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListFunctionsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
+) -> Response[Union[Error, FunctionList]]:
     """List all MCP servers
 
-     Returns all MCP server functions deployed in the workspace. Each function includes its deployment
-    status, transport protocol (websocket or http-stream), and endpoint URL.
+     Returns MCP server functions deployed in the workspace. Each function includes its deployment
+    status, transport protocol (websocket or http-stream), and endpoint URL. Starting with API version
+    2026-04-28 the response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor`
+    and `limit` query parameters; older versions keep returning a bare array with all functions.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListFunctionsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListFunctionsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, list['Function']]]
+        Response[Union[Error, FunctionList]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -89,43 +136,82 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Union[Error, list["Function"]] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListFunctionsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
+) -> Union[Error, FunctionList] | None:
     """List all MCP servers
 
-     Returns all MCP server functions deployed in the workspace. Each function includes its deployment
-    status, transport protocol (websocket or http-stream), and endpoint URL.
+     Returns MCP server functions deployed in the workspace. Each function includes its deployment
+    status, transport protocol (websocket or http-stream), and endpoint URL. Starting with API version
+    2026-04-28 the response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor`
+    and `limit` query parameters; older versions keep returning a bare array with all functions.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListFunctionsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListFunctionsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, list['Function']]
+        Union[Error, FunctionList]
     """
 
     return sync_detailed(
         client=client,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[Error, list["Function"]]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListFunctionsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
+) -> Response[Union[Error, FunctionList]]:
     """List all MCP servers
 
-     Returns all MCP server functions deployed in the workspace. Each function includes its deployment
-    status, transport protocol (websocket or http-stream), and endpoint URL.
+     Returns MCP server functions deployed in the workspace. Each function includes its deployment
+    status, transport protocol (websocket or http-stream), and endpoint URL. Starting with API version
+    2026-04-28 the response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor`
+    and `limit` query parameters; older versions keep returning a bare array with all functions.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListFunctionsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListFunctionsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, list['Function']]]
+        Response[Union[Error, FunctionList]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -135,22 +221,41 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Union[Error, list["Function"]] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListFunctionsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
+) -> Union[Error, FunctionList] | None:
     """List all MCP servers
 
-     Returns all MCP server functions deployed in the workspace. Each function includes its deployment
-    status, transport protocol (websocket or http-stream), and endpoint URL.
+     Returns MCP server functions deployed in the workspace. Each function includes its deployment
+    status, transport protocol (websocket or http-stream), and endpoint URL. Starting with API version
+    2026-04-28 the response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor`
+    and `limit` query parameters; older versions keep returning a bare array with all functions.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListFunctionsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListFunctionsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, list['Function']]
+        Union[Error, FunctionList]
     """
 
     return (
         await asyncio_detailed(
             client=client,
+            cursor=cursor,
+            limit=limit,
+            sort=sort,
+            q=q,
+            anchor=anchor,
         )
     ).parsed

--- a/src/blaxel/core/client/api/functions/list_functions.py
+++ b/src/blaxel/core/client/api/functions/list_functions.py
@@ -55,19 +55,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Error, FunctionList] | None:
     if response.status_code == 200:
-        response_200 = FunctionList.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = FunctionList.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -112,6 +152,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -158,6 +199,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -199,6 +241,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -243,6 +286,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/functions/list_functions.py
+++ b/src/blaxel/core/client/api/functions/list_functions.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Union
+from typing import Any, Union, cast
 
 import httpx
 
@@ -53,7 +53,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Client, response: httpx.Response
-) -> Union[Error, FunctionList] | None:
+) -> Union[list[Any], Error, FunctionList] | None:
     if response.status_code == 200:
         try:
             _response_content = response.json()
@@ -67,6 +67,12 @@ def _parse_response(
             return None
         response_200 = FunctionList.from_dict(_response_content)
 
+        if isinstance(_response_content, list):
+            if response_200 is None:
+                return []
+            if response_200.data is UNSET or response_200.data is None:
+                return []
+            return cast(list[Any], response_200.data)
         return response_200
     if response.status_code == 401:
         try:
@@ -118,7 +124,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[Error, FunctionList]]:
+) -> Response[Union[list[Any], Error, FunctionList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -135,7 +141,7 @@ def sync_detailed(
     sort: Union[Unset, ListFunctionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
-) -> Response[Union[Error, FunctionList]]:
+) -> Response[Union[list[Any], Error, FunctionList]]:
     """List all MCP servers
 
      Returns MCP server functions deployed in the workspace. Each function includes its deployment
@@ -156,7 +162,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, FunctionList]]
+        Response[Union[list[Any], Error, FunctionList]]
     """
 
     kwargs = _get_kwargs(
@@ -182,7 +188,7 @@ def sync(
     sort: Union[Unset, ListFunctionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
-) -> Union[Error, FunctionList] | None:
+) -> Union[list[Any], Error, FunctionList] | None:
     """List all MCP servers
 
      Returns MCP server functions deployed in the workspace. Each function includes its deployment
@@ -203,7 +209,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, FunctionList]
+        Union[list[Any], Error, FunctionList]
     """
 
     return sync_detailed(
@@ -224,7 +230,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListFunctionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
-) -> Response[Union[Error, FunctionList]]:
+) -> Response[Union[list[Any], Error, FunctionList]]:
     """List all MCP servers
 
      Returns MCP server functions deployed in the workspace. Each function includes its deployment
@@ -245,7 +251,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, FunctionList]]
+        Response[Union[list[Any], Error, FunctionList]]
     """
 
     kwargs = _get_kwargs(
@@ -269,7 +275,7 @@ async def asyncio(
     sort: Union[Unset, ListFunctionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
-) -> Union[Error, FunctionList] | None:
+) -> Union[list[Any], Error, FunctionList] | None:
     """List all MCP servers
 
      Returns MCP server functions deployed in the workspace. Each function includes its deployment
@@ -290,7 +296,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, FunctionList]
+        Union[list[Any], Error, FunctionList]
     """
 
     return (

--- a/src/blaxel/core/client/api/functions/update_function.py
+++ b/src/blaxel/core/client/api/functions/update_function.py
@@ -36,27 +36,87 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Function] | None:
     if response.status_code == 200:
-        response_200 = Function.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Function.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = Error.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -95,6 +155,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -132,6 +193,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -164,6 +226,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -199,6 +262,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/images/accept_image_share.py
+++ b/src/blaxel/core/client/api/images/accept_image_share.py
@@ -31,7 +31,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, Image] | None:
     if response.status_code == 200:
-        response_200 = Image.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Image.from_dict(_response_content)
 
         return response_200
     if response.status_code == 403:
@@ -78,6 +88,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -113,6 +124,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -143,6 +155,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -176,6 +189,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/images/cleanup_images.py
+++ b/src/blaxel/core/client/api/images/cleanup_images.py
@@ -20,7 +20,17 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> CleanupImagesResponse200 | None:
     if response.status_code == 200:
-        response_200 = CleanupImagesResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = CleanupImagesResponse200.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -51,6 +61,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -77,6 +88,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -99,6 +111,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -123,6 +136,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/images/create_image.py
+++ b/src/blaxel/core/client/api/images/create_image.py
@@ -37,7 +37,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Any, CreateImageResponse200] | None:
     if response.status_code == 200:
-        response_200 = CreateImageResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = CreateImageResponse200.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
@@ -76,6 +86,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -109,6 +120,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -137,6 +149,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -168,6 +181,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/images/delete_image.py
+++ b/src/blaxel/core/client/api/images/delete_image.py
@@ -23,7 +23,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, Image] | None:
     if response.status_code == 200:
-        response_200 = Image.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Image.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
@@ -64,6 +74,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -99,6 +110,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -129,6 +141,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -162,6 +175,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/images/delete_image_tag.py
+++ b/src/blaxel/core/client/api/images/delete_image_tag.py
@@ -24,7 +24,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, Image] | None:
     if response.status_code == 200:
-        response_200 = Image.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Image.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
@@ -67,6 +77,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -105,6 +116,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -138,6 +150,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -174,6 +187,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/images/get_image.py
+++ b/src/blaxel/core/client/api/images/get_image.py
@@ -23,7 +23,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Image | None:
     if response.status_code == 200:
-        response_200 = Image.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Image.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -58,6 +68,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -93,6 +104,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -123,6 +135,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -156,6 +169,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/images/list_image_shares.py
+++ b/src/blaxel/core/client/api/images/list_image_shares.py
@@ -25,8 +25,18 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Any, list["ImageShareTarget"]] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = ImageShareTarget.from_dict(response_200_item_data)
 
@@ -69,6 +79,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -103,6 +114,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -132,6 +144,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -164,6 +177,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/images/list_images.py
+++ b/src/blaxel/core/client/api/images/list_images.py
@@ -20,8 +20,18 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["Image"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = Image.from_dict(response_200_item_data)
 
@@ -54,6 +64,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -80,6 +91,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -102,6 +114,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -126,6 +139,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/images/list_pending_image_shares.py
+++ b/src/blaxel/core/client/api/images/list_pending_image_shares.py
@@ -37,8 +37,18 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> list["PendingImageShareRender"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = PendingImageShareRender.from_dict(response_200_item_data)
 
@@ -77,6 +87,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -109,6 +120,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -136,6 +148,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -166,6 +179,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/images/share_image.py
+++ b/src/blaxel/core/client/api/images/share_image.py
@@ -40,11 +40,31 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Any, Image, PendingImageShare] | None:
     if response.status_code == 200:
-        response_200 = Image.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Image.from_dict(_response_content)
 
         return response_200
     if response.status_code == 202:
-        response_202 = PendingImageShare.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_202 = PendingImageShare.from_dict(_response_content)
 
         return response_202
     if response.status_code == 400:
@@ -94,6 +114,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -134,6 +155,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -169,6 +191,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -207,6 +230,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/images/unshare_image.py
+++ b/src/blaxel/core/client/api/images/unshare_image.py
@@ -24,7 +24,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, Image] | None:
     if response.status_code == 200:
-        response_200 = Image.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Image.from_dict(_response_content)
 
         return response_200
     if response.status_code == 404:
@@ -64,6 +74,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -102,6 +113,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -135,6 +147,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -171,6 +184,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/integrations/create_integration_connection.py
+++ b/src/blaxel/core/client/api/integrations/create_integration_connection.py
@@ -37,27 +37,87 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Error, IntegrationConnection] | None:
     if response.status_code == 200:
-        response_200 = IntegrationConnection.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = IntegrationConnection.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = Error.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 409:
-        response_409 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_409 = Error.from_dict(_response_content)
 
         return response_409
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -93,6 +153,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -126,6 +187,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -154,6 +216,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -185,6 +248,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/integrations/delete_integration_connection.py
+++ b/src/blaxel/core/client/api/integrations/delete_integration_connection.py
@@ -25,27 +25,87 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Error, IntegrationConnection] | None:
     if response.status_code == 200:
-        response_200 = IntegrationConnection.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = IntegrationConnection.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 409:
-        response_409 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_409 = Error.from_dict(_response_content)
 
         return response_409
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -80,6 +140,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -112,6 +173,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -139,6 +201,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -169,6 +232,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/integrations/get_integration.py
+++ b/src/blaxel/core/client/api/integrations/get_integration.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Integration | None:
     if response.status_code == 200:
-        response_200 = Integration.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Integration.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -55,6 +65,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -87,6 +98,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +126,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +157,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/integrations/get_integration_connection.py
+++ b/src/blaxel/core/client/api/integrations/get_integration_connection.py
@@ -25,23 +25,73 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Error, IntegrationConnection] | None:
     if response.status_code == 200:
-        response_200 = IntegrationConnection.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = IntegrationConnection.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -76,6 +126,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -108,6 +159,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -135,6 +187,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -165,6 +218,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/integrations/list_integration_connections.py
+++ b/src/blaxel/core/client/api/integrations/list_integration_connections.py
@@ -23,8 +23,18 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Error, list["IntegrationConnection"]] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = IntegrationConnection.from_dict(response_200_item_data)
 
@@ -32,15 +42,45 @@ def _parse_response(
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -71,6 +111,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -97,6 +138,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -119,6 +161,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -143,6 +186,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/integrations/update_integration_connection.py
+++ b/src/blaxel/core/client/api/integrations/update_integration_connection.py
@@ -38,27 +38,87 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Error, IntegrationConnection] | None:
     if response.status_code == 200:
-        response_200 = IntegrationConnection.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = IntegrationConnection.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = Error.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -96,6 +156,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -132,6 +193,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -163,6 +225,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -197,6 +260,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/jobs/create_job.py
+++ b/src/blaxel/core/client/api/jobs/create_job.py
@@ -34,7 +34,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Job | None:
     if response.status_code == 200:
-        response_200 = Job.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Job.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -68,6 +78,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -101,6 +112,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -129,6 +141,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -160,6 +173,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/jobs/create_job_execution.py
+++ b/src/blaxel/core/client/api/jobs/create_job_execution.py
@@ -38,7 +38,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Any, CreateJobExecutionOutput] | None:
     if response.status_code == 200:
-        response_200 = CreateJobExecutionOutput.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = CreateJobExecutionOutput.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
@@ -81,6 +91,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -116,6 +127,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -146,6 +158,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -179,6 +192,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/jobs/delete_job.py
+++ b/src/blaxel/core/client/api/jobs/delete_job.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Job | None:
     if response.status_code == 200:
-        response_200 = Job.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Job.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -55,6 +65,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -87,6 +98,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +126,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +157,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/jobs/delete_job_execution.py
+++ b/src/blaxel/core/client/api/jobs/delete_job_execution.py
@@ -23,7 +23,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, JobExecution] | None:
     if response.status_code == 200:
-        response_200 = JobExecution.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = JobExecution.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
@@ -69,6 +79,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,6 +115,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -134,6 +146,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -167,6 +180,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/jobs/get_job.py
+++ b/src/blaxel/core/client/api/jobs/get_job.py
@@ -31,7 +31,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Job | None:
     if response.status_code == 200:
-        response_200 = Job.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Job.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -66,6 +76,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -101,6 +112,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -131,6 +143,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -164,6 +177,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/jobs/get_job_execution.py
+++ b/src/blaxel/core/client/api/jobs/get_job_execution.py
@@ -23,7 +23,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, JobExecution] | None:
     if response.status_code == 200:
-        response_200 = JobExecution.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = JobExecution.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
@@ -69,6 +79,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,6 +115,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -134,6 +146,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -167,6 +180,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/jobs/list_job_execution_tasks.py
+++ b/src/blaxel/core/client/api/jobs/list_job_execution_tasks.py
@@ -48,7 +48,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Any, JobExecutionTaskList] | None:
     if response.status_code == 200:
-        response_200 = JobExecutionTaskList.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = JobExecutionTaskList.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
@@ -103,6 +113,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -151,6 +162,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -194,6 +206,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -240,6 +253,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/jobs/list_job_execution_tasks.py
+++ b/src/blaxel/core/client/api/jobs/list_job_execution_tasks.py
@@ -46,7 +46,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Client, response: httpx.Response
-) -> Union[Any, JobExecutionTaskList] | None:
+) -> Union[list[Any], Any, JobExecutionTaskList] | None:
     if response.status_code == 200:
         try:
             _response_content = response.json()
@@ -60,6 +60,12 @@ def _parse_response(
             return None
         response_200 = JobExecutionTaskList.from_dict(_response_content)
 
+        if isinstance(_response_content, list):
+            if response_200 is None:
+                return []
+            if response_200.data is UNSET or response_200.data is None:
+                return []
+            return cast(list[Any], response_200.data)
         return response_200
     if response.status_code == 400:
         response_400 = cast(Any, None)
@@ -78,7 +84,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[Any, JobExecutionTaskList]]:
+) -> Response[Union[list[Any], Any, JobExecutionTaskList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -96,7 +102,7 @@ def sync_detailed(
     limit: Union[Unset, int] = 50,
     sort: Union[Unset, ListJobExecutionTasksSort] = UNSET,
     q: Union[Unset, str] = UNSET,
-) -> Response[Union[Any, JobExecutionTaskList]]:
+) -> Response[Union[list[Any], Any, JobExecutionTaskList]]:
     """List execution tasks
 
      Returns one cursor-paginated page of an execution's tasks. Tasks are derived from event history each
@@ -117,7 +123,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, JobExecutionTaskList]]
+        Response[Union[list[Any], Any, JobExecutionTaskList]]
     """
 
     kwargs = _get_kwargs(
@@ -145,7 +151,7 @@ def sync(
     limit: Union[Unset, int] = 50,
     sort: Union[Unset, ListJobExecutionTasksSort] = UNSET,
     q: Union[Unset, str] = UNSET,
-) -> Union[Any, JobExecutionTaskList] | None:
+) -> Union[list[Any], Any, JobExecutionTaskList] | None:
     """List execution tasks
 
      Returns one cursor-paginated page of an execution's tasks. Tasks are derived from event history each
@@ -166,7 +172,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, JobExecutionTaskList]
+        Union[list[Any], Any, JobExecutionTaskList]
     """
 
     return sync_detailed(
@@ -189,7 +195,7 @@ async def asyncio_detailed(
     limit: Union[Unset, int] = 50,
     sort: Union[Unset, ListJobExecutionTasksSort] = UNSET,
     q: Union[Unset, str] = UNSET,
-) -> Response[Union[Any, JobExecutionTaskList]]:
+) -> Response[Union[list[Any], Any, JobExecutionTaskList]]:
     """List execution tasks
 
      Returns one cursor-paginated page of an execution's tasks. Tasks are derived from event history each
@@ -210,7 +216,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, JobExecutionTaskList]]
+        Response[Union[list[Any], Any, JobExecutionTaskList]]
     """
 
     kwargs = _get_kwargs(
@@ -236,7 +242,7 @@ async def asyncio(
     limit: Union[Unset, int] = 50,
     sort: Union[Unset, ListJobExecutionTasksSort] = UNSET,
     q: Union[Unset, str] = UNSET,
-) -> Union[Any, JobExecutionTaskList] | None:
+) -> Union[list[Any], Any, JobExecutionTaskList] | None:
     """List execution tasks
 
      Returns one cursor-paginated page of an execution's tasks. Tasks are derived from event history each
@@ -257,7 +263,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, JobExecutionTaskList]
+        Union[list[Any], Any, JobExecutionTaskList]
     """
 
     return (

--- a/src/blaxel/core/client/api/jobs/list_job_execution_tasks.py
+++ b/src/blaxel/core/client/api/jobs/list_job_execution_tasks.py
@@ -1,0 +1,259 @@
+from http import HTTPStatus
+from typing import Any, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.job_execution_task_list import JobExecutionTaskList
+from ...models.list_job_execution_tasks_sort import ListJobExecutionTasksSort
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    job_id: str,
+    execution_id: str,
+    *,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListJobExecutionTasksSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    json_sort: Union[Unset, str] = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort.value
+
+    params["sort"] = json_sort
+
+    params["q"] = q
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": f"/jobs/{job_id}/executions/{execution_id}/tasks",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Client, response: httpx.Response
+) -> Union[Any, JobExecutionTaskList] | None:
+    if response.status_code == 200:
+        response_200 = JobExecutionTaskList.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 500:
+        response_500 = cast(Any, None)
+        return response_500
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Client, response: httpx.Response
+) -> Response[Union[Any, JobExecutionTaskList]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    job_id: str,
+    execution_id: str,
+    *,
+    client: Client,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListJobExecutionTasksSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+) -> Response[Union[Any, JobExecutionTaskList]]:
+    """List execution tasks
+
+     Returns one cursor-paginated page of an execution's tasks. Tasks are derived from event history each
+    request; only the in-memory slicing is paginated, the events scan still fetches the whole event log
+    behind the scenes. Available starting with API version 2026-04-28.
+
+    Args:
+        job_id (str):
+        execution_id (str):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListJobExecutionTasksSort]):
+        q (Union[Unset, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, JobExecutionTaskList]]
+    """
+
+    kwargs = _get_kwargs(
+        job_id=job_id,
+        execution_id=execution_id,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    job_id: str,
+    execution_id: str,
+    *,
+    client: Client,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListJobExecutionTasksSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+) -> Union[Any, JobExecutionTaskList] | None:
+    """List execution tasks
+
+     Returns one cursor-paginated page of an execution's tasks. Tasks are derived from event history each
+    request; only the in-memory slicing is paginated, the events scan still fetches the whole event log
+    behind the scenes. Available starting with API version 2026-04-28.
+
+    Args:
+        job_id (str):
+        execution_id (str):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListJobExecutionTasksSort]):
+        q (Union[Unset, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, JobExecutionTaskList]
+    """
+
+    return sync_detailed(
+        job_id=job_id,
+        execution_id=execution_id,
+        client=client,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+    ).parsed
+
+
+async def asyncio_detailed(
+    job_id: str,
+    execution_id: str,
+    *,
+    client: Client,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListJobExecutionTasksSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+) -> Response[Union[Any, JobExecutionTaskList]]:
+    """List execution tasks
+
+     Returns one cursor-paginated page of an execution's tasks. Tasks are derived from event history each
+    request; only the in-memory slicing is paginated, the events scan still fetches the whole event log
+    behind the scenes. Available starting with API version 2026-04-28.
+
+    Args:
+        job_id (str):
+        execution_id (str):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListJobExecutionTasksSort]):
+        q (Union[Unset, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, JobExecutionTaskList]]
+    """
+
+    kwargs = _get_kwargs(
+        job_id=job_id,
+        execution_id=execution_id,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    job_id: str,
+    execution_id: str,
+    *,
+    client: Client,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListJobExecutionTasksSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+) -> Union[Any, JobExecutionTaskList] | None:
+    """List execution tasks
+
+     Returns one cursor-paginated page of an execution's tasks. Tasks are derived from event history each
+    request; only the in-memory slicing is paginated, the events scan still fetches the whole event log
+    behind the scenes. Available starting with API version 2026-04-28.
+
+    Args:
+        job_id (str):
+        execution_id (str):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListJobExecutionTasksSort]):
+        q (Union[Unset, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, JobExecutionTaskList]
+    """
+
+    return (
+        await asyncio_detailed(
+            job_id=job_id,
+            execution_id=execution_id,
+            client=client,
+            cursor=cursor,
+            limit=limit,
+            sort=sort,
+            q=q,
+        )
+    ).parsed

--- a/src/blaxel/core/client/api/jobs/list_job_executions.py
+++ b/src/blaxel/core/client/api/jobs/list_job_executions.py
@@ -5,7 +5,8 @@ import httpx
 
 from ... import errors
 from ...client import Client
-from ...models.job_execution import JobExecution
+from ...models.job_execution_list import JobExecutionList
+from ...models.list_job_executions_sort import ListJobExecutionsSort
 from ...types import UNSET, Response, Unset
 
 
@@ -14,12 +15,25 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = 20,
     offset: Union[Unset, int] = 0,
+    cursor: Union[Unset, str] = UNSET,
+    sort: Union[Unset, ListJobExecutionsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
     params["limit"] = limit
 
     params["offset"] = offset
+
+    params["cursor"] = cursor
+
+    json_sort: Union[Unset, str] = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort.value
+
+    params["sort"] = json_sort
+
+    params["q"] = q
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -34,14 +48,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Client, response: httpx.Response
-) -> Union[Any, list["JobExecution"]] | None:
+) -> Union[Any, JobExecutionList] | None:
     if response.status_code == 200:
-        response_200 = []
-        _response_200 = response.json()
-        for response_200_item_data in _response_200:
-            response_200_item = JobExecution.from_dict(response_200_item_data)
-
-            response_200.append(response_200_item)
+        response_200 = JobExecutionList.from_dict(response.json())
 
         return response_200
     if response.status_code == 400:
@@ -58,7 +67,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[Any, list["JobExecution"]]]:
+) -> Response[Union[Any, JobExecutionList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -73,29 +82,39 @@ def sync_detailed(
     client: Client,
     limit: Union[Unset, int] = 20,
     offset: Union[Unset, int] = 0,
-) -> Response[Union[Any, list["JobExecution"]]]:
+    cursor: Union[Unset, str] = UNSET,
+    sort: Union[Unset, ListJobExecutionsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+) -> Response[Union[Any, JobExecutionList]]:
     """List job executions
 
-     Returns paginated list of executions for a batch job, sorted by creation time. Each execution
-    contains status, task counts, and timing information.
+     Returns executions for a batch job. Starting with API version 2026-04-28 the response is wrapped in
+    `{data, meta}` and supports cursor pagination via the `cursor` and `limit` query parameters; older
+    versions keep the legacy offset/limit contract and return a bare array.
 
     Args:
         job_id (str):
         limit (Union[Unset, int]):  Default: 20.
         offset (Union[Unset, int]):  Default: 0.
+        cursor (Union[Unset, str]):
+        sort (Union[Unset, ListJobExecutionsSort]):
+        q (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, list['JobExecution']]]
+        Response[Union[Any, JobExecutionList]]
     """
 
     kwargs = _get_kwargs(
         job_id=job_id,
         limit=limit,
         offset=offset,
+        cursor=cursor,
+        sort=sort,
+        q=q,
     )
 
     response = client.get_httpx_client().request(
@@ -111,23 +130,30 @@ def sync(
     client: Client,
     limit: Union[Unset, int] = 20,
     offset: Union[Unset, int] = 0,
-) -> Union[Any, list["JobExecution"]] | None:
+    cursor: Union[Unset, str] = UNSET,
+    sort: Union[Unset, ListJobExecutionsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+) -> Union[Any, JobExecutionList] | None:
     """List job executions
 
-     Returns paginated list of executions for a batch job, sorted by creation time. Each execution
-    contains status, task counts, and timing information.
+     Returns executions for a batch job. Starting with API version 2026-04-28 the response is wrapped in
+    `{data, meta}` and supports cursor pagination via the `cursor` and `limit` query parameters; older
+    versions keep the legacy offset/limit contract and return a bare array.
 
     Args:
         job_id (str):
         limit (Union[Unset, int]):  Default: 20.
         offset (Union[Unset, int]):  Default: 0.
+        cursor (Union[Unset, str]):
+        sort (Union[Unset, ListJobExecutionsSort]):
+        q (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, list['JobExecution']]
+        Union[Any, JobExecutionList]
     """
 
     return sync_detailed(
@@ -135,6 +161,9 @@ def sync(
         client=client,
         limit=limit,
         offset=offset,
+        cursor=cursor,
+        sort=sort,
+        q=q,
     ).parsed
 
 
@@ -144,29 +173,39 @@ async def asyncio_detailed(
     client: Client,
     limit: Union[Unset, int] = 20,
     offset: Union[Unset, int] = 0,
-) -> Response[Union[Any, list["JobExecution"]]]:
+    cursor: Union[Unset, str] = UNSET,
+    sort: Union[Unset, ListJobExecutionsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+) -> Response[Union[Any, JobExecutionList]]:
     """List job executions
 
-     Returns paginated list of executions for a batch job, sorted by creation time. Each execution
-    contains status, task counts, and timing information.
+     Returns executions for a batch job. Starting with API version 2026-04-28 the response is wrapped in
+    `{data, meta}` and supports cursor pagination via the `cursor` and `limit` query parameters; older
+    versions keep the legacy offset/limit contract and return a bare array.
 
     Args:
         job_id (str):
         limit (Union[Unset, int]):  Default: 20.
         offset (Union[Unset, int]):  Default: 0.
+        cursor (Union[Unset, str]):
+        sort (Union[Unset, ListJobExecutionsSort]):
+        q (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, list['JobExecution']]]
+        Response[Union[Any, JobExecutionList]]
     """
 
     kwargs = _get_kwargs(
         job_id=job_id,
         limit=limit,
         offset=offset,
+        cursor=cursor,
+        sort=sort,
+        q=q,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -180,23 +219,30 @@ async def asyncio(
     client: Client,
     limit: Union[Unset, int] = 20,
     offset: Union[Unset, int] = 0,
-) -> Union[Any, list["JobExecution"]] | None:
+    cursor: Union[Unset, str] = UNSET,
+    sort: Union[Unset, ListJobExecutionsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+) -> Union[Any, JobExecutionList] | None:
     """List job executions
 
-     Returns paginated list of executions for a batch job, sorted by creation time. Each execution
-    contains status, task counts, and timing information.
+     Returns executions for a batch job. Starting with API version 2026-04-28 the response is wrapped in
+    `{data, meta}` and supports cursor pagination via the `cursor` and `limit` query parameters; older
+    versions keep the legacy offset/limit contract and return a bare array.
 
     Args:
         job_id (str):
         limit (Union[Unset, int]):  Default: 20.
         offset (Union[Unset, int]):  Default: 0.
+        cursor (Union[Unset, str]):
+        sort (Union[Unset, ListJobExecutionsSort]):
+        q (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, list['JobExecution']]
+        Union[Any, JobExecutionList]
     """
 
     return (
@@ -205,5 +251,8 @@ async def asyncio(
             client=client,
             limit=limit,
             offset=offset,
+            cursor=cursor,
+            sort=sort,
+            q=q,
         )
     ).parsed

--- a/src/blaxel/core/client/api/jobs/list_job_executions.py
+++ b/src/blaxel/core/client/api/jobs/list_job_executions.py
@@ -50,7 +50,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Any, JobExecutionList] | None:
     if response.status_code == 200:
-        response_200 = JobExecutionList.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = JobExecutionList.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
@@ -102,6 +112,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -150,6 +161,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -193,6 +205,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -239,6 +252,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/jobs/list_job_executions.py
+++ b/src/blaxel/core/client/api/jobs/list_job_executions.py
@@ -48,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Client, response: httpx.Response
-) -> Union[Any, JobExecutionList] | None:
+) -> Union[list[Any], Any, JobExecutionList] | None:
     if response.status_code == 200:
         try:
             _response_content = response.json()
@@ -62,6 +62,12 @@ def _parse_response(
             return None
         response_200 = JobExecutionList.from_dict(_response_content)
 
+        if isinstance(_response_content, list):
+            if response_200 is None:
+                return []
+            if response_200.data is UNSET or response_200.data is None:
+                return []
+            return cast(list[Any], response_200.data)
         return response_200
     if response.status_code == 400:
         response_400 = cast(Any, None)
@@ -77,7 +83,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[Any, JobExecutionList]]:
+) -> Response[Union[list[Any], Any, JobExecutionList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -95,7 +101,7 @@ def sync_detailed(
     cursor: Union[Unset, str] = UNSET,
     sort: Union[Unset, ListJobExecutionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
-) -> Response[Union[Any, JobExecutionList]]:
+) -> Response[Union[list[Any], Any, JobExecutionList]]:
     """List job executions
 
      Returns executions for a batch job. Starting with API version 2026-04-28 the response is wrapped in
@@ -116,7 +122,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, JobExecutionList]]
+        Response[Union[list[Any], Any, JobExecutionList]]
     """
 
     kwargs = _get_kwargs(
@@ -144,7 +150,7 @@ def sync(
     cursor: Union[Unset, str] = UNSET,
     sort: Union[Unset, ListJobExecutionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
-) -> Union[Any, JobExecutionList] | None:
+) -> Union[list[Any], Any, JobExecutionList] | None:
     """List job executions
 
      Returns executions for a batch job. Starting with API version 2026-04-28 the response is wrapped in
@@ -165,7 +171,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, JobExecutionList]
+        Union[list[Any], Any, JobExecutionList]
     """
 
     return sync_detailed(
@@ -188,7 +194,7 @@ async def asyncio_detailed(
     cursor: Union[Unset, str] = UNSET,
     sort: Union[Unset, ListJobExecutionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
-) -> Response[Union[Any, JobExecutionList]]:
+) -> Response[Union[list[Any], Any, JobExecutionList]]:
     """List job executions
 
      Returns executions for a batch job. Starting with API version 2026-04-28 the response is wrapped in
@@ -209,7 +215,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, JobExecutionList]]
+        Response[Union[list[Any], Any, JobExecutionList]]
     """
 
     kwargs = _get_kwargs(
@@ -235,7 +241,7 @@ async def asyncio(
     cursor: Union[Unset, str] = UNSET,
     sort: Union[Unset, ListJobExecutionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
-) -> Union[Any, JobExecutionList] | None:
+) -> Union[list[Any], Any, JobExecutionList] | None:
     """List job executions
 
      Returns executions for a batch job. Starting with API version 2026-04-28 the response is wrapped in
@@ -256,7 +262,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, JobExecutionList]
+        Union[list[Any], Any, JobExecutionList]
     """
 
     return (

--- a/src/blaxel/core/client/api/jobs/list_job_revisions.py
+++ b/src/blaxel/core/client/api/jobs/list_job_revisions.py
@@ -22,8 +22,18 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["RevisionMetadata"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = RevisionMetadata.from_dict(response_200_item_data)
 
@@ -61,6 +71,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -92,6 +103,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -118,6 +130,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -147,6 +160,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/jobs/list_jobs.py
+++ b/src/blaxel/core/client/api/jobs/list_jobs.py
@@ -1,31 +1,58 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, Union
 
 import httpx
 
 from ... import errors
 from ...client import Client
-from ...models.job import Job
-from ...types import Response
+from ...models.job_list import JobList
+from ...models.list_jobs_anchor import ListJobsAnchor
+from ...models.list_jobs_sort import ListJobsSort
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListJobsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListJobsAnchor] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    json_sort: Union[Unset, str] = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort.value
+
+    params["sort"] = json_sort
+
+    params["q"] = q
+
+    json_anchor: Union[Unset, str] = UNSET
+    if not isinstance(anchor, Unset):
+        json_anchor = anchor.value
+
+    params["anchor"] = json_anchor
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/jobs",
+        "params": params,
     }
 
     return _kwargs
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> list["Job"] | None:
+def _parse_response(*, client: Client, response: httpx.Response) -> JobList | None:
     if response.status_code == 200:
-        response_200 = []
-        _response_200 = response.json()
-        for response_200_item_data in _response_200:
-            response_200_item = Job.from_dict(response_200_item_data)
-
-            response_200.append(response_200_item)
+        response_200 = JobList.from_dict(response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -34,7 +61,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Job"] 
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[list["Job"]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[JobList]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -46,21 +73,41 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[lis
 def sync_detailed(
     *,
     client: Client,
-) -> Response[list["Job"]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListJobsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListJobsAnchor] = UNSET,
+) -> Response[JobList]:
     """List batch jobs
 
-     Returns all batch job definitions in the workspace. Each job can be triggered to run multiple
-    parallel tasks with configurable concurrency and retry settings.
+     Returns batch job definitions in the workspace. Each job can be triggered to run multiple parallel
+    tasks with configurable concurrency and retry settings. Starting with API version 2026-04-28 the
+    response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor` and `limit`
+    query parameters; older versions keep returning a bare array with all jobs.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListJobsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListJobsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Job']]
+        Response[JobList]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -72,43 +119,82 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> list["Job"] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListJobsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListJobsAnchor] = UNSET,
+) -> JobList | None:
     """List batch jobs
 
-     Returns all batch job definitions in the workspace. Each job can be triggered to run multiple
-    parallel tasks with configurable concurrency and retry settings.
+     Returns batch job definitions in the workspace. Each job can be triggered to run multiple parallel
+    tasks with configurable concurrency and retry settings. Starting with API version 2026-04-28 the
+    response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor` and `limit`
+    query parameters; older versions keep returning a bare array with all jobs.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListJobsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListJobsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Job']
+        JobList
     """
 
     return sync_detailed(
         client=client,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[list["Job"]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListJobsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListJobsAnchor] = UNSET,
+) -> Response[JobList]:
     """List batch jobs
 
-     Returns all batch job definitions in the workspace. Each job can be triggered to run multiple
-    parallel tasks with configurable concurrency and retry settings.
+     Returns batch job definitions in the workspace. Each job can be triggered to run multiple parallel
+    tasks with configurable concurrency and retry settings. Starting with API version 2026-04-28 the
+    response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor` and `limit`
+    query parameters; older versions keep returning a bare array with all jobs.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListJobsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListJobsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Job']]
+        Response[JobList]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -118,22 +204,41 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> list["Job"] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListJobsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListJobsAnchor] = UNSET,
+) -> JobList | None:
     """List batch jobs
 
-     Returns all batch job definitions in the workspace. Each job can be triggered to run multiple
-    parallel tasks with configurable concurrency and retry settings.
+     Returns batch job definitions in the workspace. Each job can be triggered to run multiple parallel
+    tasks with configurable concurrency and retry settings. Starting with API version 2026-04-28 the
+    response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor` and `limit`
+    query parameters; older versions keep returning a bare array with all jobs.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListJobsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListJobsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Job']
+        JobList
     """
 
     return (
         await asyncio_detailed(
             client=client,
+            cursor=cursor,
+            limit=limit,
+            sort=sort,
+            q=q,
+            anchor=anchor,
         )
     ).parsed

--- a/src/blaxel/core/client/api/jobs/list_jobs.py
+++ b/src/blaxel/core/client/api/jobs/list_jobs.py
@@ -52,7 +52,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> JobList | None:
     if response.status_code == 200:
-        response_200 = JobList.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = JobList.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -95,6 +105,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -141,6 +152,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -182,6 +194,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -226,6 +239,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/jobs/list_jobs.py
+++ b/src/blaxel/core/client/api/jobs/list_jobs.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Union
+from typing import Any, Union, cast
 
 import httpx
 
@@ -50,7 +50,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> JobList | None:
+def _parse_response(
+    *, client: Client, response: httpx.Response
+) -> Union[list[Any], JobList] | None:
     if response.status_code == 200:
         try:
             _response_content = response.json()
@@ -64,6 +66,12 @@ def _parse_response(*, client: Client, response: httpx.Response) -> JobList | No
             return None
         response_200 = JobList.from_dict(_response_content)
 
+        if isinstance(_response_content, list):
+            if response_200 is None:
+                return []
+            if response_200.data is UNSET or response_200.data is None:
+                return []
+            return cast(list[Any], response_200.data)
         return response_200
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
@@ -71,7 +79,9 @@ def _parse_response(*, client: Client, response: httpx.Response) -> JobList | No
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[JobList]:
+def _build_response(
+    *, client: Client, response: httpx.Response
+) -> Response[Union[list[Any], JobList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -88,7 +98,7 @@ def sync_detailed(
     sort: Union[Unset, ListJobsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListJobsAnchor] = UNSET,
-) -> Response[JobList]:
+) -> Response[Union[list[Any], JobList]]:
     """List batch jobs
 
      Returns batch job definitions in the workspace. Each job can be triggered to run multiple parallel
@@ -109,7 +119,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[JobList]
+        Response[Union[list[Any], JobList]]
     """
 
     kwargs = _get_kwargs(
@@ -135,7 +145,7 @@ def sync(
     sort: Union[Unset, ListJobsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListJobsAnchor] = UNSET,
-) -> JobList | None:
+) -> Union[list[Any], JobList] | None:
     """List batch jobs
 
      Returns batch job definitions in the workspace. Each job can be triggered to run multiple parallel
@@ -156,7 +166,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        JobList
+        Union[list[Any], JobList]
     """
 
     return sync_detailed(
@@ -177,7 +187,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListJobsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListJobsAnchor] = UNSET,
-) -> Response[JobList]:
+) -> Response[Union[list[Any], JobList]]:
     """List batch jobs
 
      Returns batch job definitions in the workspace. Each job can be triggered to run multiple parallel
@@ -198,7 +208,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[JobList]
+        Response[Union[list[Any], JobList]]
     """
 
     kwargs = _get_kwargs(
@@ -222,7 +232,7 @@ async def asyncio(
     sort: Union[Unset, ListJobsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListJobsAnchor] = UNSET,
-) -> JobList | None:
+) -> Union[list[Any], JobList] | None:
     """List batch jobs
 
      Returns batch job definitions in the workspace. Each job can be triggered to run multiple parallel
@@ -243,7 +253,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        JobList
+        Union[list[Any], JobList]
     """
 
     return (

--- a/src/blaxel/core/client/api/jobs/update_job.py
+++ b/src/blaxel/core/client/api/jobs/update_job.py
@@ -35,7 +35,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Job | None:
     if response.status_code == 200:
-        response_200 = Job.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Job.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -71,6 +81,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -107,6 +118,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -138,6 +150,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -172,6 +185,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/locations/list_locations.py
+++ b/src/blaxel/core/client/api/locations/list_locations.py
@@ -20,8 +20,18 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["LocationResponse"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = LocationResponse.from_dict(response_200_item_data)
 
@@ -56,6 +66,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -82,6 +93,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,6 +116,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -128,6 +141,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/mcphub/list_mcp_hub_definitions.py
+++ b/src/blaxel/core/client/api/mcphub/list_mcp_hub_definitions.py
@@ -20,8 +20,18 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["MCPDefinition"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = MCPDefinition.from_dict(response_200_item_data)
 
@@ -54,6 +64,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -80,6 +91,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -102,6 +114,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -126,6 +139,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/models/create_model.py
+++ b/src/blaxel/core/client/api/models/create_model.py
@@ -35,27 +35,87 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Model] | None:
     if response.status_code == 200:
-        response_200 = Model.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Model.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = Error.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 409:
-        response_409 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_409 = Error.from_dict(_response_content)
 
         return response_409
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -89,6 +149,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -122,6 +183,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -150,6 +212,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -181,6 +244,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/models/delete_model.py
+++ b/src/blaxel/core/client/api/models/delete_model.py
@@ -23,23 +23,73 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Model] | None:
     if response.status_code == 200:
-        response_200 = Model.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Model.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -72,6 +122,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,6 +155,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -131,6 +183,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -161,6 +214,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/models/get_model.py
+++ b/src/blaxel/core/client/api/models/get_model.py
@@ -23,23 +23,73 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Model] | None:
     if response.status_code == 200:
-        response_200 = Model.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Model.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -72,6 +122,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,6 +155,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -131,6 +183,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -161,6 +214,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/models/list_model_revisions.py
+++ b/src/blaxel/core/client/api/models/list_model_revisions.py
@@ -22,8 +22,18 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["RevisionMetadata"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = RevisionMetadata.from_dict(response_200_item_data)
 
@@ -61,6 +71,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -92,6 +103,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -118,6 +130,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -147,6 +160,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/models/list_models.py
+++ b/src/blaxel/core/client/api/models/list_models.py
@@ -53,19 +53,59 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, ModelList] | None:
     if response.status_code == 200:
-        response_200 = ModelList.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = ModelList.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -110,6 +150,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -156,6 +197,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -197,6 +239,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -241,6 +284,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/models/list_models.py
+++ b/src/blaxel/core/client/api/models/list_models.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Union
+from typing import Any, Union, cast
 
 import httpx
 
@@ -51,7 +51,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, ModelList] | None:
+def _parse_response(
+    *, client: Client, response: httpx.Response
+) -> Union[list[Any], Error, ModelList] | None:
     if response.status_code == 200:
         try:
             _response_content = response.json()
@@ -65,6 +67,12 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
             return None
         response_200 = ModelList.from_dict(_response_content)
 
+        if isinstance(_response_content, list):
+            if response_200 is None:
+                return []
+            if response_200.data is UNSET or response_200.data is None:
+                return []
+            return cast(list[Any], response_200.data)
         return response_200
     if response.status_code == 401:
         try:
@@ -116,7 +124,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[Error, ModelList]]:
+) -> Response[Union[list[Any], Error, ModelList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -133,7 +141,7 @@ def sync_detailed(
     sort: Union[Unset, ListModelsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListModelsAnchor] = UNSET,
-) -> Response[Union[Error, ModelList]]:
+) -> Response[Union[list[Any], Error, ModelList]]:
     """List model endpoints
 
      Returns model gateway endpoints configured in the workspace. Each model represents a proxy to an
@@ -154,7 +162,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, ModelList]]
+        Response[Union[list[Any], Error, ModelList]]
     """
 
     kwargs = _get_kwargs(
@@ -180,7 +188,7 @@ def sync(
     sort: Union[Unset, ListModelsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListModelsAnchor] = UNSET,
-) -> Union[Error, ModelList] | None:
+) -> Union[list[Any], Error, ModelList] | None:
     """List model endpoints
 
      Returns model gateway endpoints configured in the workspace. Each model represents a proxy to an
@@ -201,7 +209,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, ModelList]
+        Union[list[Any], Error, ModelList]
     """
 
     return sync_detailed(
@@ -222,7 +230,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListModelsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListModelsAnchor] = UNSET,
-) -> Response[Union[Error, ModelList]]:
+) -> Response[Union[list[Any], Error, ModelList]]:
     """List model endpoints
 
      Returns model gateway endpoints configured in the workspace. Each model represents a proxy to an
@@ -243,7 +251,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, ModelList]]
+        Response[Union[list[Any], Error, ModelList]]
     """
 
     kwargs = _get_kwargs(
@@ -267,7 +275,7 @@ async def asyncio(
     sort: Union[Unset, ListModelsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListModelsAnchor] = UNSET,
-) -> Union[Error, ModelList] | None:
+) -> Union[list[Any], Error, ModelList] | None:
     """List model endpoints
 
      Returns model gateway endpoints configured in the workspace. Each model represents a proxy to an
@@ -288,7 +296,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, ModelList]
+        Union[list[Any], Error, ModelList]
     """
 
     return (

--- a/src/blaxel/core/client/api/models/list_models.py
+++ b/src/blaxel/core/client/api/models/list_models.py
@@ -6,29 +6,54 @@ import httpx
 from ... import errors
 from ...client import Client
 from ...models.error import Error
-from ...models.model import Model
-from ...types import Response
+from ...models.list_models_anchor import ListModelsAnchor
+from ...models.list_models_sort import ListModelsSort
+from ...models.model_list import ModelList
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListModelsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListModelsAnchor] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    json_sort: Union[Unset, str] = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort.value
+
+    params["sort"] = json_sort
+
+    params["q"] = q
+
+    json_anchor: Union[Unset, str] = UNSET
+    if not isinstance(anchor, Unset):
+        json_anchor = anchor.value
+
+    params["anchor"] = json_anchor
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/models",
+        "params": params,
     }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Client, response: httpx.Response
-) -> Union[Error, list["Model"]] | None:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, ModelList] | None:
     if response.status_code == 200:
-        response_200 = []
-        _response_200 = response.json()
-        for response_200_item_data in _response_200:
-            response_200_item = Model.from_dict(response_200_item_data)
-
-            response_200.append(response_200_item)
+        response_200 = ModelList.from_dict(response.json())
 
         return response_200
     if response.status_code == 401:
@@ -51,7 +76,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[Error, list["Model"]]]:
+) -> Response[Union[Error, ModelList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,21 +88,41 @@ def _build_response(
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[Error, list["Model"]]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListModelsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListModelsAnchor] = UNSET,
+) -> Response[Union[Error, ModelList]]:
     """List model endpoints
 
-     Returns all model gateway endpoints configured in the workspace. Each model represents a proxy to an
-    external LLM provider (OpenAI, Anthropic, etc.) with unified access control.
+     Returns model gateway endpoints configured in the workspace. Each model represents a proxy to an
+    external LLM provider (OpenAI, Anthropic, etc.) with unified access control. Starting with API
+    version 2026-04-28 the response is wrapped in `{data, meta}` and supports cursor pagination via the
+    `cursor` and `limit` query parameters; older versions keep returning a bare array with all models.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListModelsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListModelsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, list['Model']]]
+        Response[Union[Error, ModelList]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -89,43 +134,82 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Union[Error, list["Model"]] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListModelsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListModelsAnchor] = UNSET,
+) -> Union[Error, ModelList] | None:
     """List model endpoints
 
-     Returns all model gateway endpoints configured in the workspace. Each model represents a proxy to an
-    external LLM provider (OpenAI, Anthropic, etc.) with unified access control.
+     Returns model gateway endpoints configured in the workspace. Each model represents a proxy to an
+    external LLM provider (OpenAI, Anthropic, etc.) with unified access control. Starting with API
+    version 2026-04-28 the response is wrapped in `{data, meta}` and supports cursor pagination via the
+    `cursor` and `limit` query parameters; older versions keep returning a bare array with all models.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListModelsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListModelsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, list['Model']]
+        Union[Error, ModelList]
     """
 
     return sync_detailed(
         client=client,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[Error, list["Model"]]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListModelsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListModelsAnchor] = UNSET,
+) -> Response[Union[Error, ModelList]]:
     """List model endpoints
 
-     Returns all model gateway endpoints configured in the workspace. Each model represents a proxy to an
-    external LLM provider (OpenAI, Anthropic, etc.) with unified access control.
+     Returns model gateway endpoints configured in the workspace. Each model represents a proxy to an
+    external LLM provider (OpenAI, Anthropic, etc.) with unified access control. Starting with API
+    version 2026-04-28 the response is wrapped in `{data, meta}` and supports cursor pagination via the
+    `cursor` and `limit` query parameters; older versions keep returning a bare array with all models.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListModelsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListModelsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, list['Model']]]
+        Response[Union[Error, ModelList]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -135,22 +219,41 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Union[Error, list["Model"]] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListModelsSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListModelsAnchor] = UNSET,
+) -> Union[Error, ModelList] | None:
     """List model endpoints
 
-     Returns all model gateway endpoints configured in the workspace. Each model represents a proxy to an
-    external LLM provider (OpenAI, Anthropic, etc.) with unified access control.
+     Returns model gateway endpoints configured in the workspace. Each model represents a proxy to an
+    external LLM provider (OpenAI, Anthropic, etc.) with unified access control. Starting with API
+    version 2026-04-28 the response is wrapped in `{data, meta}` and supports cursor pagination via the
+    `cursor` and `limit` query parameters; older versions keep returning a bare array with all models.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListModelsSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListModelsAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, list['Model']]
+        Union[Error, ModelList]
     """
 
     return (
         await asyncio_detailed(
             client=client,
+            cursor=cursor,
+            limit=limit,
+            sort=sort,
+            q=q,
+            anchor=anchor,
         )
     ).parsed

--- a/src/blaxel/core/client/api/models/update_model.py
+++ b/src/blaxel/core/client/api/models/update_model.py
@@ -36,27 +36,87 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Model] | None:
     if response.status_code == 200:
-        response_200 = Model.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Model.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = Error.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -92,6 +152,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -128,6 +189,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -159,6 +221,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -193,6 +256,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/policies/create_policy.py
+++ b/src/blaxel/core/client/api/policies/create_policy.py
@@ -34,7 +34,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Policy | None:
     if response.status_code == 200:
-        response_200 = Policy.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Policy.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -68,6 +78,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -101,6 +112,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -129,6 +141,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -160,6 +173,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/policies/delete_policy.py
+++ b/src/blaxel/core/client/api/policies/delete_policy.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Policy | None:
     if response.status_code == 200:
-        response_200 = Policy.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Policy.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -55,6 +65,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -87,6 +98,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +126,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +157,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/policies/get_policy.py
+++ b/src/blaxel/core/client/api/policies/get_policy.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Policy | None:
     if response.status_code == 200:
-        response_200 = Policy.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Policy.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -55,6 +65,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -87,6 +98,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +126,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +157,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/policies/get_policy_usages.py
+++ b/src/blaxel/core/client/api/policies/get_policy_usages.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> PolicyUsages | None:
     if response.status_code == 200:
-        response_200 = PolicyUsages.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = PolicyUsages.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -55,6 +65,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -87,6 +98,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +126,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +157,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/policies/get_policy_usages.py
+++ b/src/blaxel/core/client/api/policies/get_policy_usages.py
@@ -1,0 +1,158 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.policy_usages import PolicyUsages
+from ...types import Response
+
+
+def _get_kwargs(
+    policy_name: str,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": f"/policies/{policy_name}/usages",
+    }
+
+    return _kwargs
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> PolicyUsages | None:
+    if response.status_code == 200:
+        response_200 = PolicyUsages.from_dict(response.json())
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[PolicyUsages]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    policy_name: str,
+    *,
+    client: Client,
+) -> Response[PolicyUsages]:
+    """List resources using a policy
+
+     Returns the names of every resource (agent, function, model, sandbox, job) currently referencing the
+    given policy. Replaces the client-side fan-out the policies UI used to do over the listings.
+
+    Args:
+        policy_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[PolicyUsages]
+    """
+
+    kwargs = _get_kwargs(
+        policy_name=policy_name,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    policy_name: str,
+    *,
+    client: Client,
+) -> PolicyUsages | None:
+    """List resources using a policy
+
+     Returns the names of every resource (agent, function, model, sandbox, job) currently referencing the
+    given policy. Replaces the client-side fan-out the policies UI used to do over the listings.
+
+    Args:
+        policy_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        PolicyUsages
+    """
+
+    return sync_detailed(
+        policy_name=policy_name,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    policy_name: str,
+    *,
+    client: Client,
+) -> Response[PolicyUsages]:
+    """List resources using a policy
+
+     Returns the names of every resource (agent, function, model, sandbox, job) currently referencing the
+    given policy. Replaces the client-side fan-out the policies UI used to do over the listings.
+
+    Args:
+        policy_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[PolicyUsages]
+    """
+
+    kwargs = _get_kwargs(
+        policy_name=policy_name,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    policy_name: str,
+    *,
+    client: Client,
+) -> PolicyUsages | None:
+    """List resources using a policy
+
+     Returns the names of every resource (agent, function, model, sandbox, job) currently referencing the
+    given policy. Replaces the client-side fan-out the policies UI used to do over the listings.
+
+    Args:
+        policy_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        PolicyUsages
+    """
+
+    return (
+        await asyncio_detailed(
+            policy_name=policy_name,
+            client=client,
+        )
+    ).parsed

--- a/src/blaxel/core/client/api/policies/list_policies.py
+++ b/src/blaxel/core/client/api/policies/list_policies.py
@@ -52,7 +52,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> PolicyList | None:
     if response.status_code == 200:
-        response_200 = PolicyList.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = PolicyList.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -95,6 +105,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -141,6 +152,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -182,6 +194,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -226,6 +239,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/policies/list_policies.py
+++ b/src/blaxel/core/client/api/policies/list_policies.py
@@ -1,31 +1,58 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, Union
 
 import httpx
 
 from ... import errors
 from ...client import Client
-from ...models.policy import Policy
-from ...types import Response
+from ...models.list_policies_anchor import ListPoliciesAnchor
+from ...models.list_policies_sort import ListPoliciesSort
+from ...models.policy_list import PolicyList
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListPoliciesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    json_sort: Union[Unset, str] = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort.value
+
+    params["sort"] = json_sort
+
+    params["q"] = q
+
+    json_anchor: Union[Unset, str] = UNSET
+    if not isinstance(anchor, Unset):
+        json_anchor = anchor.value
+
+    params["anchor"] = json_anchor
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/policies",
+        "params": params,
     }
 
     return _kwargs
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> list["Policy"] | None:
+def _parse_response(*, client: Client, response: httpx.Response) -> PolicyList | None:
     if response.status_code == 200:
-        response_200 = []
-        _response_200 = response.json()
-        for response_200_item_data in _response_200:
-            response_200_item = Policy.from_dict(response_200_item_data)
-
-            response_200.append(response_200_item)
+        response_200 = PolicyList.from_dict(response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -34,7 +61,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Policy
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[list["Policy"]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[PolicyList]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -46,21 +73,41 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[lis
 def sync_detailed(
     *,
     client: Client,
-) -> Response[list["Policy"]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListPoliciesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
+) -> Response[PolicyList]:
     """List governance policies
 
-     Returns all governance policies in the workspace. Policies control deployment locations, hardware
-    flavors, and token limits for agents, functions, and models.
+     Returns governance policies in the workspace. Policies control deployment locations, hardware
+    flavors, and token limits for agents, functions, and models. Starting with API version 2026-04-28
+    the response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor` and
+    `limit` query parameters; older versions keep returning a bare array with all policies.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListPoliciesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListPoliciesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Policy']]
+        Response[PolicyList]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -72,43 +119,82 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> list["Policy"] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListPoliciesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
+) -> PolicyList | None:
     """List governance policies
 
-     Returns all governance policies in the workspace. Policies control deployment locations, hardware
-    flavors, and token limits for agents, functions, and models.
+     Returns governance policies in the workspace. Policies control deployment locations, hardware
+    flavors, and token limits for agents, functions, and models. Starting with API version 2026-04-28
+    the response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor` and
+    `limit` query parameters; older versions keep returning a bare array with all policies.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListPoliciesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListPoliciesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Policy']
+        PolicyList
     """
 
     return sync_detailed(
         client=client,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[list["Policy"]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListPoliciesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
+) -> Response[PolicyList]:
     """List governance policies
 
-     Returns all governance policies in the workspace. Policies control deployment locations, hardware
-    flavors, and token limits for agents, functions, and models.
+     Returns governance policies in the workspace. Policies control deployment locations, hardware
+    flavors, and token limits for agents, functions, and models. Starting with API version 2026-04-28
+    the response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor` and
+    `limit` query parameters; older versions keep returning a bare array with all policies.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListPoliciesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListPoliciesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Policy']]
+        Response[PolicyList]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -118,22 +204,41 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> list["Policy"] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListPoliciesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
+) -> PolicyList | None:
     """List governance policies
 
-     Returns all governance policies in the workspace. Policies control deployment locations, hardware
-    flavors, and token limits for agents, functions, and models.
+     Returns governance policies in the workspace. Policies control deployment locations, hardware
+    flavors, and token limits for agents, functions, and models. Starting with API version 2026-04-28
+    the response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor` and
+    `limit` query parameters; older versions keep returning a bare array with all policies.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListPoliciesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListPoliciesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Policy']
+        PolicyList
     """
 
     return (
         await asyncio_detailed(
             client=client,
+            cursor=cursor,
+            limit=limit,
+            sort=sort,
+            q=q,
+            anchor=anchor,
         )
     ).parsed

--- a/src/blaxel/core/client/api/policies/list_policies.py
+++ b/src/blaxel/core/client/api/policies/list_policies.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Union
+from typing import Any, Union, cast
 
 import httpx
 
@@ -50,7 +50,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> PolicyList | None:
+def _parse_response(
+    *, client: Client, response: httpx.Response
+) -> Union[list[Any], PolicyList] | None:
     if response.status_code == 200:
         try:
             _response_content = response.json()
@@ -64,6 +66,12 @@ def _parse_response(*, client: Client, response: httpx.Response) -> PolicyList |
             return None
         response_200 = PolicyList.from_dict(_response_content)
 
+        if isinstance(_response_content, list):
+            if response_200 is None:
+                return []
+            if response_200.data is UNSET or response_200.data is None:
+                return []
+            return cast(list[Any], response_200.data)
         return response_200
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
@@ -71,7 +79,9 @@ def _parse_response(*, client: Client, response: httpx.Response) -> PolicyList |
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[PolicyList]:
+def _build_response(
+    *, client: Client, response: httpx.Response
+) -> Response[Union[list[Any], PolicyList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -88,7 +98,7 @@ def sync_detailed(
     sort: Union[Unset, ListPoliciesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
-) -> Response[PolicyList]:
+) -> Response[Union[list[Any], PolicyList]]:
     """List governance policies
 
      Returns governance policies in the workspace. Policies control deployment locations, hardware
@@ -109,7 +119,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[PolicyList]
+        Response[Union[list[Any], PolicyList]]
     """
 
     kwargs = _get_kwargs(
@@ -135,7 +145,7 @@ def sync(
     sort: Union[Unset, ListPoliciesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
-) -> PolicyList | None:
+) -> Union[list[Any], PolicyList] | None:
     """List governance policies
 
      Returns governance policies in the workspace. Policies control deployment locations, hardware
@@ -156,7 +166,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        PolicyList
+        Union[list[Any], PolicyList]
     """
 
     return sync_detailed(
@@ -177,7 +187,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListPoliciesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
-) -> Response[PolicyList]:
+) -> Response[Union[list[Any], PolicyList]]:
     """List governance policies
 
      Returns governance policies in the workspace. Policies control deployment locations, hardware
@@ -198,7 +208,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[PolicyList]
+        Response[Union[list[Any], PolicyList]]
     """
 
     kwargs = _get_kwargs(
@@ -222,7 +232,7 @@ async def asyncio(
     sort: Union[Unset, ListPoliciesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
-) -> PolicyList | None:
+) -> Union[list[Any], PolicyList] | None:
     """List governance policies
 
      Returns governance policies in the workspace. Policies control deployment locations, hardware
@@ -243,7 +253,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        PolicyList
+        Union[list[Any], PolicyList]
     """
 
     return (

--- a/src/blaxel/core/client/api/policies/update_policy.py
+++ b/src/blaxel/core/client/api/policies/update_policy.py
@@ -35,7 +35,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Policy | None:
     if response.status_code == 200:
-        response_200 = Policy.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Policy.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -71,6 +81,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -107,6 +118,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -138,6 +150,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -172,6 +185,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/public_ipslist/list_public_ips.py
+++ b/src/blaxel/core/client/api/public_ipslist/list_public_ips.py
@@ -30,7 +30,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> PublicIps | None:
     if response.status_code == 200:
-        response_200 = PublicIps.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = PublicIps.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -62,6 +72,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -93,6 +104,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -119,6 +131,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -148,6 +161,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/sandboxhub/list_sandbox_hub_definitions.py
+++ b/src/blaxel/core/client/api/sandboxhub/list_sandbox_hub_definitions.py
@@ -22,8 +22,18 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> list["SandboxDefinition"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = SandboxDefinition.from_dict(response_200_item_data)
 
@@ -58,6 +68,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -84,6 +95,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -106,6 +118,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -130,6 +143,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/service_accounts/create_api_key_for_service_account.py
+++ b/src/blaxel/core/client/api/service_accounts/create_api_key_for_service_account.py
@@ -36,7 +36,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> ApiKey | None:
     if response.status_code == 200:
-        response_200 = ApiKey.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = ApiKey.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -71,6 +81,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -106,6 +117,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -136,6 +148,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -169,6 +182,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/service_accounts/create_workspace_service_account.py
+++ b/src/blaxel/core/client/api/service_accounts/create_workspace_service_account.py
@@ -39,7 +39,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> CreateWorkspaceServiceAccountResponse200 | None:
     if response.status_code == 200:
-        response_200 = CreateWorkspaceServiceAccountResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = CreateWorkspaceServiceAccountResponse200.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -74,6 +84,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -106,6 +117,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -133,6 +145,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -163,6 +176,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/service_accounts/delete_workspace_service_account.py
+++ b/src/blaxel/core/client/api/service_accounts/delete_workspace_service_account.py
@@ -26,7 +26,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> DeleteWorkspaceServiceAccountResponse200 | None:
     if response.status_code == 200:
-        response_200 = DeleteWorkspaceServiceAccountResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = DeleteWorkspaceServiceAccountResponse200.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -61,6 +71,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -93,6 +104,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -120,6 +132,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -150,6 +163,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/service_accounts/get_workspace_service_accounts.py
+++ b/src/blaxel/core/client/api/service_accounts/get_workspace_service_accounts.py
@@ -24,8 +24,18 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> list["GetWorkspaceServiceAccountsResponse200Item"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = GetWorkspaceServiceAccountsResponse200Item.from_dict(
                 response_200_item_data
@@ -62,6 +72,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -88,6 +99,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -110,6 +122,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -134,6 +147,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/service_accounts/list_api_keys_for_service_account.py
+++ b/src/blaxel/core/client/api/service_accounts/list_api_keys_for_service_account.py
@@ -22,8 +22,18 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["ApiKey"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = ApiKey.from_dict(response_200_item_data)
 
@@ -60,6 +70,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -92,6 +103,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -119,6 +131,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -149,6 +162,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/service_accounts/update_workspace_service_account.py
+++ b/src/blaxel/core/client/api/service_accounts/update_workspace_service_account.py
@@ -40,7 +40,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> UpdateWorkspaceServiceAccountResponse200 | None:
     if response.status_code == 200:
-        response_200 = UpdateWorkspaceServiceAccountResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = UpdateWorkspaceServiceAccountResponse200.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -76,6 +86,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -110,6 +121,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -139,6 +151,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -171,6 +184,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/templates/list_templates.py
+++ b/src/blaxel/core/client/api/templates/list_templates.py
@@ -20,8 +20,18 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["Template"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = Template.from_dict(response_200_item_data)
 
@@ -54,6 +64,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -80,6 +91,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -102,6 +114,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -126,6 +139,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/volume_templates/create_volume_template.py
+++ b/src/blaxel/core/client/api/volume_templates/create_volume_template.py
@@ -45,7 +45,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> VolumeTemplate | None:
     if response.status_code == 200:
-        response_200 = VolumeTemplate.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = VolumeTemplate.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -82,6 +92,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -120,6 +131,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -153,6 +165,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -189,6 +202,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/volume_templates/delete_volume_template.py
+++ b/src/blaxel/core/client/api/volume_templates/delete_volume_template.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> VolumeTemplate | None:
     if response.status_code == 200:
-        response_200 = VolumeTemplate.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = VolumeTemplate.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -54,6 +64,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -85,6 +96,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -111,6 +123,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -140,6 +153,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/volume_templates/delete_volume_template_version.py
+++ b/src/blaxel/core/client/api/volume_templates/delete_volume_template_version.py
@@ -27,7 +27,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Any, DeleteVolumeTemplateVersionResponse200] | None:
     if response.status_code == 200:
-        response_200 = DeleteVolumeTemplateVersionResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = DeleteVolumeTemplateVersionResponse200.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
@@ -69,6 +79,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -103,6 +114,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -132,6 +144,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -164,6 +177,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/volume_templates/get_volume_template.py
+++ b/src/blaxel/core/client/api/volume_templates/get_volume_template.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> VolumeTemplate | None:
     if response.status_code == 200:
-        response_200 = VolumeTemplate.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = VolumeTemplate.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -54,6 +64,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -85,6 +96,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -111,6 +123,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -140,6 +153,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/volume_templates/list_volume_templates.py
+++ b/src/blaxel/core/client/api/volume_templates/list_volume_templates.py
@@ -20,8 +20,18 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["VolumeTemplate"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = VolumeTemplate.from_dict(response_200_item_data)
 
@@ -56,6 +66,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -82,6 +93,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,6 +116,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -128,6 +141,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/volume_templates/update_volume_template.py
+++ b/src/blaxel/core/client/api/volume_templates/update_volume_template.py
@@ -46,7 +46,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> VolumeTemplate | None:
     if response.status_code == 200:
-        response_200 = VolumeTemplate.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = VolumeTemplate.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -84,6 +94,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -124,6 +135,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -159,6 +171,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -197,6 +210,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/volumes/create_volume.py
+++ b/src/blaxel/core/client/api/volumes/create_volume.py
@@ -35,27 +35,87 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Volume] | None:
     if response.status_code == 200:
-        response_200 = Volume.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Volume.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = Error.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 409:
-        response_409 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_409 = Error.from_dict(_response_content)
 
         return response_409
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -90,6 +150,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -124,6 +185,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -153,6 +215,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -185,6 +248,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/volumes/delete_volume.py
+++ b/src/blaxel/core/client/api/volumes/delete_volume.py
@@ -23,27 +23,87 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Volume] | None:
     if response.status_code == 200:
-        response_200 = Volume.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Volume.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 409:
-        response_409 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_409 = Error.from_dict(_response_content)
 
         return response_409
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -76,6 +136,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -108,6 +169,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -135,6 +197,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -165,6 +228,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/volumes/get_volume.py
+++ b/src/blaxel/core/client/api/volumes/get_volume.py
@@ -23,23 +23,73 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Volume] | None:
     if response.status_code == 200:
-        response_200 = Volume.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Volume.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -72,6 +122,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,6 +155,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -131,6 +183,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -161,6 +214,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/volumes/list_volumes.py
+++ b/src/blaxel/core/client/api/volumes/list_volumes.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Union
+from typing import Any, Union, cast
 
 import httpx
 
@@ -51,7 +51,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, VolumeList] | None:
+def _parse_response(
+    *, client: Client, response: httpx.Response
+) -> Union[list[Any], Error, VolumeList] | None:
     if response.status_code == 200:
         try:
             _response_content = response.json()
@@ -65,6 +67,12 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
             return None
         response_200 = VolumeList.from_dict(_response_content)
 
+        if isinstance(_response_content, list):
+            if response_200 is None:
+                return []
+            if response_200.data is UNSET or response_200.data is None:
+                return []
+            return cast(list[Any], response_200.data)
         return response_200
     if response.status_code == 401:
         try:
@@ -116,7 +124,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[Error, VolumeList]]:
+) -> Response[Union[list[Any], Error, VolumeList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -133,7 +141,7 @@ def sync_detailed(
     sort: Union[Unset, ListVolumesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListVolumesAnchor] = UNSET,
-) -> Response[Union[Error, VolumeList]]:
+) -> Response[Union[list[Any], Error, VolumeList]]:
     """List persistent volumes
 
      Returns persistent storage volumes in the workspace. Volumes can be attached to sandboxes for
@@ -154,7 +162,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, VolumeList]]
+        Response[Union[list[Any], Error, VolumeList]]
     """
 
     kwargs = _get_kwargs(
@@ -180,7 +188,7 @@ def sync(
     sort: Union[Unset, ListVolumesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListVolumesAnchor] = UNSET,
-) -> Union[Error, VolumeList] | None:
+) -> Union[list[Any], Error, VolumeList] | None:
     """List persistent volumes
 
      Returns persistent storage volumes in the workspace. Volumes can be attached to sandboxes for
@@ -201,7 +209,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, VolumeList]
+        Union[list[Any], Error, VolumeList]
     """
 
     return sync_detailed(
@@ -222,7 +230,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListVolumesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListVolumesAnchor] = UNSET,
-) -> Response[Union[Error, VolumeList]]:
+) -> Response[Union[list[Any], Error, VolumeList]]:
     """List persistent volumes
 
      Returns persistent storage volumes in the workspace. Volumes can be attached to sandboxes for
@@ -243,7 +251,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, VolumeList]]
+        Response[Union[list[Any], Error, VolumeList]]
     """
 
     kwargs = _get_kwargs(
@@ -267,7 +275,7 @@ async def asyncio(
     sort: Union[Unset, ListVolumesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListVolumesAnchor] = UNSET,
-) -> Union[Error, VolumeList] | None:
+) -> Union[list[Any], Error, VolumeList] | None:
     """List persistent volumes
 
      Returns persistent storage volumes in the workspace. Volumes can be attached to sandboxes for
@@ -288,7 +296,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, VolumeList]
+        Union[list[Any], Error, VolumeList]
     """
 
     return (

--- a/src/blaxel/core/client/api/volumes/list_volumes.py
+++ b/src/blaxel/core/client/api/volumes/list_volumes.py
@@ -53,19 +53,59 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, VolumeList] | None:
     if response.status_code == 200:
-        response_200 = VolumeList.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = VolumeList.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -110,6 +150,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -156,6 +197,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -197,6 +239,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -241,6 +284,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/volumes/list_volumes.py
+++ b/src/blaxel/core/client/api/volumes/list_volumes.py
@@ -6,29 +6,54 @@ import httpx
 from ... import errors
 from ...client import Client
 from ...models.error import Error
-from ...models.volume import Volume
-from ...types import Response
+from ...models.list_volumes_anchor import ListVolumesAnchor
+from ...models.list_volumes_sort import ListVolumesSort
+from ...models.volume_list import VolumeList
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListVolumesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListVolumesAnchor] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    json_sort: Union[Unset, str] = UNSET
+    if not isinstance(sort, Unset):
+        json_sort = sort.value
+
+    params["sort"] = json_sort
+
+    params["q"] = q
+
+    json_anchor: Union[Unset, str] = UNSET
+    if not isinstance(anchor, Unset):
+        json_anchor = anchor.value
+
+    params["anchor"] = json_anchor
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/volumes",
+        "params": params,
     }
 
     return _kwargs
 
 
-def _parse_response(
-    *, client: Client, response: httpx.Response
-) -> Union[Error, list["Volume"]] | None:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, VolumeList] | None:
     if response.status_code == 200:
-        response_200 = []
-        _response_200 = response.json()
-        for response_200_item_data in _response_200:
-            response_200_item = Volume.from_dict(response_200_item_data)
-
-            response_200.append(response_200_item)
+        response_200 = VolumeList.from_dict(response.json())
 
         return response_200
     if response.status_code == 401:
@@ -51,7 +76,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[Error, list["Volume"]]]:
+) -> Response[Union[Error, VolumeList]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,21 +88,41 @@ def _build_response(
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[Error, list["Volume"]]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListVolumesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListVolumesAnchor] = UNSET,
+) -> Response[Union[Error, VolumeList]]:
     """List persistent volumes
 
-     Returns all persistent storage volumes in the workspace. Volumes can be attached to sandboxes for
-    durable file storage that persists across sessions and sandbox deletions.
+     Returns persistent storage volumes in the workspace. Volumes can be attached to sandboxes for
+    durable file storage that persists across sessions and sandbox deletions. Starting with API version
+    2026-04-28 the response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor`
+    and `limit` query parameters; older versions keep returning a bare array of volumes.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListVolumesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListVolumesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, list['Volume']]]
+        Response[Union[Error, VolumeList]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -89,43 +134,82 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Union[Error, list["Volume"]] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListVolumesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListVolumesAnchor] = UNSET,
+) -> Union[Error, VolumeList] | None:
     """List persistent volumes
 
-     Returns all persistent storage volumes in the workspace. Volumes can be attached to sandboxes for
-    durable file storage that persists across sessions and sandbox deletions.
+     Returns persistent storage volumes in the workspace. Volumes can be attached to sandboxes for
+    durable file storage that persists across sessions and sandbox deletions. Starting with API version
+    2026-04-28 the response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor`
+    and `limit` query parameters; older versions keep returning a bare array of volumes.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListVolumesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListVolumesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, list['Volume']]
+        Union[Error, VolumeList]
     """
 
     return sync_detailed(
         client=client,
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[Error, list["Volume"]]]:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListVolumesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListVolumesAnchor] = UNSET,
+) -> Response[Union[Error, VolumeList]]:
     """List persistent volumes
 
-     Returns all persistent storage volumes in the workspace. Volumes can be attached to sandboxes for
-    durable file storage that persists across sessions and sandbox deletions.
+     Returns persistent storage volumes in the workspace. Volumes can be attached to sandboxes for
+    durable file storage that persists across sessions and sandbox deletions. Starting with API version
+    2026-04-28 the response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor`
+    and `limit` query parameters; older versions keep returning a bare array of volumes.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListVolumesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListVolumesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Error, list['Volume']]]
+        Response[Union[Error, VolumeList]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        limit=limit,
+        sort=sort,
+        q=q,
+        anchor=anchor,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -135,22 +219,41 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Union[Error, list["Volume"]] | None:
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    sort: Union[Unset, ListVolumesSort] = UNSET,
+    q: Union[Unset, str] = UNSET,
+    anchor: Union[Unset, ListVolumesAnchor] = UNSET,
+) -> Union[Error, VolumeList] | None:
     """List persistent volumes
 
-     Returns all persistent storage volumes in the workspace. Volumes can be attached to sandboxes for
-    durable file storage that persists across sessions and sandbox deletions.
+     Returns persistent storage volumes in the workspace. Volumes can be attached to sandboxes for
+    durable file storage that persists across sessions and sandbox deletions. Starting with API version
+    2026-04-28 the response is wrapped in `{data, meta}` and supports cursor pagination via the `cursor`
+    and `limit` query parameters; older versions keep returning a bare array of volumes.
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        sort (Union[Unset, ListVolumesSort]):
+        q (Union[Unset, str]):
+        anchor (Union[Unset, ListVolumesAnchor]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Error, list['Volume']]
+        Union[Error, VolumeList]
     """
 
     return (
         await asyncio_detailed(
             client=client,
+            cursor=cursor,
+            limit=limit,
+            sort=sort,
+            q=q,
+            anchor=anchor,
         )
     ).parsed

--- a/src/blaxel/core/client/api/volumes/update_volume.py
+++ b/src/blaxel/core/client/api/volumes/update_volume.py
@@ -35,7 +35,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Volume | None:
     if response.status_code == 200:
-        response_200 = Volume.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Volume.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -71,6 +81,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -107,6 +118,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -138,6 +150,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -172,6 +185,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/create_egress_gateway.py
+++ b/src/blaxel/core/client/api/vpcs/create_egress_gateway.py
@@ -35,7 +35,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> EgressGateway | None:
     if response.status_code == 200:
-        response_200 = EgressGateway.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = EgressGateway.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -68,6 +78,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -101,6 +112,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -129,6 +141,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -160,6 +173,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/create_egress_ip.py
+++ b/src/blaxel/core/client/api/vpcs/create_egress_ip.py
@@ -36,7 +36,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> EgressIP | None:
     if response.status_code == 200:
-        response_200 = EgressIP.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = EgressIP.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -71,6 +81,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -107,6 +118,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -138,6 +150,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -172,6 +185,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/create_vpc.py
+++ b/src/blaxel/core/client/api/vpcs/create_vpc.py
@@ -34,7 +34,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> VPC | None:
     if response.status_code == 200:
-        response_200 = VPC.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = VPC.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -65,6 +75,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -95,6 +106,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -120,6 +132,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -148,6 +161,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/delete_egress_gateway.py
+++ b/src/blaxel/core/client/api/vpcs/delete_egress_gateway.py
@@ -23,7 +23,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> EgressGateway | None:
     if response.status_code == 200:
-        response_200 = EgressGateway.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = EgressGateway.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -55,6 +65,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -87,6 +98,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +126,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +157,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/delete_egress_ip.py
+++ b/src/blaxel/core/client/api/vpcs/delete_egress_ip.py
@@ -24,7 +24,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> EgressIP | None:
     if response.status_code == 200:
-        response_200 = EgressIP.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = EgressIP.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -58,6 +68,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -93,6 +104,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -123,6 +135,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -156,6 +169,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/delete_vpc.py
+++ b/src/blaxel/core/client/api/vpcs/delete_vpc.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> VPC | None:
     if response.status_code == 200:
-        response_200 = VPC.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = VPC.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -52,6 +62,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -81,6 +92,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -105,6 +117,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -132,6 +145,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/get_egress_gateway.py
+++ b/src/blaxel/core/client/api/vpcs/get_egress_gateway.py
@@ -23,7 +23,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> EgressGateway | None:
     if response.status_code == 200:
-        response_200 = EgressGateway.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = EgressGateway.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -55,6 +65,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -87,6 +98,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +126,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +157,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/get_egress_gateway_usage.py
+++ b/src/blaxel/core/client/api/vpcs/get_egress_gateway_usage.py
@@ -1,0 +1,134 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.egress_gateway_usage import EgressGatewayUsage
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/egressgateways/usage",
+    }
+
+    return _kwargs
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> EgressGatewayUsage | None:
+    if response.status_code == 200:
+        response_200 = EgressGatewayUsage.from_dict(response.json())
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[EgressGatewayUsage]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+) -> Response[EgressGatewayUsage]:
+    """Egress gateway sandbox attachments
+
+     Returns the inverse map (gateway → sandbox names) for the workspace. Used by the egress-IPs UI to
+    render attachment counts without fetching the sandboxes listing full client-side.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[EgressGatewayUsage]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+) -> EgressGatewayUsage | None:
+    """Egress gateway sandbox attachments
+
+     Returns the inverse map (gateway → sandbox names) for the workspace. Used by the egress-IPs UI to
+    render attachment counts without fetching the sandboxes listing full client-side.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        EgressGatewayUsage
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+) -> Response[EgressGatewayUsage]:
+    """Egress gateway sandbox attachments
+
+     Returns the inverse map (gateway → sandbox names) for the workspace. Used by the egress-IPs UI to
+    render attachment counts without fetching the sandboxes listing full client-side.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[EgressGatewayUsage]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+) -> EgressGatewayUsage | None:
+    """Egress gateway sandbox attachments
+
+     Returns the inverse map (gateway → sandbox names) for the workspace. Used by the egress-IPs UI to
+    render attachment counts without fetching the sandboxes listing full client-side.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        EgressGatewayUsage
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/src/blaxel/core/client/api/vpcs/get_egress_gateway_usage.py
+++ b/src/blaxel/core/client/api/vpcs/get_egress_gateway_usage.py
@@ -20,7 +20,17 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> EgressGatewayUsage | None:
     if response.status_code == 200:
-        response_200 = EgressGatewayUsage.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = EgressGatewayUsage.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -49,6 +59,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -75,6 +86,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -97,6 +109,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -121,6 +134,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/get_egress_ip.py
+++ b/src/blaxel/core/client/api/vpcs/get_egress_ip.py
@@ -24,7 +24,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> EgressIP | None:
     if response.status_code == 200:
-        response_200 = EgressIP.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = EgressIP.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -58,6 +68,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -93,6 +104,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -123,6 +135,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -156,6 +169,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/get_vpc.py
+++ b/src/blaxel/core/client/api/vpcs/get_vpc.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> VPC | None:
     if response.status_code == 200:
-        response_200 = VPC.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = VPC.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -52,6 +62,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -81,6 +92,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -105,6 +117,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -132,6 +145,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/list_all_egress_gateways.py
+++ b/src/blaxel/core/client/api/vpcs/list_all_egress_gateways.py
@@ -20,8 +20,18 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["EgressGateway"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = EgressGateway.from_dict(response_200_item_data)
 
@@ -51,6 +61,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -74,6 +85,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -93,6 +105,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +127,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/list_all_egress_i_ps.py
+++ b/src/blaxel/core/client/api/vpcs/list_all_egress_i_ps.py
@@ -20,8 +20,18 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["EgressIP"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = EgressIP.from_dict(response_200_item_data)
 
@@ -51,6 +61,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -74,6 +85,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -93,6 +105,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +127,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/list_egress_gateways.py
+++ b/src/blaxel/core/client/api/vpcs/list_egress_gateways.py
@@ -22,8 +22,18 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["EgressGateway"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = EgressGateway.from_dict(response_200_item_data)
 
@@ -57,6 +67,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -86,6 +97,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -110,6 +122,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -137,6 +150,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/list_egress_i_ps.py
+++ b/src/blaxel/core/client/api/vpcs/list_egress_i_ps.py
@@ -23,8 +23,18 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["EgressIP"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = EgressIP.from_dict(response_200_item_data)
 
@@ -60,6 +70,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -92,6 +103,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -119,6 +131,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -149,6 +162,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/vpcs/list_vp_cs.py
+++ b/src/blaxel/core/client/api/vpcs/list_vp_cs.py
@@ -20,8 +20,18 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["VPC"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = VPC.from_dict(response_200_item_data)
 
@@ -51,6 +61,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -74,6 +85,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -93,6 +105,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +127,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/accept_workspace_invitation.py
+++ b/src/blaxel/core/client/api/workspaces/accept_workspace_invitation.py
@@ -24,7 +24,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Any, PendingInvitationAccept] | None:
     if response.status_code == 200:
-        response_200 = PendingInvitationAccept.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = PendingInvitationAccept.from_dict(_response_content)
 
         return response_200
     if response.status_code == 404:
@@ -61,6 +71,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -92,6 +103,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -118,6 +130,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -147,6 +160,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/check_workspace_availability.py
+++ b/src/blaxel/core/client/api/workspaces/check_workspace_availability.py
@@ -45,6 +45,16 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union["WorkspaceAvailability", bool] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
 
         def _parse_response_200(data: object) -> Union["WorkspaceAvailability", bool]:
             try:
@@ -57,7 +67,7 @@ def _parse_response(
                 pass
             return cast(Union["WorkspaceAvailability", bool], data)
 
-        response_200 = _parse_response_200(response.json())
+        response_200 = _parse_response_200(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -93,6 +103,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -127,6 +138,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -156,6 +168,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -188,6 +201,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/create_workspace.py
+++ b/src/blaxel/core/client/api/workspaces/create_workspace.py
@@ -35,27 +35,87 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Workspace] | None:
     if response.status_code == 200:
-        response_200 = Workspace.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Workspace.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = Error.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 409:
-        response_409 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_409 = Error.from_dict(_response_content)
 
         return response_409
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -91,6 +151,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -124,6 +185,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -152,6 +214,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -183,6 +246,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/decline_workspace_invitation.py
+++ b/src/blaxel/core/client/api/workspaces/decline_workspace_invitation.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> PendingInvitation | None:
     if response.status_code == 200:
-        response_200 = PendingInvitation.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = PendingInvitation.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -54,6 +64,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -85,6 +96,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -111,6 +123,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -140,6 +153,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/delete_workspace.py
+++ b/src/blaxel/core/client/api/workspaces/delete_workspace.py
@@ -23,23 +23,73 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Workspace] | None:
     if response.status_code == 200:
-        response_200 = Workspace.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Workspace.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -74,6 +124,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -106,6 +157,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -133,6 +185,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -163,6 +216,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/get_workspace.py
+++ b/src/blaxel/core/client/api/workspaces/get_workspace.py
@@ -32,23 +32,73 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Workspace] | None:
     if response.status_code == 200:
-        response_200 = Workspace.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Workspace.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -85,6 +135,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -120,6 +171,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -150,6 +202,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -183,6 +236,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/get_workspace.py
+++ b/src/blaxel/core/client/api/workspaces/get_workspace.py
@@ -7,15 +7,24 @@ from ... import errors
 from ...client import Client
 from ...models.error import Error
 from ...models.workspace import Workspace
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     workspace_name: str,
+    *,
+    count_resources: Union[Unset, bool] = False,
 ) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["countResources"] = count_resources
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": f"/workspaces/{workspace_name}",
+        "params": params,
     }
 
     return _kwargs
@@ -63,6 +72,7 @@ def sync_detailed(
     workspace_name: str,
     *,
     client: Client,
+    count_resources: Union[Unset, bool] = False,
 ) -> Response[Union[Error, Workspace]]:
     """Get workspace details
 
@@ -71,6 +81,7 @@ def sync_detailed(
 
     Args:
         workspace_name (str):
+        count_resources (Union[Unset, bool]):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -82,6 +93,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         workspace_name=workspace_name,
+        count_resources=count_resources,
     )
 
     response = client.get_httpx_client().request(
@@ -95,6 +107,7 @@ def sync(
     workspace_name: str,
     *,
     client: Client,
+    count_resources: Union[Unset, bool] = False,
 ) -> Union[Error, Workspace] | None:
     """Get workspace details
 
@@ -103,6 +116,7 @@ def sync(
 
     Args:
         workspace_name (str):
+        count_resources (Union[Unset, bool]):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -115,6 +129,7 @@ def sync(
     return sync_detailed(
         workspace_name=workspace_name,
         client=client,
+        count_resources=count_resources,
     ).parsed
 
 
@@ -122,6 +137,7 @@ async def asyncio_detailed(
     workspace_name: str,
     *,
     client: Client,
+    count_resources: Union[Unset, bool] = False,
 ) -> Response[Union[Error, Workspace]]:
     """Get workspace details
 
@@ -130,6 +146,7 @@ async def asyncio_detailed(
 
     Args:
         workspace_name (str):
+        count_resources (Union[Unset, bool]):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,6 +158,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         workspace_name=workspace_name,
+        count_resources=count_resources,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -152,6 +170,7 @@ async def asyncio(
     workspace_name: str,
     *,
     client: Client,
+    count_resources: Union[Unset, bool] = False,
 ) -> Union[Error, Workspace] | None:
     """Get workspace details
 
@@ -160,6 +179,7 @@ async def asyncio(
 
     Args:
         workspace_name (str):
+        count_resources (Union[Unset, bool]):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -173,5 +193,6 @@ async def asyncio(
         await asyncio_detailed(
             workspace_name=workspace_name,
             client=client,
+            count_resources=count_resources,
         )
     ).parsed

--- a/src/blaxel/core/client/api/workspaces/get_workspace_features.py
+++ b/src/blaxel/core/client/api/workspaces/get_workspace_features.py
@@ -23,19 +23,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Error, GetWorkspaceFeaturesResponse200] | None:
     if response.status_code == 200:
-        response_200 = GetWorkspaceFeaturesResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = GetWorkspaceFeaturesResponse200.from_dict(_response_content)
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if client.raise_on_unexpected_status:
@@ -66,6 +106,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -92,6 +133,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +156,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -138,6 +181,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/invite_workspace_user.py
+++ b/src/blaxel/core/client/api/workspaces/invite_workspace_user.py
@@ -37,7 +37,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Any, PendingInvitation] | None:
     if response.status_code == 200:
-        response_200 = PendingInvitation.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = PendingInvitation.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
@@ -78,6 +88,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -110,6 +121,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -137,6 +149,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -167,6 +180,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/leave_workspace.py
+++ b/src/blaxel/core/client/api/workspaces/leave_workspace.py
@@ -22,7 +22,17 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, Workspace] | None:
     if response.status_code == 200:
-        response_200 = Workspace.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Workspace.from_dict(_response_content)
 
         return response_200
     if response.status_code == 404:
@@ -57,6 +67,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -88,6 +99,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +126,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -143,6 +156,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/list_workspace_users.py
+++ b/src/blaxel/core/client/api/workspaces/list_workspace_users.py
@@ -20,8 +20,18 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["WorkspaceUser"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = WorkspaceUser.from_dict(response_200_item_data)
 
@@ -54,6 +64,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -80,6 +91,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -102,6 +114,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -126,6 +139,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/list_workspaces.py
+++ b/src/blaxel/core/client/api/workspaces/list_workspaces.py
@@ -23,8 +23,18 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Error, list["Workspace"]] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = Workspace.from_dict(response_200_item_data)
 
@@ -32,11 +42,31 @@ def _parse_response(
 
         return response_200
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -67,6 +97,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -93,6 +124,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -115,6 +147,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -139,6 +172,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/update_workspace.py
+++ b/src/blaxel/core/client/api/workspaces/update_workspace.py
@@ -36,27 +36,87 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error, Workspace] | None:
     if response.status_code == 200:
-        response_200 = Workspace.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = Workspace.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = Error.from_dict(_response_content)
 
         return response_400
     if response.status_code == 401:
-        response_401 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_401 = Error.from_dict(_response_content)
 
         return response_401
     if response.status_code == 403:
-        response_403 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_403 = Error.from_dict(_response_content)
 
         return response_403
     if response.status_code == 404:
-        response_404 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = Error.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = Error.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = Error.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -94,6 +154,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -130,6 +191,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -161,6 +223,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -195,6 +258,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/api/workspaces/update_workspace_user_role.py
+++ b/src/blaxel/core/client/api/workspaces/update_workspace_user_role.py
@@ -38,7 +38,17 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[Any, WorkspaceUser] | None:
     if response.status_code == 200:
-        response_200 = WorkspaceUser.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = WorkspaceUser.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
@@ -80,6 +90,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,6 +125,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -143,6 +155,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -175,6 +188,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/client/errors.py
+++ b/src/blaxel/core/client/errors.py
@@ -13,4 +13,24 @@ class UnexpectedStatus(Exception):
         )
 
 
-__all__ = ["UnexpectedStatus"]
+class ResponseParseError(Exception):
+    """Raised by api functions when a documented response body cannot be parsed"""
+
+    def __init__(self, status_code: int, content: bytes, content_type: str | None = None):
+        self.status_code = status_code
+        self.content = content
+        self.content_type = content_type
+
+        preview = content[:500].decode(errors="replace")
+        if len(content) > 500:
+            preview = f"{preview}..."
+
+        content_type_text = content_type or "unknown content type"
+        super().__init__(
+            "Could not parse response body for documented status code "
+            f"{status_code} as JSON ({content_type_text}).\n\n"
+            f"Response content:\n{preview}"
+        )
+
+
+__all__ = ["ResponseParseError", "UnexpectedStatus"]

--- a/src/blaxel/core/client/models/__init__.py
+++ b/src/blaxel/core/client/models/__init__.py
@@ -1,6 +1,7 @@
 """Contains all the data models used in inputs/outputs"""
 
 from .agent import Agent
+from .agent_list import AgentList
 from .agent_runtime import AgentRuntime
 from .agent_runtime_generation import AgentRuntimeGeneration
 from .agent_spec import AgentSpec
@@ -32,12 +33,14 @@ from .delete_sandbox_preview_token_response_200 import DeleteSandboxPreviewToken
 from .delete_volume_template_version_response_200 import DeleteVolumeTemplateVersionResponse200
 from .delete_workspace_service_account_response_200 import DeleteWorkspaceServiceAccountResponse200
 from .drive import Drive
+from .drive_list import DriveList
 from .drive_spec import DriveSpec
 from .drive_state import DriveState
 from .egress_config import EgressConfig
 from .egress_gateway import EgressGateway
 from .egress_gateway_metadata import EgressGatewayMetadata
 from .egress_gateway_spec import EgressGatewaySpec
+from .egress_gateway_usage import EgressGatewayUsage
 from .egress_ip import EgressIP
 from .egress_ip_metadata import EgressIPMetadata
 from .egress_ip_spec import EgressIPSpec
@@ -58,6 +61,7 @@ from .form import Form
 from .form_config import FormConfig
 from .form_secrets import FormSecrets
 from .function import Function
+from .function_list import FunctionList
 from .function_runtime import FunctionRuntime
 from .function_runtime_generation import FunctionRuntimeGeneration
 from .function_runtime_transport import FunctionRuntimeTransport
@@ -95,6 +99,7 @@ from .integration_repository import IntegrationRepository
 from .invite_workspace_user_body import InviteWorkspaceUserBody
 from .job import Job
 from .job_execution import JobExecution
+from .job_execution_list import JobExecutionList
 from .job_execution_metadata import JobExecutionMetadata
 from .job_execution_spec import JobExecutionSpec
 from .job_execution_spec_env_override import JobExecutionSpecEnvOverride
@@ -102,21 +107,45 @@ from .job_execution_stats import JobExecutionStats
 from .job_execution_status import JobExecutionStatus
 from .job_execution_task import JobExecutionTask
 from .job_execution_task_condition import JobExecutionTaskCondition
+from .job_execution_task_list import JobExecutionTaskList
 from .job_execution_task_metadata import JobExecutionTaskMetadata
 from .job_execution_task_spec import JobExecutionTaskSpec
 from .job_execution_task_status import JobExecutionTaskStatus
+from .job_list import JobList
 from .job_runtime import JobRuntime
 from .job_runtime_generation import JobRuntimeGeneration
 from .job_spec import JobSpec
 from .job_volume import JobVolume
 from .job_volume_type import JobVolumeType
+from .list_agents_anchor import ListAgentsAnchor
+from .list_agents_sort import ListAgentsSort
+from .list_drives_anchor import ListDrivesAnchor
+from .list_drives_sort import ListDrivesSort
+from .list_functions_anchor import ListFunctionsAnchor
+from .list_functions_sort import ListFunctionsSort
+from .list_job_execution_tasks_sort import ListJobExecutionTasksSort
+from .list_job_executions_sort import ListJobExecutionsSort
+from .list_jobs_anchor import ListJobsAnchor
+from .list_jobs_sort import ListJobsSort
+from .list_models_anchor import ListModelsAnchor
+from .list_models_sort import ListModelsSort
 from .list_pending_image_shares_direction import ListPendingImageSharesDirection
+from .list_policies_anchor import ListPoliciesAnchor
+from .list_policies_sort import ListPoliciesSort
+from .list_sandboxes_anchor import ListSandboxesAnchor
+from .list_sandboxes_sort import ListSandboxesSort
+from .list_volumes_anchor import ListVolumesAnchor
+from .list_volumes_sort import ListVolumesSort
+from .lite_volume import LiteVolume
+from .lite_volume_metadata import LiteVolumeMetadata
+from .lite_volume_spec import LiteVolumeSpec
 from .location_response import LocationResponse
 from .mcp_definition import MCPDefinition
 from .mcp_definition_categories_item import MCPDefinitionCategoriesItem
 from .metadata import Metadata
 from .metadata_labels import MetadataLabels
 from .model import Model
+from .model_list import ModelList
 from .model_runtime import ModelRuntime
 from .model_runtime_generation import ModelRuntimeGeneration
 from .model_runtime_type import ModelRuntimeType
@@ -125,6 +154,7 @@ from .network_firewall import NetworkFirewall
 from .o_auth import OAuth
 from .o_auth_scope_item import OAuthScopeItem
 from .owner_fields import OwnerFields
+from .pagination_meta import PaginationMeta
 from .pending_image_share import PendingImageShare
 from .pending_image_share_render import PendingImageShareRender
 from .pending_invitation import PendingInvitation
@@ -138,12 +168,20 @@ from .pending_invitation_workspace_details_emails_item import (
     PendingInvitationWorkspaceDetailsEmailsItem,
 )
 from .policy import Policy
+from .policy_list import PolicyList
 from .policy_location import PolicyLocation
 from .policy_location_type import PolicyLocationType
 from .policy_max_tokens import PolicyMaxTokens
 from .policy_resource_type import PolicyResourceType
 from .policy_spec import PolicySpec
 from .policy_spec_type import PolicySpecType
+from .policy_usage_counts import PolicyUsageCounts
+from .policy_usages import PolicyUsages
+from .policy_usages_agents_item import PolicyUsagesAgentsItem
+from .policy_usages_functions_item import PolicyUsagesFunctionsItem
+from .policy_usages_jobs_item import PolicyUsagesJobsItem
+from .policy_usages_models_item import PolicyUsagesModelsItem
+from .policy_usages_sandboxes_item import PolicyUsagesSandboxesItem
 from .port import Port
 from .port_protocol import PortProtocol
 from .preview import Preview
@@ -173,6 +211,7 @@ from .sandbox_definition_categories_item import SandboxDefinitionCategoriesItem
 from .sandbox_error import SandboxError
 from .sandbox_error_details import SandboxErrorDetails
 from .sandbox_lifecycle import SandboxLifecycle
+from .sandbox_list import SandboxList
 from .sandbox_network import SandboxNetwork
 from .sandbox_runtime import SandboxRuntime
 from .sandbox_runtime_extra_args import SandboxRuntimeExtraArgs
@@ -198,6 +237,7 @@ from .update_workspace_service_account_response_200 import UpdateWorkspaceServic
 from .update_workspace_user_role_body import UpdateWorkspaceUserRoleBody
 from .volume import Volume
 from .volume_attachment import VolumeAttachment
+from .volume_list import VolumeList
 from .volume_spec import VolumeSpec
 from .volume_state import VolumeState
 from .volume_template import VolumeTemplate
@@ -211,6 +251,9 @@ from .vpc_spec import VPCSpec
 from .workspace import Workspace
 from .workspace_availability import WorkspaceAvailability
 from .workspace_availability_reason import WorkspaceAvailabilityReason
+from .workspace_hipaa_info import WorkspaceHipaaInfo
+from .workspace_hipaa_unsafe import WorkspaceHipaaUnsafe
+from .workspace_resource_counts import WorkspaceResourceCounts
 from .workspace_runtime import WorkspaceRuntime
 from .workspace_status import WorkspaceStatus
 from .workspace_user import WorkspaceUser
@@ -218,6 +261,7 @@ from .workspace_user_source import WorkspaceUserSource
 
 __all__ = (
     "Agent",
+    "AgentList",
     "AgentRuntime",
     "AgentRuntimeGeneration",
     "AgentSpec",
@@ -249,12 +293,14 @@ __all__ = (
     "DeleteVolumeTemplateVersionResponse200",
     "DeleteWorkspaceServiceAccountResponse200",
     "Drive",
+    "DriveList",
     "DriveSpec",
     "DriveState",
     "EgressConfig",
     "EgressGateway",
     "EgressGatewayMetadata",
     "EgressGatewaySpec",
+    "EgressGatewayUsage",
     "EgressIP",
     "EgressIPMetadata",
     "EgressIPSpec",
@@ -275,6 +321,7 @@ __all__ = (
     "FormConfig",
     "FormSecrets",
     "Function",
+    "FunctionList",
     "FunctionRuntime",
     "FunctionRuntimeGeneration",
     "FunctionRuntimeTransport",
@@ -310,6 +357,7 @@ __all__ = (
     "InviteWorkspaceUserBody",
     "Job",
     "JobExecution",
+    "JobExecutionList",
     "JobExecutionMetadata",
     "JobExecutionSpec",
     "JobExecutionSpecEnvOverride",
@@ -317,21 +365,45 @@ __all__ = (
     "JobExecutionStatus",
     "JobExecutionTask",
     "JobExecutionTaskCondition",
+    "JobExecutionTaskList",
     "JobExecutionTaskMetadata",
     "JobExecutionTaskSpec",
     "JobExecutionTaskStatus",
+    "JobList",
     "JobRuntime",
     "JobRuntimeGeneration",
     "JobSpec",
     "JobVolume",
     "JobVolumeType",
+    "ListAgentsAnchor",
+    "ListAgentsSort",
+    "ListDrivesAnchor",
+    "ListDrivesSort",
+    "ListFunctionsAnchor",
+    "ListFunctionsSort",
+    "ListJobExecutionsSort",
+    "ListJobExecutionTasksSort",
+    "ListJobsAnchor",
+    "ListJobsSort",
+    "ListModelsAnchor",
+    "ListModelsSort",
     "ListPendingImageSharesDirection",
+    "ListPoliciesAnchor",
+    "ListPoliciesSort",
+    "ListSandboxesAnchor",
+    "ListSandboxesSort",
+    "ListVolumesAnchor",
+    "ListVolumesSort",
+    "LiteVolume",
+    "LiteVolumeMetadata",
+    "LiteVolumeSpec",
     "LocationResponse",
     "MCPDefinition",
     "MCPDefinitionCategoriesItem",
     "Metadata",
     "MetadataLabels",
     "Model",
+    "ModelList",
     "ModelRuntime",
     "ModelRuntimeGeneration",
     "ModelRuntimeType",
@@ -340,6 +412,7 @@ __all__ = (
     "OAuth",
     "OAuthScopeItem",
     "OwnerFields",
+    "PaginationMeta",
     "PendingImageShare",
     "PendingImageShareRender",
     "PendingInvitation",
@@ -351,12 +424,20 @@ __all__ = (
     "PendingInvitationWorkspaceDetails",
     "PendingInvitationWorkspaceDetailsEmailsItem",
     "Policy",
+    "PolicyList",
     "PolicyLocation",
     "PolicyLocationType",
     "PolicyMaxTokens",
     "PolicyResourceType",
     "PolicySpec",
     "PolicySpecType",
+    "PolicyUsageCounts",
+    "PolicyUsages",
+    "PolicyUsagesAgentsItem",
+    "PolicyUsagesFunctionsItem",
+    "PolicyUsagesJobsItem",
+    "PolicyUsagesModelsItem",
+    "PolicyUsagesSandboxesItem",
     "Port",
     "PortProtocol",
     "Preview",
@@ -386,6 +467,7 @@ __all__ = (
     "SandboxError",
     "SandboxErrorDetails",
     "SandboxLifecycle",
+    "SandboxList",
     "SandboxNetwork",
     "SandboxRuntime",
     "SandboxRuntimeExtraArgs",
@@ -411,6 +493,7 @@ __all__ = (
     "UpdateWorkspaceUserRoleBody",
     "Volume",
     "VolumeAttachment",
+    "VolumeList",
     "VolumeSpec",
     "VolumeState",
     "VolumeTemplate",
@@ -424,6 +507,9 @@ __all__ = (
     "Workspace",
     "WorkspaceAvailability",
     "WorkspaceAvailabilityReason",
+    "WorkspaceHipaaInfo",
+    "WorkspaceHipaaUnsafe",
+    "WorkspaceResourceCounts",
     "WorkspaceRuntime",
     "WorkspaceStatus",
     "WorkspaceUser",

--- a/src/blaxel/core/client/models/__init__.py
+++ b/src/blaxel/core/client/models/__init__.py
@@ -28,6 +28,7 @@ from .custom_domain_metadata import CustomDomainMetadata
 from .custom_domain_spec import CustomDomainSpec
 from .custom_domain_spec_status import CustomDomainSpecStatus
 from .custom_domain_spec_txt_records import CustomDomainSpecTxtRecords
+from .custom_domain_subdomain import CustomDomainSubdomain
 from .delete_drive_response_200 import DeleteDriveResponse200
 from .delete_sandbox_preview_token_response_200 import DeleteSandboxPreviewTokenResponse200
 from .delete_volume_template_version_response_200 import DeleteVolumeTemplateVersionResponse200
@@ -55,6 +56,7 @@ from .error import Error
 from .expiration_policy import ExpirationPolicy
 from .expiration_policy_action import ExpirationPolicyAction
 from .expiration_policy_type import ExpirationPolicyType
+from .firewall_config import FirewallConfig
 from .flavor import Flavor
 from .flavor_type import FlavorType
 from .form import Form
@@ -255,6 +257,7 @@ from .workspace_hipaa_info import WorkspaceHipaaInfo
 from .workspace_hipaa_unsafe import WorkspaceHipaaUnsafe
 from .workspace_resource_counts import WorkspaceResourceCounts
 from .workspace_runtime import WorkspaceRuntime
+from .workspace_sandbox_settings import WorkspaceSandboxSettings
 from .workspace_status import WorkspaceStatus
 from .workspace_user import WorkspaceUser
 from .workspace_user_source import WorkspaceUserSource
@@ -288,6 +291,7 @@ __all__ = (
     "CustomDomainSpec",
     "CustomDomainSpecStatus",
     "CustomDomainSpecTxtRecords",
+    "CustomDomainSubdomain",
     "DeleteDriveResponse200",
     "DeleteSandboxPreviewTokenResponse200",
     "DeleteVolumeTemplateVersionResponse200",
@@ -315,6 +319,7 @@ __all__ = (
     "ExpirationPolicy",
     "ExpirationPolicyAction",
     "ExpirationPolicyType",
+    "FirewallConfig",
     "Flavor",
     "FlavorType",
     "Form",
@@ -511,6 +516,7 @@ __all__ = (
     "WorkspaceHipaaUnsafe",
     "WorkspaceResourceCounts",
     "WorkspaceRuntime",
+    "WorkspaceSandboxSettings",
     "WorkspaceStatus",
     "WorkspaceUser",
     "WorkspaceUserSource",

--- a/src/blaxel/core/client/models/agent.py
+++ b/src/blaxel/core/client/models/agent.py
@@ -36,7 +36,6 @@ class Agent:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/agent_list.py
+++ b/src/blaxel/core/client/models/agent_list.py
@@ -56,13 +56,18 @@ class AgentList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+    def from_dict(cls: type[T], src_dict: dict[str, Any] | list[Any]) -> T | None:
         from ..models.agent import Agent
         from ..models.pagination_meta import PaginationMeta
 
-        if not src_dict:
+        if isinstance(src_dict, list):
+            d = {"data": src_dict}
+        elif src_dict is None:
             return None
-        d = src_dict.copy()
+        elif not src_dict:
+            d = {}
+        else:
+            d = src_dict.copy()
         data = []
         _data = d.pop("data", UNSET)
         for data_item_data in _data or []:

--- a/src/blaxel/core/client/models/agent_list.py
+++ b/src/blaxel/core/client/models/agent_list.py
@@ -1,0 +1,102 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent import Agent
+    from ..models.pagination_meta import PaginationMeta
+
+
+T = TypeVar("T", bound="AgentList")
+
+
+@_attrs_define
+class AgentList:
+    """Cursor-paginated list of agents. Returned starting with API version 2026-04-28; older API versions return a bare
+    array of agents instead.
+
+        Attributes:
+            data (Union[Unset, list['Agent']]): Page of agents.
+            meta (Union[Unset, PaginationMeta]): Pagination metadata returned alongside a page of listing results. Always
+                present on listing endpoints starting with API version 2026-04-28.
+    """
+
+    data: Union[Unset, list["Agent"]] = UNSET
+    meta: Union[Unset, "PaginationMeta"] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.data, Unset):
+            data = []
+            for data_item_data in self.data:
+                if type(data_item_data) is dict:
+                    data_item = data_item_data
+                else:
+                    data_item = data_item_data.to_dict()
+                data.append(data_item)
+
+        meta: Union[Unset, dict[str, Any]] = UNSET
+        if self.meta and not isinstance(self.meta, Unset) and not isinstance(self.meta, dict):
+            meta = self.meta.to_dict()
+        elif self.meta and isinstance(self.meta, dict):
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if data is not UNSET:
+            field_dict["data"] = data
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.agent import Agent
+        from ..models.pagination_meta import PaginationMeta
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        data = []
+        _data = d.pop("data", UNSET)
+        for data_item_data in _data or []:
+            data_item = Agent.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        _meta = d.pop("meta", UNSET)
+        meta: Union[Unset, PaginationMeta]
+        if isinstance(_meta, Unset):
+            meta = UNSET
+        else:
+            meta = PaginationMeta.from_dict(_meta)
+
+        agent_list = cls(
+            data=data,
+            meta=meta,
+        )
+
+        agent_list.additional_properties = d
+        return agent_list
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/agent_runtime.py
+++ b/src/blaxel/core/client/models/agent_runtime.py
@@ -41,7 +41,6 @@ class AgentRuntime:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         envs: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.envs, Unset):
             envs = []

--- a/src/blaxel/core/client/models/agent_spec.py
+++ b/src/blaxel/core/client/models/agent_spec.py
@@ -48,7 +48,6 @@ class AgentSpec:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         enabled = self.enabled
 
         policies: Union[Unset, list[str]] = UNSET

--- a/src/blaxel/core/client/models/configuration.py
+++ b/src/blaxel/core/client/models/configuration.py
@@ -22,18 +22,20 @@ class Configuration:
     Attributes:
         continents (Union[Unset, list['Continent']]): Continents
         countries (Union[Unset, list['Country']]): Countries
+        detected_region (Union[Unset, str]): Auto-detected closest region based on viewer geolocation (from CloudFront
+            headers). Empty when geo headers are not available.
         private_locations (Union[Unset, list['PrivateLocation']]): Private locations managed with blaxel operator
         regions (Union[Unset, list['Region']]): Regions
     """
 
     continents: Union[Unset, list["Continent"]] = UNSET
     countries: Union[Unset, list["Country"]] = UNSET
+    detected_region: Union[Unset, str] = UNSET
     private_locations: Union[Unset, list["PrivateLocation"]] = UNSET
     regions: Union[Unset, list["Region"]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         continents: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.continents, Unset):
             continents = []
@@ -53,6 +55,8 @@ class Configuration:
                 else:
                     countries_item = countries_item_data.to_dict()
                 countries.append(countries_item)
+
+        detected_region = self.detected_region
 
         private_locations: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.private_locations, Unset):
@@ -81,6 +85,8 @@ class Configuration:
             field_dict["continents"] = continents
         if countries is not UNSET:
             field_dict["countries"] = countries
+        if detected_region is not UNSET:
+            field_dict["detectedRegion"] = detected_region
         if private_locations is not UNSET:
             field_dict["privateLocations"] = private_locations
         if regions is not UNSET:
@@ -112,6 +118,8 @@ class Configuration:
 
             countries.append(countries_item)
 
+        detected_region = d.pop("detectedRegion", d.pop("detected_region", UNSET))
+
         private_locations = []
         _private_locations = d.pop("privateLocations", d.pop("private_locations", UNSET))
         for private_locations_item_data in _private_locations or []:
@@ -129,6 +137,7 @@ class Configuration:
         configuration = cls(
             continents=continents,
             countries=countries,
+            detected_region=detected_region,
             private_locations=private_locations,
             regions=regions,
         )

--- a/src/blaxel/core/client/models/create_job_execution_output.py
+++ b/src/blaxel/core/client/models/create_job_execution_output.py
@@ -37,7 +37,6 @@ class CreateJobExecutionOutput:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         execution_id = self.execution_id
 
         id = self.id

--- a/src/blaxel/core/client/models/create_job_execution_request.py
+++ b/src/blaxel/core/client/models/create_job_execution_request.py
@@ -40,7 +40,6 @@ class CreateJobExecutionRequest:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         env: Union[Unset, dict[str, Any]] = UNSET
         if self.env and not isinstance(self.env, Unset) and not isinstance(self.env, dict):
             env = self.env.to_dict()

--- a/src/blaxel/core/client/models/custom_domain.py
+++ b/src/blaxel/core/client/models/custom_domain.py
@@ -28,7 +28,6 @@ class CustomDomain:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/custom_domain_metadata.py
+++ b/src/blaxel/core/client/models/custom_domain_metadata.py
@@ -39,7 +39,6 @@ class CustomDomainMetadata:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         created_at = self.created_at
 
         updated_at = self.updated_at

--- a/src/blaxel/core/client/models/custom_domain_spec.py
+++ b/src/blaxel/core/client/models/custom_domain_spec.py
@@ -37,7 +37,6 @@ class CustomDomainSpec:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         cname_records = self.cname_records
 
         last_verified_at = self.last_verified_at

--- a/src/blaxel/core/client/models/custom_domain_spec.py
+++ b/src/blaxel/core/client/models/custom_domain_spec.py
@@ -8,6 +8,7 @@ from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
     from ..models.custom_domain_spec_txt_records import CustomDomainSpecTxtRecords
+    from ..models.custom_domain_subdomain import CustomDomainSubdomain
 
 
 T = TypeVar("T", bound="CustomDomainSpec")
@@ -19,25 +20,33 @@ class CustomDomainSpec:
 
     Attributes:
         cname_records (Union[Unset, str]): CNAME target for the domain
+        fallback_preview_id (Union[Unset, str]): Preview ID to route to when a preview lookup fails on this custom
+            domain Example: my-fallback-preview.
         last_verified_at (Union[Unset, str]): Last verification attempt timestamp
         region (Union[Unset, str]): Region that the custom domain is associated with Example: us-pdx-1.
         status (Union[Unset, CustomDomainSpecStatus]): Current status of the domain (pending, verified, failed) Example:
             verified.
+        subdomains (Union[Unset, list['CustomDomainSubdomain']]): List of subdomains (previews) currently using this
+            custom domain. Only populated on GET /customdomains/{domainName}.
         txt_records (Union[Unset, CustomDomainSpecTxtRecords]): Map of TXT record names to values for domain
             verification
         verification_error (Union[Unset, str]): Error message if verification failed
     """
 
     cname_records: Union[Unset, str] = UNSET
+    fallback_preview_id: Union[Unset, str] = UNSET
     last_verified_at: Union[Unset, str] = UNSET
     region: Union[Unset, str] = UNSET
     status: Union[Unset, CustomDomainSpecStatus] = UNSET
+    subdomains: Union[Unset, list["CustomDomainSubdomain"]] = UNSET
     txt_records: Union[Unset, "CustomDomainSpecTxtRecords"] = UNSET
     verification_error: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         cname_records = self.cname_records
+
+        fallback_preview_id = self.fallback_preview_id
 
         last_verified_at = self.last_verified_at
 
@@ -46,6 +55,16 @@ class CustomDomainSpec:
         status: Union[Unset, str] = UNSET
         if not isinstance(self.status, Unset):
             status = self.status.value
+
+        subdomains: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.subdomains, Unset):
+            subdomains = []
+            for subdomains_item_data in self.subdomains:
+                if type(subdomains_item_data) is dict:
+                    subdomains_item = subdomains_item_data
+                else:
+                    subdomains_item = subdomains_item_data.to_dict()
+                subdomains.append(subdomains_item)
 
         txt_records: Union[Unset, dict[str, Any]] = UNSET
         if (
@@ -64,12 +83,16 @@ class CustomDomainSpec:
         field_dict.update({})
         if cname_records is not UNSET:
             field_dict["cnameRecords"] = cname_records
+        if fallback_preview_id is not UNSET:
+            field_dict["fallbackPreviewId"] = fallback_preview_id
         if last_verified_at is not UNSET:
             field_dict["lastVerifiedAt"] = last_verified_at
         if region is not UNSET:
             field_dict["region"] = region
         if status is not UNSET:
             field_dict["status"] = status
+        if subdomains is not UNSET:
+            field_dict["subdomains"] = subdomains
         if txt_records is not UNSET:
             field_dict["txtRecords"] = txt_records
         if verification_error is not UNSET:
@@ -80,11 +103,14 @@ class CustomDomainSpec:
     @classmethod
     def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
         from ..models.custom_domain_spec_txt_records import CustomDomainSpecTxtRecords
+        from ..models.custom_domain_subdomain import CustomDomainSubdomain
 
         if not src_dict:
             return None
         d = src_dict.copy()
         cname_records = d.pop("cnameRecords", d.pop("cname_records", UNSET))
+
+        fallback_preview_id = d.pop("fallbackPreviewId", d.pop("fallback_preview_id", UNSET))
 
         last_verified_at = d.pop("lastVerifiedAt", d.pop("last_verified_at", UNSET))
 
@@ -97,6 +123,13 @@ class CustomDomainSpec:
         else:
             status = CustomDomainSpecStatus(_status)
 
+        subdomains = []
+        _subdomains = d.pop("subdomains", UNSET)
+        for subdomains_item_data in _subdomains or []:
+            subdomains_item = CustomDomainSubdomain.from_dict(subdomains_item_data)
+
+            subdomains.append(subdomains_item)
+
         _txt_records = d.pop("txtRecords", d.pop("txt_records", UNSET))
         txt_records: Union[Unset, CustomDomainSpecTxtRecords]
         if isinstance(_txt_records, Unset):
@@ -108,9 +141,11 @@ class CustomDomainSpec:
 
         custom_domain_spec = cls(
             cname_records=cname_records,
+            fallback_preview_id=fallback_preview_id,
             last_verified_at=last_verified_at,
             region=region,
             status=status,
+            subdomains=subdomains,
             txt_records=txt_records,
             verification_error=verification_error,
         )

--- a/src/blaxel/core/client/models/custom_domain_subdomain.py
+++ b/src/blaxel/core/client/models/custom_domain_subdomain.py
@@ -1,0 +1,97 @@
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CustomDomainSubdomain")
+
+
+@_attrs_define
+class CustomDomainSubdomain:
+    """A subdomain (preview) using a custom domain
+
+    Attributes:
+        preview_name (Union[Unset, str]): Preview name
+        resource_name (Union[Unset, str]): Resource name
+        resource_type (Union[Unset, str]): Resource type (e.g., sandbox)
+        subdomain (Union[Unset, str]): Subdomain prefix used for routing
+        url (Union[Unset, str]): Full URL of the preview on this custom domain
+    """
+
+    preview_name: Union[Unset, str] = UNSET
+    resource_name: Union[Unset, str] = UNSET
+    resource_type: Union[Unset, str] = UNSET
+    subdomain: Union[Unset, str] = UNSET
+    url: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        preview_name = self.preview_name
+
+        resource_name = self.resource_name
+
+        resource_type = self.resource_type
+
+        subdomain = self.subdomain
+
+        url = self.url
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if preview_name is not UNSET:
+            field_dict["previewName"] = preview_name
+        if resource_name is not UNSET:
+            field_dict["resourceName"] = resource_name
+        if resource_type is not UNSET:
+            field_dict["resourceType"] = resource_type
+        if subdomain is not UNSET:
+            field_dict["subdomain"] = subdomain
+        if url is not UNSET:
+            field_dict["url"] = url
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        preview_name = d.pop("previewName", d.pop("preview_name", UNSET))
+
+        resource_name = d.pop("resourceName", d.pop("resource_name", UNSET))
+
+        resource_type = d.pop("resourceType", d.pop("resource_type", UNSET))
+
+        subdomain = d.pop("subdomain", UNSET)
+
+        url = d.pop("url", UNSET)
+
+        custom_domain_subdomain = cls(
+            preview_name=preview_name,
+            resource_name=resource_name,
+            resource_type=resource_type,
+            subdomain=subdomain,
+            url=url,
+        )
+
+        custom_domain_subdomain.additional_properties = d
+        return custom_domain_subdomain
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/delete_volume_template_version_response_200.py
+++ b/src/blaxel/core/client/models/delete_volume_template_version_response_200.py
@@ -25,7 +25,6 @@ class DeleteVolumeTemplateVersionResponse200:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         message = self.message
 
         template: Union[Unset, dict[str, Any]] = UNSET

--- a/src/blaxel/core/client/models/drive.py
+++ b/src/blaxel/core/client/models/drive.py
@@ -37,7 +37,6 @@ class Drive:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/drive_list.py
+++ b/src/blaxel/core/client/models/drive_list.py
@@ -1,0 +1,102 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.drive import Drive
+    from ..models.pagination_meta import PaginationMeta
+
+
+T = TypeVar("T", bound="DriveList")
+
+
+@_attrs_define
+class DriveList:
+    """Cursor-paginated list of drives. Returned starting with API version 2026-04-28; older API versions return a bare
+    array.
+
+        Attributes:
+            data (Union[Unset, list['Drive']]): Page of drives.
+            meta (Union[Unset, PaginationMeta]): Pagination metadata returned alongside a page of listing results. Always
+                present on listing endpoints starting with API version 2026-04-28.
+    """
+
+    data: Union[Unset, list["Drive"]] = UNSET
+    meta: Union[Unset, "PaginationMeta"] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.data, Unset):
+            data = []
+            for data_item_data in self.data:
+                if type(data_item_data) is dict:
+                    data_item = data_item_data
+                else:
+                    data_item = data_item_data.to_dict()
+                data.append(data_item)
+
+        meta: Union[Unset, dict[str, Any]] = UNSET
+        if self.meta and not isinstance(self.meta, Unset) and not isinstance(self.meta, dict):
+            meta = self.meta.to_dict()
+        elif self.meta and isinstance(self.meta, dict):
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if data is not UNSET:
+            field_dict["data"] = data
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.drive import Drive
+        from ..models.pagination_meta import PaginationMeta
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        data = []
+        _data = d.pop("data", UNSET)
+        for data_item_data in _data or []:
+            data_item = Drive.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        _meta = d.pop("meta", UNSET)
+        meta: Union[Unset, PaginationMeta]
+        if isinstance(_meta, Unset):
+            meta = UNSET
+        else:
+            meta = PaginationMeta.from_dict(_meta)
+
+        drive_list = cls(
+            data=data,
+            meta=meta,
+        )
+
+        drive_list.additional_properties = d
+        return drive_list
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/drive_list.py
+++ b/src/blaxel/core/client/models/drive_list.py
@@ -56,13 +56,18 @@ class DriveList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+    def from_dict(cls: type[T], src_dict: dict[str, Any] | list[Any]) -> T | None:
         from ..models.drive import Drive
         from ..models.pagination_meta import PaginationMeta
 
-        if not src_dict:
+        if isinstance(src_dict, list):
+            d = {"data": src_dict}
+        elif src_dict is None:
             return None
-        d = src_dict.copy()
+        elif not src_dict:
+            d = {}
+        else:
+            d = src_dict.copy()
         data = []
         _data = d.pop("data", UNSET)
         for data_item_data in _data or []:

--- a/src/blaxel/core/client/models/egress_config.py
+++ b/src/blaxel/core/client/models/egress_config.py
@@ -29,7 +29,6 @@ class EgressConfig:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         gateway = self.gateway
 
         mode = self.mode

--- a/src/blaxel/core/client/models/egress_gateway.py
+++ b/src/blaxel/core/client/models/egress_gateway.py
@@ -34,7 +34,6 @@ class EgressGateway:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/egress_gateway_usage.py
+++ b/src/blaxel/core/client/models/egress_gateway_usage.py
@@ -1,0 +1,56 @@
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="EgressGatewayUsage")
+
+
+@_attrs_define
+class EgressGatewayUsage:
+    """Sandboxes currently bound to each egress gateway. Returned by GET /egressgateways/usage so the egress-IPs UI can
+    render attachment counts without fetching the sandboxes listing full. Keys are gateway names; values are sandbox
+    names.
+
+    """
+
+    additional_properties: dict[str, list[str]] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        for prop_name, prop in self.additional_properties.items():
+            field_dict[prop_name] = prop
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        egress_gateway_usage = cls()
+
+        additional_properties = {}
+        for prop_name, prop_dict in d.items():
+            additional_property = cast(list[str], prop_dict)
+
+            additional_properties[prop_name] = additional_property
+
+        egress_gateway_usage.additional_properties = additional_properties
+        return egress_gateway_usage
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> list[str]:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: list[str]) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/egress_ip.py
+++ b/src/blaxel/core/client/models/egress_ip.py
@@ -33,7 +33,6 @@ class EgressIP:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/entrypoint.py
+++ b/src/blaxel/core/client/models/entrypoint.py
@@ -32,7 +32,6 @@ class Entrypoint:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         args: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.args, Unset):
             args = []

--- a/src/blaxel/core/client/models/firewall_config.py
+++ b/src/blaxel/core/client/models/firewall_config.py
@@ -1,0 +1,66 @@
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="FirewallConfig")
+
+
+@_attrs_define
+class FirewallConfig:
+    """Firewall configuration specifying which network lockdown rulesets to apply. Valid rulesets are "default" (no-op),
+    "proxy" (restrict egress to proxy), and "dedicated-ip" (restrict egress to dedicated IP gateway).
+
+        Attributes:
+            rulesets (Union[Unset, list[str]]): List of firewall rulesets to apply. Valid values: "default" (no-op), "proxy"
+                (restrict egress to proxy), "dedicated-ip" (restrict egress to dedicated IP gateway). Example: ["proxy",
+                "dedicated-ip"].
+    """
+
+    rulesets: Union[Unset, list[str]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        rulesets: Union[Unset, list[str]] = UNSET
+        if not isinstance(self.rulesets, Unset):
+            rulesets = self.rulesets
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if rulesets is not UNSET:
+            field_dict["rulesets"] = rulesets
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        rulesets = cast(list[str], d.pop("rulesets", UNSET))
+
+        firewall_config = cls(
+            rulesets=rulesets,
+        )
+
+        firewall_config.additional_properties = d
+        return firewall_config
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/form.py
+++ b/src/blaxel/core/client/models/form.py
@@ -30,7 +30,6 @@ class Form:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         config: Union[Unset, dict[str, Any]] = UNSET
         if self.config and not isinstance(self.config, Unset) and not isinstance(self.config, dict):
             config = self.config.to_dict()

--- a/src/blaxel/core/client/models/function.py
+++ b/src/blaxel/core/client/models/function.py
@@ -36,7 +36,6 @@ class Function:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/function_list.py
+++ b/src/blaxel/core/client/models/function_list.py
@@ -56,13 +56,18 @@ class FunctionList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+    def from_dict(cls: type[T], src_dict: dict[str, Any] | list[Any]) -> T | None:
         from ..models.function import Function
         from ..models.pagination_meta import PaginationMeta
 
-        if not src_dict:
+        if isinstance(src_dict, list):
+            d = {"data": src_dict}
+        elif src_dict is None:
             return None
-        d = src_dict.copy()
+        elif not src_dict:
+            d = {}
+        else:
+            d = src_dict.copy()
         data = []
         _data = d.pop("data", UNSET)
         for data_item_data in _data or []:

--- a/src/blaxel/core/client/models/function_list.py
+++ b/src/blaxel/core/client/models/function_list.py
@@ -1,0 +1,102 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.function import Function
+    from ..models.pagination_meta import PaginationMeta
+
+
+T = TypeVar("T", bound="FunctionList")
+
+
+@_attrs_define
+class FunctionList:
+    """Cursor-paginated list of MCP server functions. Returned starting with API version 2026-04-28; older API versions
+    return a bare array.
+
+        Attributes:
+            data (Union[Unset, list['Function']]): Page of functions.
+            meta (Union[Unset, PaginationMeta]): Pagination metadata returned alongside a page of listing results. Always
+                present on listing endpoints starting with API version 2026-04-28.
+    """
+
+    data: Union[Unset, list["Function"]] = UNSET
+    meta: Union[Unset, "PaginationMeta"] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.data, Unset):
+            data = []
+            for data_item_data in self.data:
+                if type(data_item_data) is dict:
+                    data_item = data_item_data
+                else:
+                    data_item = data_item_data.to_dict()
+                data.append(data_item)
+
+        meta: Union[Unset, dict[str, Any]] = UNSET
+        if self.meta and not isinstance(self.meta, Unset) and not isinstance(self.meta, dict):
+            meta = self.meta.to_dict()
+        elif self.meta and isinstance(self.meta, dict):
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if data is not UNSET:
+            field_dict["data"] = data
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.function import Function
+        from ..models.pagination_meta import PaginationMeta
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        data = []
+        _data = d.pop("data", UNSET)
+        for data_item_data in _data or []:
+            data_item = Function.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        _meta = d.pop("meta", UNSET)
+        meta: Union[Unset, PaginationMeta]
+        if isinstance(_meta, Unset):
+            meta = UNSET
+        else:
+            meta = PaginationMeta.from_dict(_meta)
+
+        function_list = cls(
+            data=data,
+            meta=meta,
+        )
+
+        function_list.additional_properties = d
+        return function_list
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/function_runtime.py
+++ b/src/blaxel/core/client/models/function_runtime.py
@@ -44,7 +44,6 @@ class FunctionRuntime:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         envs: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.envs, Unset):
             envs = []

--- a/src/blaxel/core/client/models/function_spec.py
+++ b/src/blaxel/core/client/models/function_spec.py
@@ -44,7 +44,6 @@ class FunctionSpec:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         enabled = self.enabled
 
         integration_connections: Union[Unset, list[str]] = UNSET

--- a/src/blaxel/core/client/models/get_drive_jwks_response_200.py
+++ b/src/blaxel/core/client/models/get_drive_jwks_response_200.py
@@ -23,7 +23,6 @@ class GetDriveJWKSResponse200:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         keys: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.keys, Unset):
             keys = []

--- a/src/blaxel/core/client/models/get_workspace_features_response_200.py
+++ b/src/blaxel/core/client/models/get_workspace_features_response_200.py
@@ -26,7 +26,6 @@ class GetWorkspaceFeaturesResponse200:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         features: Union[Unset, dict[str, Any]] = UNSET
         if (
             self.features

--- a/src/blaxel/core/client/models/image.py
+++ b/src/blaxel/core/client/models/image.py
@@ -24,7 +24,6 @@ class Image:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/image_metadata.py
+++ b/src/blaxel/core/client/models/image_metadata.py
@@ -44,7 +44,6 @@ class ImageMetadata:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         created_at = self.created_at
 
         display_name = self.display_name

--- a/src/blaxel/core/client/models/image_spec.py
+++ b/src/blaxel/core/client/models/image_spec.py
@@ -25,7 +25,6 @@ class ImageSpec:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         size = self.size
 
         tags: Union[Unset, list[dict[str, Any]]] = UNSET

--- a/src/blaxel/core/client/models/integration.py
+++ b/src/blaxel/core/client/models/integration.py
@@ -41,7 +41,6 @@ class Integration:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         additional_infos: Union[Unset, dict[str, Any]] = UNSET
         if (
             self.additional_infos

--- a/src/blaxel/core/client/models/integration_connection.py
+++ b/src/blaxel/core/client/models/integration_connection.py
@@ -28,7 +28,6 @@ class IntegrationConnection:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/integration_connection_spec.py
+++ b/src/blaxel/core/client/models/integration_connection_spec.py
@@ -34,7 +34,6 @@ class IntegrationConnectionSpec:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         config: Union[Unset, dict[str, Any]] = UNSET
         if self.config and not isinstance(self.config, Unset) and not isinstance(self.config, dict):
             config = self.config.to_dict()

--- a/src/blaxel/core/client/models/integration_endpoint.py
+++ b/src/blaxel/core/client/models/integration_endpoint.py
@@ -38,7 +38,6 @@ class IntegrationEndpoint:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         body = self.body
 
         ignore_models: Union[Unset, list[dict[str, Any]]] = UNSET

--- a/src/blaxel/core/client/models/integration_endpoints.py
+++ b/src/blaxel/core/client/models/integration_endpoints.py
@@ -17,7 +17,6 @@ class IntegrationEndpoints:
     additional_properties: dict[str, "IntegrationEndpoint"] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
             if type(prop) is dict:
@@ -35,7 +34,6 @@ class IntegrationEndpoints:
             return None
         d = src_dict.copy()
         integration_endpoints = cls()
-
 
         additional_properties = {}
         for prop_name, prop_dict in d.items():

--- a/src/blaxel/core/client/models/job.py
+++ b/src/blaxel/core/client/models/job.py
@@ -36,7 +36,6 @@ class Job:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/job_execution.py
+++ b/src/blaxel/core/client/models/job_execution.py
@@ -36,7 +36,6 @@ class JobExecution:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/job_execution_list.py
+++ b/src/blaxel/core/client/models/job_execution_list.py
@@ -1,0 +1,102 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.job_execution import JobExecution
+    from ..models.pagination_meta import PaginationMeta
+
+
+T = TypeVar("T", bound="JobExecutionList")
+
+
+@_attrs_define
+class JobExecutionList:
+    """Cursor-paginated list of job executions. Returned starting with API version 2026-04-28; older API versions keep the
+    legacy offset-based contract and return a bare array.
+
+        Attributes:
+            data (Union[Unset, list['JobExecution']]): Page of job executions.
+            meta (Union[Unset, PaginationMeta]): Pagination metadata returned alongside a page of listing results. Always
+                present on listing endpoints starting with API version 2026-04-28.
+    """
+
+    data: Union[Unset, list["JobExecution"]] = UNSET
+    meta: Union[Unset, "PaginationMeta"] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.data, Unset):
+            data = []
+            for data_item_data in self.data:
+                if type(data_item_data) is dict:
+                    data_item = data_item_data
+                else:
+                    data_item = data_item_data.to_dict()
+                data.append(data_item)
+
+        meta: Union[Unset, dict[str, Any]] = UNSET
+        if self.meta and not isinstance(self.meta, Unset) and not isinstance(self.meta, dict):
+            meta = self.meta.to_dict()
+        elif self.meta and isinstance(self.meta, dict):
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if data is not UNSET:
+            field_dict["data"] = data
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.job_execution import JobExecution
+        from ..models.pagination_meta import PaginationMeta
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        data = []
+        _data = d.pop("data", UNSET)
+        for data_item_data in _data or []:
+            data_item = JobExecution.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        _meta = d.pop("meta", UNSET)
+        meta: Union[Unset, PaginationMeta]
+        if isinstance(_meta, Unset):
+            meta = UNSET
+        else:
+            meta = PaginationMeta.from_dict(_meta)
+
+        job_execution_list = cls(
+            data=data,
+            meta=meta,
+        )
+
+        job_execution_list.additional_properties = d
+        return job_execution_list
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/job_execution_list.py
+++ b/src/blaxel/core/client/models/job_execution_list.py
@@ -56,13 +56,18 @@ class JobExecutionList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+    def from_dict(cls: type[T], src_dict: dict[str, Any] | list[Any]) -> T | None:
         from ..models.job_execution import JobExecution
         from ..models.pagination_meta import PaginationMeta
 
-        if not src_dict:
+        if isinstance(src_dict, list):
+            d = {"data": src_dict}
+        elif src_dict is None:
             return None
-        d = src_dict.copy()
+        elif not src_dict:
+            d = {}
+        else:
+            d = src_dict.copy()
         data = []
         _data = d.pop("data", UNSET)
         for data_item_data in _data or []:

--- a/src/blaxel/core/client/models/job_execution_spec.py
+++ b/src/blaxel/core/client/models/job_execution_spec.py
@@ -35,7 +35,6 @@ class JobExecutionSpec:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         env_override: Union[Unset, dict[str, Any]] = UNSET
         if (
             self.env_override

--- a/src/blaxel/core/client/models/job_execution_task.py
+++ b/src/blaxel/core/client/models/job_execution_task.py
@@ -33,7 +33,6 @@ class JobExecutionTask:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         conditions: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.conditions, Unset):
             conditions = []

--- a/src/blaxel/core/client/models/job_execution_task_list.py
+++ b/src/blaxel/core/client/models/job_execution_task_list.py
@@ -1,0 +1,102 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.job_execution_task import JobExecutionTask
+    from ..models.pagination_meta import PaginationMeta
+
+
+T = TypeVar("T", bound="JobExecutionTaskList")
+
+
+@_attrs_define
+class JobExecutionTaskList:
+    """Cursor-paginated list of an execution's tasks. Tasks are derived from event history; pagination slices the in-memory
+    list and the cursor is a base64-JSON offset bound to (workspace, job, execution).
+
+        Attributes:
+            data (Union[Unset, list['JobExecutionTask']]): Page of execution tasks.
+            meta (Union[Unset, PaginationMeta]): Pagination metadata returned alongside a page of listing results. Always
+                present on listing endpoints starting with API version 2026-04-28.
+    """
+
+    data: Union[Unset, list["JobExecutionTask"]] = UNSET
+    meta: Union[Unset, "PaginationMeta"] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.data, Unset):
+            data = []
+            for data_item_data in self.data:
+                if type(data_item_data) is dict:
+                    data_item = data_item_data
+                else:
+                    data_item = data_item_data.to_dict()
+                data.append(data_item)
+
+        meta: Union[Unset, dict[str, Any]] = UNSET
+        if self.meta and not isinstance(self.meta, Unset) and not isinstance(self.meta, dict):
+            meta = self.meta.to_dict()
+        elif self.meta and isinstance(self.meta, dict):
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if data is not UNSET:
+            field_dict["data"] = data
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.job_execution_task import JobExecutionTask
+        from ..models.pagination_meta import PaginationMeta
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        data = []
+        _data = d.pop("data", UNSET)
+        for data_item_data in _data or []:
+            data_item = JobExecutionTask.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        _meta = d.pop("meta", UNSET)
+        meta: Union[Unset, PaginationMeta]
+        if isinstance(_meta, Unset):
+            meta = UNSET
+        else:
+            meta = PaginationMeta.from_dict(_meta)
+
+        job_execution_task_list = cls(
+            data=data,
+            meta=meta,
+        )
+
+        job_execution_task_list.additional_properties = d
+        return job_execution_task_list
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/job_execution_task_list.py
+++ b/src/blaxel/core/client/models/job_execution_task_list.py
@@ -56,13 +56,18 @@ class JobExecutionTaskList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+    def from_dict(cls: type[T], src_dict: dict[str, Any] | list[Any]) -> T | None:
         from ..models.job_execution_task import JobExecutionTask
         from ..models.pagination_meta import PaginationMeta
 
-        if not src_dict:
+        if isinstance(src_dict, list):
+            d = {"data": src_dict}
+        elif src_dict is None:
             return None
-        d = src_dict.copy()
+        elif not src_dict:
+            d = {}
+        else:
+            d = src_dict.copy()
         data = []
         _data = d.pop("data", UNSET)
         for data_item_data in _data or []:

--- a/src/blaxel/core/client/models/job_list.py
+++ b/src/blaxel/core/client/models/job_list.py
@@ -56,13 +56,18 @@ class JobList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+    def from_dict(cls: type[T], src_dict: dict[str, Any] | list[Any]) -> T | None:
         from ..models.job import Job
         from ..models.pagination_meta import PaginationMeta
 
-        if not src_dict:
+        if isinstance(src_dict, list):
+            d = {"data": src_dict}
+        elif src_dict is None:
             return None
-        d = src_dict.copy()
+        elif not src_dict:
+            d = {}
+        else:
+            d = src_dict.copy()
         data = []
         _data = d.pop("data", UNSET)
         for data_item_data in _data or []:

--- a/src/blaxel/core/client/models/job_list.py
+++ b/src/blaxel/core/client/models/job_list.py
@@ -1,0 +1,102 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.job import Job
+    from ..models.pagination_meta import PaginationMeta
+
+
+T = TypeVar("T", bound="JobList")
+
+
+@_attrs_define
+class JobList:
+    """Cursor-paginated list of batch jobs. Returned starting with API version 2026-04-28; older API versions return a bare
+    array.
+
+        Attributes:
+            data (Union[Unset, list['Job']]): Page of jobs.
+            meta (Union[Unset, PaginationMeta]): Pagination metadata returned alongside a page of listing results. Always
+                present on listing endpoints starting with API version 2026-04-28.
+    """
+
+    data: Union[Unset, list["Job"]] = UNSET
+    meta: Union[Unset, "PaginationMeta"] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.data, Unset):
+            data = []
+            for data_item_data in self.data:
+                if type(data_item_data) is dict:
+                    data_item = data_item_data
+                else:
+                    data_item = data_item_data.to_dict()
+                data.append(data_item)
+
+        meta: Union[Unset, dict[str, Any]] = UNSET
+        if self.meta and not isinstance(self.meta, Unset) and not isinstance(self.meta, dict):
+            meta = self.meta.to_dict()
+        elif self.meta and isinstance(self.meta, dict):
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if data is not UNSET:
+            field_dict["data"] = data
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.job import Job
+        from ..models.pagination_meta import PaginationMeta
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        data = []
+        _data = d.pop("data", UNSET)
+        for data_item_data in _data or []:
+            data_item = Job.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        _meta = d.pop("meta", UNSET)
+        meta: Union[Unset, PaginationMeta]
+        if isinstance(_meta, Unset):
+            meta = UNSET
+        else:
+            meta = PaginationMeta.from_dict(_meta)
+
+        job_list = cls(
+            data=data,
+            meta=meta,
+        )
+
+        job_list.additional_properties = d
+        return job_list
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/job_runtime.py
+++ b/src/blaxel/core/client/models/job_runtime.py
@@ -46,7 +46,6 @@ class JobRuntime:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         disk_percent = self.disk_percent
 
         envs: Union[Unset, list[dict[str, Any]]] = UNSET

--- a/src/blaxel/core/client/models/job_spec.py
+++ b/src/blaxel/core/client/models/job_spec.py
@@ -46,7 +46,6 @@ class JobSpec:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         enabled = self.enabled
 
         github_runner: Union[Unset, dict[str, Any]] = UNSET

--- a/src/blaxel/core/client/models/list_agents_anchor.py
+++ b/src/blaxel/core/client/models/list_agents_anchor.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class ListAgentsAnchor(str, Enum):
+    END = "end"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListAgentsAnchor | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_agents_sort.py
+++ b/src/blaxel/core/client/models/list_agents_sort.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class ListAgentsSort(str, Enum):
+    CREATEDATASC = "createdAt:asc"
+    CREATEDATDESC = "createdAt:desc"
+    NAMEASC = "name:asc"
+    NAMEDESC = "name:desc"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListAgentsSort | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_drives_anchor.py
+++ b/src/blaxel/core/client/models/list_drives_anchor.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class ListDrivesAnchor(str, Enum):
+    END = "end"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListDrivesAnchor | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_drives_sort.py
+++ b/src/blaxel/core/client/models/list_drives_sort.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class ListDrivesSort(str, Enum):
+    CREATEDATASC = "createdAt:asc"
+    CREATEDATDESC = "createdAt:desc"
+    NAMEASC = "name:asc"
+    NAMEDESC = "name:desc"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListDrivesSort | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_functions_anchor.py
+++ b/src/blaxel/core/client/models/list_functions_anchor.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class ListFunctionsAnchor(str, Enum):
+    END = "end"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListFunctionsAnchor | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_functions_sort.py
+++ b/src/blaxel/core/client/models/list_functions_sort.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class ListFunctionsSort(str, Enum):
+    CREATEDATASC = "createdAt:asc"
+    CREATEDATDESC = "createdAt:desc"
+    NAMEASC = "name:asc"
+    NAMEDESC = "name:desc"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListFunctionsSort | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_job_execution_tasks_sort.py
+++ b/src/blaxel/core/client/models/list_job_execution_tasks_sort.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class ListJobExecutionTasksSort(str, Enum):
+    CREATEDATASC = "createdAt:asc"
+    CREATEDATDESC = "createdAt:desc"
+    NAMEASC = "name:asc"
+    NAMEDESC = "name:desc"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListJobExecutionTasksSort | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_job_executions_sort.py
+++ b/src/blaxel/core/client/models/list_job_executions_sort.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class ListJobExecutionsSort(str, Enum):
+    CREATEDATASC = "createdAt:asc"
+    CREATEDATDESC = "createdAt:desc"
+    NAMEASC = "name:asc"
+    NAMEDESC = "name:desc"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListJobExecutionsSort | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_jobs_anchor.py
+++ b/src/blaxel/core/client/models/list_jobs_anchor.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class ListJobsAnchor(str, Enum):
+    END = "end"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListJobsAnchor | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_jobs_sort.py
+++ b/src/blaxel/core/client/models/list_jobs_sort.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class ListJobsSort(str, Enum):
+    CREATEDATASC = "createdAt:asc"
+    CREATEDATDESC = "createdAt:desc"
+    NAMEASC = "name:asc"
+    NAMEDESC = "name:desc"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListJobsSort | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_models_anchor.py
+++ b/src/blaxel/core/client/models/list_models_anchor.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class ListModelsAnchor(str, Enum):
+    END = "end"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListModelsAnchor | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_models_sort.py
+++ b/src/blaxel/core/client/models/list_models_sort.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class ListModelsSort(str, Enum):
+    CREATEDATASC = "createdAt:asc"
+    CREATEDATDESC = "createdAt:desc"
+    NAMEASC = "name:asc"
+    NAMEDESC = "name:desc"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListModelsSort | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_policies_anchor.py
+++ b/src/blaxel/core/client/models/list_policies_anchor.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class ListPoliciesAnchor(str, Enum):
+    END = "end"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListPoliciesAnchor | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_policies_sort.py
+++ b/src/blaxel/core/client/models/list_policies_sort.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class ListPoliciesSort(str, Enum):
+    CREATEDATASC = "createdAt:asc"
+    CREATEDATDESC = "createdAt:desc"
+    NAMEASC = "name:asc"
+    NAMEDESC = "name:desc"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListPoliciesSort | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_sandboxes_anchor.py
+++ b/src/blaxel/core/client/models/list_sandboxes_anchor.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class ListSandboxesAnchor(str, Enum):
+    END = "end"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListSandboxesAnchor | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_sandboxes_sort.py
+++ b/src/blaxel/core/client/models/list_sandboxes_sort.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class ListSandboxesSort(str, Enum):
+    CREATEDATASC = "createdAt:asc"
+    CREATEDATDESC = "createdAt:desc"
+    NAMEASC = "name:asc"
+    NAMEDESC = "name:desc"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListSandboxesSort | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_volumes_anchor.py
+++ b/src/blaxel/core/client/models/list_volumes_anchor.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class ListVolumesAnchor(str, Enum):
+    END = "end"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListVolumesAnchor | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/list_volumes_sort.py
+++ b/src/blaxel/core/client/models/list_volumes_sort.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class ListVolumesSort(str, Enum):
+    CREATEDATASC = "createdAt:asc"
+    CREATEDATDESC = "createdAt:desc"
+    NAMEASC = "name:asc"
+    NAMEDESC = "name:desc"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ListVolumesSort | None":
+        if isinstance(value, str):
+            upper_value = value.upper()
+            for member in cls:
+                if member.value.upper() == upper_value:
+                    return member
+        return None

--- a/src/blaxel/core/client/models/lite_volume.py
+++ b/src/blaxel/core/client/models/lite_volume.py
@@ -1,0 +1,138 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.lite_volume_metadata import LiteVolumeMetadata
+    from ..models.lite_volume_spec import LiteVolumeSpec
+    from ..models.volume_state import VolumeState
+
+
+T = TypeVar("T", bound="LiteVolume")
+
+
+@_attrs_define
+class LiteVolume:
+    """LiteVolume is the listing-shape projection of a Volume. Drops events to keep page payloads small.
+
+    Attributes:
+        metadata (Union[Unset, LiteVolumeMetadata]): Compact metadata for a Volume, returned in listing responses.
+        spec (Union[Unset, LiteVolumeSpec]): Compact spec for a Volume, returned in listing responses.
+        state (Union[Unset, VolumeState]): Current runtime state of the volume including attachment status
+        status (Union[Unset, str]): Computed status of the volume.
+        terminated_at (Union[Unset, str]): Termination timestamp for soft-deleted volumes.
+    """
+
+    metadata: Union[Unset, "LiteVolumeMetadata"] = UNSET
+    spec: Union[Unset, "LiteVolumeSpec"] = UNSET
+    state: Union[Unset, "VolumeState"] = UNSET
+    status: Union[Unset, str] = UNSET
+    terminated_at: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        metadata: Union[Unset, dict[str, Any]] = UNSET
+        if (
+            self.metadata
+            and not isinstance(self.metadata, Unset)
+            and not isinstance(self.metadata, dict)
+        ):
+            metadata = self.metadata.to_dict()
+        elif self.metadata and isinstance(self.metadata, dict):
+            metadata = self.metadata
+
+        spec: Union[Unset, dict[str, Any]] = UNSET
+        if self.spec and not isinstance(self.spec, Unset) and not isinstance(self.spec, dict):
+            spec = self.spec.to_dict()
+        elif self.spec and isinstance(self.spec, dict):
+            spec = self.spec
+
+        state: Union[Unset, dict[str, Any]] = UNSET
+        if self.state and not isinstance(self.state, Unset) and not isinstance(self.state, dict):
+            state = self.state.to_dict()
+        elif self.state and isinstance(self.state, dict):
+            state = self.state
+
+        status = self.status
+
+        terminated_at = self.terminated_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if spec is not UNSET:
+            field_dict["spec"] = spec
+        if state is not UNSET:
+            field_dict["state"] = state
+        if status is not UNSET:
+            field_dict["status"] = status
+        if terminated_at is not UNSET:
+            field_dict["terminatedAt"] = terminated_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.lite_volume_metadata import LiteVolumeMetadata
+        from ..models.lite_volume_spec import LiteVolumeSpec
+        from ..models.volume_state import VolumeState
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        _metadata = d.pop("metadata", UNSET)
+        metadata: Union[Unset, LiteVolumeMetadata]
+        if isinstance(_metadata, Unset):
+            metadata = UNSET
+        else:
+            metadata = LiteVolumeMetadata.from_dict(_metadata)
+
+        _spec = d.pop("spec", UNSET)
+        spec: Union[Unset, LiteVolumeSpec]
+        if isinstance(_spec, Unset):
+            spec = UNSET
+        else:
+            spec = LiteVolumeSpec.from_dict(_spec)
+
+        _state = d.pop("state", UNSET)
+        state: Union[Unset, VolumeState]
+        if isinstance(_state, Unset):
+            state = UNSET
+        else:
+            state = VolumeState.from_dict(_state)
+
+        status = d.pop("status", UNSET)
+
+        terminated_at = d.pop("terminatedAt", d.pop("terminated_at", UNSET))
+
+        lite_volume = cls(
+            metadata=metadata,
+            spec=spec,
+            state=state,
+            status=status,
+            terminated_at=terminated_at,
+        )
+
+        lite_volume.additional_properties = d
+        return lite_volume
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/lite_volume_metadata.py
+++ b/src/blaxel/core/client/models/lite_volume_metadata.py
@@ -1,0 +1,88 @@
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="LiteVolumeMetadata")
+
+
+@_attrs_define
+class LiteVolumeMetadata:
+    """Compact metadata for a Volume, returned in listing responses.
+
+    Attributes:
+        created_at (Union[Unset, str]):
+        display_name (Union[Unset, str]):
+        name (Union[Unset, str]):
+        updated_at (Union[Unset, str]):
+    """
+
+    created_at: Union[Unset, str] = UNSET
+    display_name: Union[Unset, str] = UNSET
+    name: Union[Unset, str] = UNSET
+    updated_at: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        created_at = self.created_at
+
+        display_name = self.display_name
+
+        name = self.name
+
+        updated_at = self.updated_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if created_at is not UNSET:
+            field_dict["createdAt"] = created_at
+        if display_name is not UNSET:
+            field_dict["displayName"] = display_name
+        if name is not UNSET:
+            field_dict["name"] = name
+        if updated_at is not UNSET:
+            field_dict["updatedAt"] = updated_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        created_at = d.pop("createdAt", d.pop("created_at", UNSET))
+
+        display_name = d.pop("displayName", d.pop("display_name", UNSET))
+
+        name = d.pop("name", UNSET)
+
+        updated_at = d.pop("updatedAt", d.pop("updated_at", UNSET))
+
+        lite_volume_metadata = cls(
+            created_at=created_at,
+            display_name=display_name,
+            name=name,
+            updated_at=updated_at,
+        )
+
+        lite_volume_metadata.additional_properties = d
+        return lite_volume_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/lite_volume_spec.py
+++ b/src/blaxel/core/client/models/lite_volume_spec.py
@@ -1,0 +1,70 @@
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="LiteVolumeSpec")
+
+
+@_attrs_define
+class LiteVolumeSpec:
+    """Compact spec for a Volume, returned in listing responses.
+
+    Attributes:
+        region (Union[Unset, str]): Region the volume is provisioned in.
+        size (Union[Unset, int]): Volume size in gigabytes.
+    """
+
+    region: Union[Unset, str] = UNSET
+    size: Union[Unset, int] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        region = self.region
+
+        size = self.size
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if region is not UNSET:
+            field_dict["region"] = region
+        if size is not UNSET:
+            field_dict["size"] = size
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        region = d.pop("region", UNSET)
+
+        size = d.pop("size", UNSET)
+
+        lite_volume_spec = cls(
+            region=region,
+            size=size,
+        )
+
+        lite_volume_spec.additional_properties = d
+        return lite_volume_spec
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/location_response.py
+++ b/src/blaxel/core/client/models/location_response.py
@@ -34,7 +34,6 @@ class LocationResponse:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         continent = self.continent
 
         country = self.country

--- a/src/blaxel/core/client/models/mcp_definition.py
+++ b/src/blaxel/core/client/models/mcp_definition.py
@@ -60,7 +60,6 @@ class MCPDefinition:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         created_at = self.created_at
 
         updated_at = self.updated_at

--- a/src/blaxel/core/client/models/metadata.py
+++ b/src/blaxel/core/client/models/metadata.py
@@ -46,7 +46,6 @@ class Metadata:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         name = self.name
 
         created_at = self.created_at

--- a/src/blaxel/core/client/models/model.py
+++ b/src/blaxel/core/client/models/model.py
@@ -36,7 +36,6 @@ class Model:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/model_list.py
+++ b/src/blaxel/core/client/models/model_list.py
@@ -56,13 +56,18 @@ class ModelList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+    def from_dict(cls: type[T], src_dict: dict[str, Any] | list[Any]) -> T | None:
         from ..models.model import Model
         from ..models.pagination_meta import PaginationMeta
 
-        if not src_dict:
+        if isinstance(src_dict, list):
+            d = {"data": src_dict}
+        elif src_dict is None:
             return None
-        d = src_dict.copy()
+        elif not src_dict:
+            d = {}
+        else:
+            d = src_dict.copy()
         data = []
         _data = d.pop("data", UNSET)
         for data_item_data in _data or []:

--- a/src/blaxel/core/client/models/model_list.py
+++ b/src/blaxel/core/client/models/model_list.py
@@ -1,0 +1,102 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.model import Model
+    from ..models.pagination_meta import PaginationMeta
+
+
+T = TypeVar("T", bound="ModelList")
+
+
+@_attrs_define
+class ModelList:
+    """Cursor-paginated list of model gateway endpoints. Returned starting with API version 2026-04-28; older API versions
+    return a bare array.
+
+        Attributes:
+            data (Union[Unset, list['Model']]): Page of models.
+            meta (Union[Unset, PaginationMeta]): Pagination metadata returned alongside a page of listing results. Always
+                present on listing endpoints starting with API version 2026-04-28.
+    """
+
+    data: Union[Unset, list["Model"]] = UNSET
+    meta: Union[Unset, "PaginationMeta"] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.data, Unset):
+            data = []
+            for data_item_data in self.data:
+                if type(data_item_data) is dict:
+                    data_item = data_item_data
+                else:
+                    data_item = data_item_data.to_dict()
+                data.append(data_item)
+
+        meta: Union[Unset, dict[str, Any]] = UNSET
+        if self.meta and not isinstance(self.meta, Unset) and not isinstance(self.meta, dict):
+            meta = self.meta.to_dict()
+        elif self.meta and isinstance(self.meta, dict):
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if data is not UNSET:
+            field_dict["data"] = data
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.model import Model
+        from ..models.pagination_meta import PaginationMeta
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        data = []
+        _data = d.pop("data", UNSET)
+        for data_item_data in _data or []:
+            data_item = Model.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        _meta = d.pop("meta", UNSET)
+        meta: Union[Unset, PaginationMeta]
+        if isinstance(_meta, Unset):
+            meta = UNSET
+        else:
+            meta = PaginationMeta.from_dict(_meta)
+
+        model_list = cls(
+            data=data,
+            meta=meta,
+        )
+
+        model_list.additional_properties = d
+        return model_list
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/model_spec.py
+++ b/src/blaxel/core/client/models/model_spec.py
@@ -37,7 +37,6 @@ class ModelSpec:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         enabled = self.enabled
 
         flavors: Union[Unset, list[dict[str, Any]]] = UNSET

--- a/src/blaxel/core/client/models/o_auth.py
+++ b/src/blaxel/core/client/models/o_auth.py
@@ -26,7 +26,6 @@ class OAuth:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         scope: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.scope, Unset):
             scope = []

--- a/src/blaxel/core/client/models/pagination_meta.py
+++ b/src/blaxel/core/client/models/pagination_meta.py
@@ -1,0 +1,83 @@
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="PaginationMeta")
+
+
+@_attrs_define
+class PaginationMeta:
+    """Pagination metadata returned alongside a page of listing results. Always present on listing endpoints starting with
+    API version 2026-04-28.
+
+        Attributes:
+            has_more (Union[Unset, bool]): True when more pages are available beyond the current one.
+            next_cursor (Union[Unset, str]): Opaque cursor to pass back as the `cursor` query param for the next page. Empty
+                when there are no more pages.
+            total (Union[Unset, int]): Total number of items in the workspace, ignoring the current page's filters. Lets the
+                UI render "page X of Y" without walking the cursor chain. Computed from the hash-only metadata.workspace GSI
+                count, so search (`q`) does not narrow it.
+    """
+
+    has_more: Union[Unset, bool] = UNSET
+    next_cursor: Union[Unset, str] = UNSET
+    total: Union[Unset, int] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        has_more = self.has_more
+
+        next_cursor = self.next_cursor
+
+        total = self.total
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if has_more is not UNSET:
+            field_dict["hasMore"] = has_more
+        if next_cursor is not UNSET:
+            field_dict["nextCursor"] = next_cursor
+        if total is not UNSET:
+            field_dict["total"] = total
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        has_more = d.pop("hasMore", d.pop("has_more", UNSET))
+
+        next_cursor = d.pop("nextCursor", d.pop("next_cursor", UNSET))
+
+        total = d.pop("total", UNSET)
+
+        pagination_meta = cls(
+            has_more=has_more,
+            next_cursor=next_cursor,
+            total=total,
+        )
+
+        pagination_meta.additional_properties = d
+        return pagination_meta
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/pending_invitation_accept.py
+++ b/src/blaxel/core/client/models/pending_invitation_accept.py
@@ -27,7 +27,6 @@ class PendingInvitationAccept:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         email = self.email
 
         workspace: Union[Unset, dict[str, Any]] = UNSET

--- a/src/blaxel/core/client/models/pending_invitation_render.py
+++ b/src/blaxel/core/client/models/pending_invitation_render.py
@@ -44,7 +44,6 @@ class PendingInvitationRender:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         account: Union[Unset, dict[str, Any]] = UNSET
         if (
             self.account

--- a/src/blaxel/core/client/models/pending_invitation_workspace_details.py
+++ b/src/blaxel/core/client/models/pending_invitation_workspace_details.py
@@ -28,7 +28,6 @@ class PendingInvitationWorkspaceDetails:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         emails: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.emails, Unset):
             emails = []

--- a/src/blaxel/core/client/models/policy.py
+++ b/src/blaxel/core/client/models/policy.py
@@ -1,11 +1,14 @@
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
 if TYPE_CHECKING:
     from ..models.metadata import Metadata
     from ..models.policy_spec import PolicySpec
+    from ..models.policy_usage_counts import PolicyUsageCounts
 
 
 T = TypeVar("T", bound="Policy")
@@ -19,14 +22,17 @@ class Policy:
         metadata (Metadata): Common metadata fields shared by all Blaxel resources including name, labels, timestamps,
             and ownership information
         spec (PolicySpec): Policy specification
+        usage (Union[Unset, PolicyUsageCounts]): Per-resource counts of how many resources reference a policy. Computed
+            by the policies listing endpoint to avoid client-side fan-out across the agents/models/functions/sandboxes/jobs
+            listings.
     """
 
     metadata: "Metadata"
     spec: "PolicySpec"
+    usage: Union[Unset, "PolicyUsageCounts"] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:
@@ -37,6 +43,12 @@ class Policy:
         else:
             spec = self.spec.to_dict()
 
+        usage: Union[Unset, dict[str, Any]] = UNSET
+        if self.usage and not isinstance(self.usage, Unset) and not isinstance(self.usage, dict):
+            usage = self.usage.to_dict()
+        elif self.usage and isinstance(self.usage, dict):
+            usage = self.usage
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -45,6 +57,8 @@ class Policy:
                 "spec": spec,
             }
         )
+        if usage is not UNSET:
+            field_dict["usage"] = usage
 
         return field_dict
 
@@ -52,6 +66,7 @@ class Policy:
     def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
         from ..models.metadata import Metadata
         from ..models.policy_spec import PolicySpec
+        from ..models.policy_usage_counts import PolicyUsageCounts
 
         if not src_dict:
             return None
@@ -60,9 +75,17 @@ class Policy:
 
         spec = PolicySpec.from_dict(d.pop("spec"))
 
+        _usage = d.pop("usage", UNSET)
+        usage: Union[Unset, PolicyUsageCounts]
+        if isinstance(_usage, Unset):
+            usage = UNSET
+        else:
+            usage = PolicyUsageCounts.from_dict(_usage)
+
         policy = cls(
             metadata=metadata,
             spec=spec,
+            usage=usage,
         )
 
         policy.additional_properties = d

--- a/src/blaxel/core/client/models/policy_list.py
+++ b/src/blaxel/core/client/models/policy_list.py
@@ -56,13 +56,18 @@ class PolicyList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+    def from_dict(cls: type[T], src_dict: dict[str, Any] | list[Any]) -> T | None:
         from ..models.pagination_meta import PaginationMeta
         from ..models.policy import Policy
 
-        if not src_dict:
+        if isinstance(src_dict, list):
+            d = {"data": src_dict}
+        elif src_dict is None:
             return None
-        d = src_dict.copy()
+        elif not src_dict:
+            d = {}
+        else:
+            d = src_dict.copy()
         data = []
         _data = d.pop("data", UNSET)
         for data_item_data in _data or []:

--- a/src/blaxel/core/client/models/policy_list.py
+++ b/src/blaxel/core/client/models/policy_list.py
@@ -1,0 +1,102 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.pagination_meta import PaginationMeta
+    from ..models.policy import Policy
+
+
+T = TypeVar("T", bound="PolicyList")
+
+
+@_attrs_define
+class PolicyList:
+    """Cursor-paginated list of policies. Returned starting with API version 2026-04-28; older API versions return a bare
+    array.
+
+        Attributes:
+            data (Union[Unset, list['Policy']]): Page of policies.
+            meta (Union[Unset, PaginationMeta]): Pagination metadata returned alongside a page of listing results. Always
+                present on listing endpoints starting with API version 2026-04-28.
+    """
+
+    data: Union[Unset, list["Policy"]] = UNSET
+    meta: Union[Unset, "PaginationMeta"] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.data, Unset):
+            data = []
+            for data_item_data in self.data:
+                if type(data_item_data) is dict:
+                    data_item = data_item_data
+                else:
+                    data_item = data_item_data.to_dict()
+                data.append(data_item)
+
+        meta: Union[Unset, dict[str, Any]] = UNSET
+        if self.meta and not isinstance(self.meta, Unset) and not isinstance(self.meta, dict):
+            meta = self.meta.to_dict()
+        elif self.meta and isinstance(self.meta, dict):
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if data is not UNSET:
+            field_dict["data"] = data
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.pagination_meta import PaginationMeta
+        from ..models.policy import Policy
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        data = []
+        _data = d.pop("data", UNSET)
+        for data_item_data in _data or []:
+            data_item = Policy.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        _meta = d.pop("meta", UNSET)
+        meta: Union[Unset, PaginationMeta]
+        if isinstance(_meta, Unset):
+            meta = UNSET
+        else:
+            meta = PaginationMeta.from_dict(_meta)
+
+        policy_list = cls(
+            data=data,
+            meta=meta,
+        )
+
+        policy_list.additional_properties = d
+        return policy_list
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/policy_spec.py
+++ b/src/blaxel/core/client/models/policy_spec.py
@@ -40,7 +40,6 @@ class PolicySpec:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         flavors: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.flavors, Unset):
             flavors = []

--- a/src/blaxel/core/client/models/policy_usage_counts.py
+++ b/src/blaxel/core/client/models/policy_usage_counts.py
@@ -1,0 +1,98 @@
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="PolicyUsageCounts")
+
+
+@_attrs_define
+class PolicyUsageCounts:
+    """Per-resource counts of how many resources reference a policy. Computed by the policies listing endpoint to avoid
+    client-side fan-out across the agents/models/functions/sandboxes/jobs listings.
+
+        Attributes:
+            agents (Union[Unset, int]):
+            functions (Union[Unset, int]):
+            jobs (Union[Unset, int]):
+            models (Union[Unset, int]):
+            sandboxes (Union[Unset, int]):
+    """
+
+    agents: Union[Unset, int] = UNSET
+    functions: Union[Unset, int] = UNSET
+    jobs: Union[Unset, int] = UNSET
+    models: Union[Unset, int] = UNSET
+    sandboxes: Union[Unset, int] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        agents = self.agents
+
+        functions = self.functions
+
+        jobs = self.jobs
+
+        models = self.models
+
+        sandboxes = self.sandboxes
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if agents is not UNSET:
+            field_dict["agents"] = agents
+        if functions is not UNSET:
+            field_dict["functions"] = functions
+        if jobs is not UNSET:
+            field_dict["jobs"] = jobs
+        if models is not UNSET:
+            field_dict["models"] = models
+        if sandboxes is not UNSET:
+            field_dict["sandboxes"] = sandboxes
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        agents = d.pop("agents", UNSET)
+
+        functions = d.pop("functions", UNSET)
+
+        jobs = d.pop("jobs", UNSET)
+
+        models = d.pop("models", UNSET)
+
+        sandboxes = d.pop("sandboxes", UNSET)
+
+        policy_usage_counts = cls(
+            agents=agents,
+            functions=functions,
+            jobs=jobs,
+            models=models,
+            sandboxes=sandboxes,
+        )
+
+        policy_usage_counts.additional_properties = d
+        return policy_usage_counts
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/policy_usages.py
+++ b/src/blaxel/core/client/models/policy_usages.py
@@ -1,0 +1,179 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.policy_usages_agents_item import PolicyUsagesAgentsItem
+    from ..models.policy_usages_functions_item import PolicyUsagesFunctionsItem
+    from ..models.policy_usages_jobs_item import PolicyUsagesJobsItem
+    from ..models.policy_usages_models_item import PolicyUsagesModelsItem
+    from ..models.policy_usages_sandboxes_item import PolicyUsagesSandboxesItem
+
+
+T = TypeVar("T", bound="PolicyUsages")
+
+
+@_attrs_define
+class PolicyUsages:
+    """Resources currently referencing a policy. Returned by GET /policies/{name}/usages so the policies UI can render
+    attachments without fetching the agents/models/functions listings full.
+
+        Attributes:
+            agents (Union[Unset, list['PolicyUsagesAgentsItem']]): Names of agents whose spec.policies contains this policy.
+            functions (Union[Unset, list['PolicyUsagesFunctionsItem']]): Names of functions whose spec.policies contains
+                this policy.
+            jobs (Union[Unset, list['PolicyUsagesJobsItem']]): Names of jobs whose spec.policies contains this policy.
+            models (Union[Unset, list['PolicyUsagesModelsItem']]): Names of models whose spec.policies contains this policy.
+            sandboxes (Union[Unset, list['PolicyUsagesSandboxesItem']]): Names of sandboxes whose spec.policies contains
+                this policy.
+    """
+
+    agents: Union[Unset, list["PolicyUsagesAgentsItem"]] = UNSET
+    functions: Union[Unset, list["PolicyUsagesFunctionsItem"]] = UNSET
+    jobs: Union[Unset, list["PolicyUsagesJobsItem"]] = UNSET
+    models: Union[Unset, list["PolicyUsagesModelsItem"]] = UNSET
+    sandboxes: Union[Unset, list["PolicyUsagesSandboxesItem"]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        agents: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.agents, Unset):
+            agents = []
+            for agents_item_data in self.agents:
+                if type(agents_item_data) is dict:
+                    agents_item = agents_item_data
+                else:
+                    agents_item = agents_item_data.to_dict()
+                agents.append(agents_item)
+
+        functions: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.functions, Unset):
+            functions = []
+            for functions_item_data in self.functions:
+                if type(functions_item_data) is dict:
+                    functions_item = functions_item_data
+                else:
+                    functions_item = functions_item_data.to_dict()
+                functions.append(functions_item)
+
+        jobs: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.jobs, Unset):
+            jobs = []
+            for jobs_item_data in self.jobs:
+                if type(jobs_item_data) is dict:
+                    jobs_item = jobs_item_data
+                else:
+                    jobs_item = jobs_item_data.to_dict()
+                jobs.append(jobs_item)
+
+        models: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.models, Unset):
+            models = []
+            for models_item_data in self.models:
+                if type(models_item_data) is dict:
+                    models_item = models_item_data
+                else:
+                    models_item = models_item_data.to_dict()
+                models.append(models_item)
+
+        sandboxes: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.sandboxes, Unset):
+            sandboxes = []
+            for sandboxes_item_data in self.sandboxes:
+                if type(sandboxes_item_data) is dict:
+                    sandboxes_item = sandboxes_item_data
+                else:
+                    sandboxes_item = sandboxes_item_data.to_dict()
+                sandboxes.append(sandboxes_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if agents is not UNSET:
+            field_dict["agents"] = agents
+        if functions is not UNSET:
+            field_dict["functions"] = functions
+        if jobs is not UNSET:
+            field_dict["jobs"] = jobs
+        if models is not UNSET:
+            field_dict["models"] = models
+        if sandboxes is not UNSET:
+            field_dict["sandboxes"] = sandboxes
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.policy_usages_agents_item import PolicyUsagesAgentsItem
+        from ..models.policy_usages_functions_item import PolicyUsagesFunctionsItem
+        from ..models.policy_usages_jobs_item import PolicyUsagesJobsItem
+        from ..models.policy_usages_models_item import PolicyUsagesModelsItem
+        from ..models.policy_usages_sandboxes_item import PolicyUsagesSandboxesItem
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        agents = []
+        _agents = d.pop("agents", UNSET)
+        for agents_item_data in _agents or []:
+            agents_item = PolicyUsagesAgentsItem.from_dict(agents_item_data)
+
+            agents.append(agents_item)
+
+        functions = []
+        _functions = d.pop("functions", UNSET)
+        for functions_item_data in _functions or []:
+            functions_item = PolicyUsagesFunctionsItem.from_dict(functions_item_data)
+
+            functions.append(functions_item)
+
+        jobs = []
+        _jobs = d.pop("jobs", UNSET)
+        for jobs_item_data in _jobs or []:
+            jobs_item = PolicyUsagesJobsItem.from_dict(jobs_item_data)
+
+            jobs.append(jobs_item)
+
+        models = []
+        _models = d.pop("models", UNSET)
+        for models_item_data in _models or []:
+            models_item = PolicyUsagesModelsItem.from_dict(models_item_data)
+
+            models.append(models_item)
+
+        sandboxes = []
+        _sandboxes = d.pop("sandboxes", UNSET)
+        for sandboxes_item_data in _sandboxes or []:
+            sandboxes_item = PolicyUsagesSandboxesItem.from_dict(sandboxes_item_data)
+
+            sandboxes.append(sandboxes_item)
+
+        policy_usages = cls(
+            agents=agents,
+            functions=functions,
+            jobs=jobs,
+            models=models,
+            sandboxes=sandboxes,
+        )
+
+        policy_usages.additional_properties = d
+        return policy_usages
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/policy_usages_agents_item.py
+++ b/src/blaxel/core/client/models/policy_usages_agents_item.py
@@ -1,0 +1,45 @@
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="PolicyUsagesAgentsItem")
+
+
+@_attrs_define
+class PolicyUsagesAgentsItem:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        policy_usages_agents_item = cls()
+
+        policy_usages_agents_item.additional_properties = d
+        return policy_usages_agents_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/policy_usages_functions_item.py
+++ b/src/blaxel/core/client/models/policy_usages_functions_item.py
@@ -1,0 +1,45 @@
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="PolicyUsagesFunctionsItem")
+
+
+@_attrs_define
+class PolicyUsagesFunctionsItem:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        policy_usages_functions_item = cls()
+
+        policy_usages_functions_item.additional_properties = d
+        return policy_usages_functions_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/policy_usages_jobs_item.py
+++ b/src/blaxel/core/client/models/policy_usages_jobs_item.py
@@ -1,0 +1,45 @@
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="PolicyUsagesJobsItem")
+
+
+@_attrs_define
+class PolicyUsagesJobsItem:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        policy_usages_jobs_item = cls()
+
+        policy_usages_jobs_item.additional_properties = d
+        return policy_usages_jobs_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/policy_usages_models_item.py
+++ b/src/blaxel/core/client/models/policy_usages_models_item.py
@@ -1,0 +1,45 @@
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="PolicyUsagesModelsItem")
+
+
+@_attrs_define
+class PolicyUsagesModelsItem:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        policy_usages_models_item = cls()
+
+        policy_usages_models_item.additional_properties = d
+        return policy_usages_models_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/policy_usages_sandboxes_item.py
+++ b/src/blaxel/core/client/models/policy_usages_sandboxes_item.py
@@ -1,0 +1,45 @@
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="PolicyUsagesSandboxesItem")
+
+
+@_attrs_define
+class PolicyUsagesSandboxesItem:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        policy_usages_sandboxes_item = cls()
+
+        policy_usages_sandboxes_item.additional_properties = d
+        return policy_usages_sandboxes_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/preview.py
+++ b/src/blaxel/core/client/models/preview.py
@@ -33,7 +33,6 @@ class Preview:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/preview_spec.py
+++ b/src/blaxel/core/client/models/preview_spec.py
@@ -46,7 +46,6 @@ class PreviewSpec:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         custom_domain = self.custom_domain
 
         expires = self.expires

--- a/src/blaxel/core/client/models/preview_token.py
+++ b/src/blaxel/core/client/models/preview_token.py
@@ -25,7 +25,6 @@ class PreviewToken:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/proxy_config.py
+++ b/src/blaxel/core/client/models/proxy_config.py
@@ -18,22 +18,38 @@ class ProxyConfig:
     destination header/body injection
 
         Attributes:
+            allowed_domains (Union[Unset, list[str]]): List of allowed external domains (allowlist). When set, only these
+                domains are reachable. Supports wildcards (e.g. *.s3.amazonaws.com). Example: ["api.stripe.com",
+                "api.openai.com", "*.s3.amazonaws.com"].
             bypass (Union[Unset, list[str]]): Domains that bypass the proxy entirely via the NO_PROXY directive. Traffic to
                 these destinations goes direct, not through the CONNECT tunnel. Supports wildcards. Note that localhost, private
                 ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), 169.254.169.254, .local and .internal are always bypassed by
                 default. Example: ["*.s3.amazonaws.com"].
+            forbidden_domains (Union[Unset, list[str]]): List of forbidden external domains (denylist). When set, all
+                domains except these are reachable. Supports wildcards (e.g. *.malware.com). If both allowedDomains and
+                forbiddenDomains are set, allowedDomains takes precedence. Example: ["*.malware.com", "evil.example.org"].
             routing (Union[Unset, list['ProxyTarget']]): Per-destination routing rules with header/body injection and
                 secrets. Use destinations ["*"] for global rules that apply to all destinations.
     """
 
+    allowed_domains: Union[Unset, list[str]] = UNSET
     bypass: Union[Unset, list[str]] = UNSET
+    forbidden_domains: Union[Unset, list[str]] = UNSET
     routing: Union[Unset, list["ProxyTarget"]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        allowed_domains: Union[Unset, list[str]] = UNSET
+        if not isinstance(self.allowed_domains, Unset):
+            allowed_domains = self.allowed_domains
+
         bypass: Union[Unset, list[str]] = UNSET
         if not isinstance(self.bypass, Unset):
             bypass = self.bypass
+
+        forbidden_domains: Union[Unset, list[str]] = UNSET
+        if not isinstance(self.forbidden_domains, Unset):
+            forbidden_domains = self.forbidden_domains
 
         routing: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.routing, Unset):
@@ -48,8 +64,12 @@ class ProxyConfig:
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
+        if allowed_domains is not UNSET:
+            field_dict["allowedDomains"] = allowed_domains
         if bypass is not UNSET:
             field_dict["bypass"] = bypass
+        if forbidden_domains is not UNSET:
+            field_dict["forbiddenDomains"] = forbidden_domains
         if routing is not UNSET:
             field_dict["routing"] = routing
 
@@ -62,7 +82,13 @@ class ProxyConfig:
         if not src_dict:
             return None
         d = src_dict.copy()
+        allowed_domains = cast(list[str], d.pop("allowedDomains", d.pop("allowed_domains", UNSET)))
+
         bypass = cast(list[str], d.pop("bypass", UNSET))
+
+        forbidden_domains = cast(
+            list[str], d.pop("forbiddenDomains", d.pop("forbidden_domains", UNSET))
+        )
 
         routing = []
         _routing = d.pop("routing", UNSET)
@@ -72,7 +98,9 @@ class ProxyConfig:
             routing.append(routing_item)
 
         proxy_config = cls(
+            allowed_domains=allowed_domains,
             bypass=bypass,
+            forbidden_domains=forbidden_domains,
             routing=routing,
         )
 

--- a/src/blaxel/core/client/models/proxy_config.py
+++ b/src/blaxel/core/client/models/proxy_config.py
@@ -31,7 +31,6 @@ class ProxyConfig:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         bypass: Union[Unset, list[str]] = UNSET
         if not isinstance(self.bypass, Unset):
             bypass = self.bypass

--- a/src/blaxel/core/client/models/proxy_target.py
+++ b/src/blaxel/core/client/models/proxy_target.py
@@ -39,7 +39,6 @@ class ProxyTarget:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         body: Union[Unset, dict[str, Any]] = UNSET
         if self.body and not isinstance(self.body, Unset) and not isinstance(self.body, dict):
             body = self.body.to_dict()

--- a/src/blaxel/core/client/models/public_ips.py
+++ b/src/blaxel/core/client/models/public_ips.py
@@ -17,7 +17,6 @@ class PublicIps:
     additional_properties: dict[str, "PublicIp"] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
             if type(prop) is dict:

--- a/src/blaxel/core/client/models/region.py
+++ b/src/blaxel/core/client/models/region.py
@@ -46,7 +46,6 @@ class Region:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         agent_drive_public_url: Union[Unset, dict[str, Any]] = UNSET
         if (
             self.agent_drive_public_url

--- a/src/blaxel/core/client/models/sandbox.py
+++ b/src/blaxel/core/client/models/sandbox.py
@@ -44,7 +44,6 @@ class Sandbox:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/sandbox_definition.py
+++ b/src/blaxel/core/client/models/sandbox_definition.py
@@ -53,7 +53,6 @@ class SandboxDefinition:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         categories: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.categories, Unset):
             categories = []

--- a/src/blaxel/core/client/models/sandbox_error.py
+++ b/src/blaxel/core/client/models/sandbox_error.py
@@ -42,7 +42,6 @@ class SandboxError:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         code = self.code
 
         message = self.message

--- a/src/blaxel/core/client/models/sandbox_lifecycle.py
+++ b/src/blaxel/core/client/models/sandbox_lifecycle.py
@@ -28,7 +28,6 @@ class SandboxLifecycle:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         expiration_policies: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.expiration_policies, Unset):
             expiration_policies = []

--- a/src/blaxel/core/client/models/sandbox_list.py
+++ b/src/blaxel/core/client/models/sandbox_list.py
@@ -57,13 +57,18 @@ class SandboxList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+    def from_dict(cls: type[T], src_dict: dict[str, Any] | list[Any]) -> T | None:
         from ..models.pagination_meta import PaginationMeta
         from ..models.sandbox import Sandbox
 
-        if not src_dict:
+        if isinstance(src_dict, list):
+            d = {"data": src_dict}
+        elif src_dict is None:
             return None
-        d = src_dict.copy()
+        elif not src_dict:
+            d = {}
+        else:
+            d = src_dict.copy()
         data = []
         _data = d.pop("data", UNSET)
         for data_item_data in _data or []:

--- a/src/blaxel/core/client/models/sandbox_list.py
+++ b/src/blaxel/core/client/models/sandbox_list.py
@@ -1,0 +1,103 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.pagination_meta import PaginationMeta
+    from ..models.sandbox import Sandbox
+
+
+T = TypeVar("T", bound="SandboxList")
+
+
+@_attrs_define
+class SandboxList:
+    """Cursor-paginated list of sandboxes. Returned starting with API version 2026-04-28; older API versions return a bare
+    array.
+
+        Attributes:
+            data (Union[Unset, list['Sandbox']]): Page of sandboxes. Items use the lite shape (no inline event history) to
+                keep the page payload small, matching the unpaginated response.
+            meta (Union[Unset, PaginationMeta]): Pagination metadata returned alongside a page of listing results. Always
+                present on listing endpoints starting with API version 2026-04-28.
+    """
+
+    data: Union[Unset, list["Sandbox"]] = UNSET
+    meta: Union[Unset, "PaginationMeta"] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.data, Unset):
+            data = []
+            for data_item_data in self.data:
+                if type(data_item_data) is dict:
+                    data_item = data_item_data
+                else:
+                    data_item = data_item_data.to_dict()
+                data.append(data_item)
+
+        meta: Union[Unset, dict[str, Any]] = UNSET
+        if self.meta and not isinstance(self.meta, Unset) and not isinstance(self.meta, dict):
+            meta = self.meta.to_dict()
+        elif self.meta and isinstance(self.meta, dict):
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if data is not UNSET:
+            field_dict["data"] = data
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.pagination_meta import PaginationMeta
+        from ..models.sandbox import Sandbox
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        data = []
+        _data = d.pop("data", UNSET)
+        for data_item_data in _data or []:
+            data_item = Sandbox.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        _meta = d.pop("meta", UNSET)
+        meta: Union[Unset, PaginationMeta]
+        if isinstance(_meta, Unset):
+            meta = UNSET
+        else:
+            meta = PaginationMeta.from_dict(_meta)
+
+        sandbox_list = cls(
+            data=data,
+            meta=meta,
+        )
+
+        sandbox_list.additional_properties = d
+        return sandbox_list
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/sandbox_network.py
+++ b/src/blaxel/core/client/models/sandbox_network.py
@@ -7,6 +7,7 @@ from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
     from ..models.egress_config import EgressConfig
+    from ..models.firewall_config import FirewallConfig
     from ..models.proxy_config import ProxyConfig
 
 
@@ -15,25 +16,32 @@ T = TypeVar("T", bound="SandboxNetwork")
 
 @_attrs_define
 class SandboxNetwork:
-    """Network configuration for a sandbox including domain filtering, egress IP binding, and proxy settings
+    """Network configuration for a sandbox including subnet, firewall rulesets, domain filtering, egress IP binding, and
+    proxy settings
 
-    Attributes:
-        allowed_domains (Union[Unset, list[str]]): List of allowed external domains (allowlist). When set, only these
-            domains are reachable. Supports wildcards (e.g. *.s3.amazonaws.com). Example: ["api.stripe.com",
-            "api.openai.com", "*.s3.amazonaws.com"].
-        egress (Union[Unset, EgressConfig]): Egress configuration for routing sandbox outbound traffic through a
-            dedicated IP gateway
-        forbidden_domains (Union[Unset, list[str]]): List of forbidden external domains (denylist). When set, all
-            domains except these are reachable. Supports wildcards (e.g. *.malware.com). If both allowedDomains and
-            forbiddenDomains are set, allowedDomains takes precedence. Example: ["*.malware.com", "evil.example.org"].
-        proxy (Union[Unset, ProxyConfig]): Proxy configuration for routing sandbox HTTP traffic through the platform
-            proxy with MITM inspection and per-destination header/body injection
+        Attributes:
+            allowed_domains (Union[Unset, list[str]]): Deprecated: use proxy.allowedDomains instead. List of allowed
+                external domains (allowlist). Kept for backward compatibility. Example: ["api.stripe.com", "api.openai.com",
+                "*.s3.amazonaws.com"].
+            egress (Union[Unset, EgressConfig]): Egress configuration for routing sandbox outbound traffic through a
+                dedicated IP gateway
+            firewall (Union[Unset, FirewallConfig]): Firewall configuration specifying which network lockdown rulesets to
+                apply. Valid rulesets are "default" (no-op), "proxy" (restrict egress to proxy), and "dedicated-ip" (restrict
+                egress to dedicated IP gateway).
+            forbidden_domains (Union[Unset, list[str]]): Deprecated: use proxy.forbiddenDomains instead. List of forbidden
+                external domains (denylist). Kept for backward compatibility. Example: ["*.malware.com", "evil.example.org"].
+            proxy (Union[Unset, ProxyConfig]): Proxy configuration for routing sandbox HTTP traffic through the platform
+                proxy with MITM inspection and per-destination header/body injection
+            subnet (Union[Unset, str]): Subnet name for the sandbox. Takes priority over any subnet derived from egress
+                config. Defaults to "default" when absent. Example: default.
     """
 
     allowed_domains: Union[Unset, list[str]] = UNSET
     egress: Union[Unset, "EgressConfig"] = UNSET
+    firewall: Union[Unset, "FirewallConfig"] = UNSET
     forbidden_domains: Union[Unset, list[str]] = UNSET
     proxy: Union[Unset, "ProxyConfig"] = UNSET
+    subnet: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -47,6 +55,16 @@ class SandboxNetwork:
         elif self.egress and isinstance(self.egress, dict):
             egress = self.egress
 
+        firewall: Union[Unset, dict[str, Any]] = UNSET
+        if (
+            self.firewall
+            and not isinstance(self.firewall, Unset)
+            and not isinstance(self.firewall, dict)
+        ):
+            firewall = self.firewall.to_dict()
+        elif self.firewall and isinstance(self.firewall, dict):
+            firewall = self.firewall
+
         forbidden_domains: Union[Unset, list[str]] = UNSET
         if not isinstance(self.forbidden_domains, Unset):
             forbidden_domains = self.forbidden_domains
@@ -57,6 +75,8 @@ class SandboxNetwork:
         elif self.proxy and isinstance(self.proxy, dict):
             proxy = self.proxy
 
+        subnet = self.subnet
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -64,16 +84,21 @@ class SandboxNetwork:
             field_dict["allowedDomains"] = allowed_domains
         if egress is not UNSET:
             field_dict["egress"] = egress
+        if firewall is not UNSET:
+            field_dict["firewall"] = firewall
         if forbidden_domains is not UNSET:
             field_dict["forbiddenDomains"] = forbidden_domains
         if proxy is not UNSET:
             field_dict["proxy"] = proxy
+        if subnet is not UNSET:
+            field_dict["subnet"] = subnet
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
         from ..models.egress_config import EgressConfig
+        from ..models.firewall_config import FirewallConfig
         from ..models.proxy_config import ProxyConfig
 
         if not src_dict:
@@ -88,6 +113,13 @@ class SandboxNetwork:
         else:
             egress = EgressConfig.from_dict(_egress)
 
+        _firewall = d.pop("firewall", UNSET)
+        firewall: Union[Unset, FirewallConfig]
+        if isinstance(_firewall, Unset):
+            firewall = UNSET
+        else:
+            firewall = FirewallConfig.from_dict(_firewall)
+
         forbidden_domains = cast(
             list[str], d.pop("forbiddenDomains", d.pop("forbidden_domains", UNSET))
         )
@@ -99,11 +131,15 @@ class SandboxNetwork:
         else:
             proxy = ProxyConfig.from_dict(_proxy)
 
+        subnet = d.pop("subnet", UNSET)
+
         sandbox_network = cls(
             allowed_domains=allowed_domains,
             egress=egress,
+            firewall=firewall,
             forbidden_domains=forbidden_domains,
             proxy=proxy,
+            subnet=subnet,
         )
 
         sandbox_network.additional_properties = d

--- a/src/blaxel/core/client/models/sandbox_network.py
+++ b/src/blaxel/core/client/models/sandbox_network.py
@@ -37,7 +37,6 @@ class SandboxNetwork:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         allowed_domains: Union[Unset, list[str]] = UNSET
         if not isinstance(self.allowed_domains, Unset):
             allowed_domains = self.allowed_domains

--- a/src/blaxel/core/client/models/sandbox_runtime.py
+++ b/src/blaxel/core/client/models/sandbox_runtime.py
@@ -48,7 +48,6 @@ class SandboxRuntime:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         envs: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.envs, Unset):
             envs = []

--- a/src/blaxel/core/client/models/sandbox_runtime.py
+++ b/src/blaxel/core/client/models/sandbox_runtime.py
@@ -33,8 +33,9 @@ class SandboxRuntime:
         ports (Union[Unset, list['Port']]): Set of ports for a resource
         termination_grace_period_seconds (Union[Unset, int]): Duration in seconds the pod needs to terminate gracefully.
             Defaults to 0 for immediate termination. Example: 30.
-        ttl (Union[Unset, str]): Time-to-live duration after which the sandbox is automatically deleted (e.g., '30m',
-            '24h', '7d') Example: 24h.
+        ttl (Union[Unset, str]): Max-age from creation: the sandbox is deleted this long after it is created, regardless
+            of activity (not an idle timeout). Units s, m, h, d, w (e.g., '30m', '24h', '7d', '2w'). For idle-based cleanup,
+            use a lifecycle expiration policy of type ttl-idle. Example: 24h.
     """
 
     envs: Union[Unset, list["Env"]] = UNSET

--- a/src/blaxel/core/client/models/sandbox_spec.py
+++ b/src/blaxel/core/client/models/sandbox_spec.py
@@ -42,7 +42,6 @@ class SandboxSpec:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         enabled = self.enabled
 
         lifecycle: Union[Unset, dict[str, Any]] = UNSET

--- a/src/blaxel/core/client/models/sandbox_spec.py
+++ b/src/blaxel/core/client/models/sandbox_spec.py
@@ -24,13 +24,14 @@ class SandboxSpec:
             Example: True.
         lifecycle (Union[Unset, SandboxLifecycle]): Lifecycle configuration controlling automatic sandbox deletion based
             on idle time, max age, or specific dates
-        network (Union[Unset, SandboxNetwork]): Network configuration for a sandbox including domain filtering, egress
-            IP binding, and proxy settings
+        network (Union[Unset, SandboxNetwork]): Network configuration for a sandbox including subnet, firewall rulesets,
+            domain filtering, egress IP binding, and proxy settings
         region (Union[Unset, str]): Region where the sandbox should be created (e.g. us-pdx-1, eu-lon-1). If not
             specified, defaults to the region closest to the user. Example: us-pdx-1.
         runtime (Union[Unset, SandboxRuntime]): Runtime configuration defining how the sandbox VM is provisioned and its
             resource limits
         volumes (Union[Unset, list['VolumeAttachment']]):
+        vpc (Union[Unset, str]): VPC name for the sandbox. Defaults to "default" when absent. Example: default.
     """
 
     enabled: Union[Unset, bool] = True
@@ -39,6 +40,7 @@ class SandboxSpec:
     region: Union[Unset, str] = UNSET
     runtime: Union[Unset, "SandboxRuntime"] = UNSET
     volumes: Union[Unset, list["VolumeAttachment"]] = UNSET
+    vpc: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -90,6 +92,8 @@ class SandboxSpec:
                     )
                 volumes.append(componentsschemas_volume_attachments_item)
 
+        vpc = self.vpc
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -105,6 +109,8 @@ class SandboxSpec:
             field_dict["runtime"] = runtime
         if volumes is not UNSET:
             field_dict["volumes"] = volumes
+        if vpc is not UNSET:
+            field_dict["vpc"] = vpc
 
         return field_dict
 
@@ -152,6 +158,8 @@ class SandboxSpec:
 
             volumes.append(componentsschemas_volume_attachments_item)
 
+        vpc = d.pop("vpc", UNSET)
+
         sandbox_spec = cls(
             enabled=enabled,
             lifecycle=lifecycle,
@@ -159,6 +167,7 @@ class SandboxSpec:
             region=region,
             runtime=runtime,
             volumes=volumes,
+            vpc=vpc,
         )
 
         sandbox_spec.additional_properties = d

--- a/src/blaxel/core/client/models/sso_domain.py
+++ b/src/blaxel/core/client/models/sso_domain.py
@@ -28,7 +28,6 @@ class SSODomain:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/template.py
+++ b/src/blaxel/core/client/models/template.py
@@ -47,7 +47,6 @@ class Template:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         default_branch = self.default_branch
 
         description = self.description

--- a/src/blaxel/core/client/models/test_feature_flag_response_200.py
+++ b/src/blaxel/core/client/models/test_feature_flag_response_200.py
@@ -33,7 +33,6 @@ class TestFeatureFlagResponse200:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         enabled = self.enabled
 
         evaluated_at: Union[Unset, str] = UNSET

--- a/src/blaxel/core/client/models/trigger.py
+++ b/src/blaxel/core/client/models/trigger.py
@@ -20,7 +20,8 @@ class Trigger:
     Attributes:
         configuration (Union[Unset, TriggerConfiguration]): Trigger configuration
         enabled (Union[Unset, bool]): Enable or disable the trigger (default: true) Example: True.
-        id (Union[Unset, str]): The id of the trigger Example: trigger-1.
+        id (Union[Unset, str]): Identifier of the trigger. Optional — the server auto-generates a unique id when one is
+            not provided, and disambiguates duplicates within a resource. Example: trigger-1.
         type_ (Union[Unset, TriggerType]): The type of trigger, can be http or http-async Example: http.
     """
 
@@ -31,7 +32,6 @@ class Trigger:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         configuration: Union[Unset, dict[str, Any]] = UNSET
         if (
             self.configuration

--- a/src/blaxel/core/client/models/trigger_configuration.py
+++ b/src/blaxel/core/client/models/trigger_configuration.py
@@ -39,7 +39,6 @@ class TriggerConfiguration:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         authentication_type = self.authentication_type
 
         callback_secret = self.callback_secret

--- a/src/blaxel/core/client/models/volume.py
+++ b/src/blaxel/core/client/models/volume.py
@@ -40,7 +40,6 @@ class Volume:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/volume_list.py
+++ b/src/blaxel/core/client/models/volume_list.py
@@ -56,13 +56,18 @@ class VolumeList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+    def from_dict(cls: type[T], src_dict: dict[str, Any] | list[Any]) -> T | None:
         from ..models.lite_volume import LiteVolume
         from ..models.pagination_meta import PaginationMeta
 
-        if not src_dict:
+        if isinstance(src_dict, list):
+            d = {"data": src_dict}
+        elif src_dict is None:
             return None
-        d = src_dict.copy()
+        elif not src_dict:
+            d = {}
+        else:
+            d = src_dict.copy()
         data = []
         _data = d.pop("data", UNSET)
         for data_item_data in _data or []:

--- a/src/blaxel/core/client/models/volume_list.py
+++ b/src/blaxel/core/client/models/volume_list.py
@@ -1,0 +1,102 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.lite_volume import LiteVolume
+    from ..models.pagination_meta import PaginationMeta
+
+
+T = TypeVar("T", bound="VolumeList")
+
+
+@_attrs_define
+class VolumeList:
+    """Cursor-paginated list of volumes. Returned starting with API version 2026-04-28; older API versions return a bare
+    array. Items use the lite shape (no inline event history).
+
+        Attributes:
+            data (Union[Unset, list['LiteVolume']]): Page of volumes.
+            meta (Union[Unset, PaginationMeta]): Pagination metadata returned alongside a page of listing results. Always
+                present on listing endpoints starting with API version 2026-04-28.
+    """
+
+    data: Union[Unset, list["LiteVolume"]] = UNSET
+    meta: Union[Unset, "PaginationMeta"] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.data, Unset):
+            data = []
+            for data_item_data in self.data:
+                if type(data_item_data) is dict:
+                    data_item = data_item_data
+                else:
+                    data_item = data_item_data.to_dict()
+                data.append(data_item)
+
+        meta: Union[Unset, dict[str, Any]] = UNSET
+        if self.meta and not isinstance(self.meta, Unset) and not isinstance(self.meta, dict):
+            meta = self.meta.to_dict()
+        elif self.meta and isinstance(self.meta, dict):
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if data is not UNSET:
+            field_dict["data"] = data
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.lite_volume import LiteVolume
+        from ..models.pagination_meta import PaginationMeta
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        data = []
+        _data = d.pop("data", UNSET)
+        for data_item_data in _data or []:
+            data_item = LiteVolume.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        _meta = d.pop("meta", UNSET)
+        meta: Union[Unset, PaginationMeta]
+        if isinstance(_meta, Unset):
+            meta = UNSET
+        else:
+            meta = PaginationMeta.from_dict(_meta)
+
+        volume_list = cls(
+            data=data,
+            meta=meta,
+        )
+
+        volume_list.additional_properties = d
+        return volume_list
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/volume_template.py
+++ b/src/blaxel/core/client/models/volume_template.py
@@ -34,7 +34,6 @@ class VolumeTemplate:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/vpc.py
+++ b/src/blaxel/core/client/models/vpc.py
@@ -34,7 +34,6 @@ class VPC:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         if type(self.metadata) is dict:
             metadata = self.metadata
         else:

--- a/src/blaxel/core/client/models/workspace.py
+++ b/src/blaxel/core/client/models/workspace.py
@@ -9,6 +9,7 @@ from ..types import UNSET, Unset
 if TYPE_CHECKING:
     from ..models.group_workspace_mapping import GroupWorkspaceMapping
     from ..models.metadata_labels import MetadataLabels
+    from ..models.workspace_resource_counts import WorkspaceResourceCounts
     from ..models.workspace_runtime import WorkspaceRuntime
 
 
@@ -34,6 +35,9 @@ class Workspace:
                 used to categorize resources by environment, project, team, or any custom taxonomy.
             name (Union[Unset, str]): Workspace name Example: my-workspace.
             region (Union[Unset, str]): Workspace write region Example: us-west-2.
+            resource_counts (Union[Unset, WorkspaceResourceCounts]): Per-resource counts (agents, functions, models,
+                sandboxes, policies, jobs, volumes, drives, volumetemplates, integrationconnections, previews, customdomains,
+                serviceaccounts, images). Only populated when GetWorkspace is called with ?countResources=true.
             runtime (Union[Unset, WorkspaceRuntime]): Runtime configuration for the workspace infrastructure
             status (Union[Unset, WorkspaceStatus]): Workspace status (created, account_binded, account_configured,
                 workspace_configured, ready, error) Example: ready.
@@ -51,13 +55,13 @@ class Workspace:
     labels: Union[Unset, "MetadataLabels"] = UNSET
     name: Union[Unset, str] = UNSET
     region: Union[Unset, str] = UNSET
+    resource_counts: Union[Unset, "WorkspaceResourceCounts"] = UNSET
     runtime: Union[Unset, "WorkspaceRuntime"] = UNSET
     status: Union[Unset, WorkspaceStatus] = UNSET
     status_reason: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-
         created_at = self.created_at
 
         updated_at = self.updated_at
@@ -91,6 +95,16 @@ class Workspace:
         name = self.name
 
         region = self.region
+
+        resource_counts: Union[Unset, dict[str, Any]] = UNSET
+        if (
+            self.resource_counts
+            and not isinstance(self.resource_counts, Unset)
+            and not isinstance(self.resource_counts, dict)
+        ):
+            resource_counts = self.resource_counts.to_dict()
+        elif self.resource_counts and isinstance(self.resource_counts, dict):
+            resource_counts = self.resource_counts
 
         runtime: Union[Unset, dict[str, Any]] = UNSET
         if (
@@ -133,6 +147,8 @@ class Workspace:
             field_dict["name"] = name
         if region is not UNSET:
             field_dict["region"] = region
+        if resource_counts is not UNSET:
+            field_dict["resourceCounts"] = resource_counts
         if runtime is not UNSET:
             field_dict["runtime"] = runtime
         if status is not UNSET:
@@ -146,6 +162,7 @@ class Workspace:
     def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
         from ..models.group_workspace_mapping import GroupWorkspaceMapping
         from ..models.metadata_labels import MetadataLabels
+        from ..models.workspace_resource_counts import WorkspaceResourceCounts
         from ..models.workspace_runtime import WorkspaceRuntime
 
         if not src_dict:
@@ -183,6 +200,13 @@ class Workspace:
 
         region = d.pop("region", UNSET)
 
+        _resource_counts = d.pop("resourceCounts", d.pop("resource_counts", UNSET))
+        resource_counts: Union[Unset, WorkspaceResourceCounts]
+        if isinstance(_resource_counts, Unset):
+            resource_counts = UNSET
+        else:
+            resource_counts = WorkspaceResourceCounts.from_dict(_resource_counts)
+
         _runtime = d.pop("runtime", UNSET)
         runtime: Union[Unset, WorkspaceRuntime]
         if isinstance(_runtime, Unset):
@@ -211,6 +235,7 @@ class Workspace:
             labels=labels,
             name=name,
             region=region,
+            resource_counts=resource_counts,
             runtime=runtime,
             status=status,
             status_reason=status_reason,

--- a/src/blaxel/core/client/models/workspace_hipaa_info.py
+++ b/src/blaxel/core/client/models/workspace_hipaa_info.py
@@ -1,0 +1,89 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.workspace_hipaa_unsafe import WorkspaceHipaaUnsafe
+
+
+T = TypeVar("T", bound="WorkspaceHipaaInfo")
+
+
+@_attrs_define
+class WorkspaceHipaaInfo:
+    """HIPAA compliance state for a workspace. `accountEnabled` mirrors the account-level `hipaa_compliance` addon (set
+    server-side from operator tooling and Stripe billing events). `unsafe` records a per-workspace opt-out toggled from
+    workspace settings; absent when the account does not have the addon.
+
+        Attributes:
+            account_enabled (Union[Unset, bool]): True when the parent account has the HIPAA compliance addon active. Set
+                server-side from operator tooling and Stripe billing events; cannot be changed from workspace settings.
+            unsafe (Union[Unset, WorkspaceHipaaUnsafe]): Per-workspace HIPAA opt-out record. Toggled from workspace
+                settings; the backend stamps `updatedBy` and `updatedAt`.
+    """
+
+    account_enabled: Union[Unset, bool] = UNSET
+    unsafe: Union[Unset, "WorkspaceHipaaUnsafe"] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        account_enabled = self.account_enabled
+
+        unsafe: Union[Unset, dict[str, Any]] = UNSET
+        if self.unsafe and not isinstance(self.unsafe, Unset) and not isinstance(self.unsafe, dict):
+            unsafe = self.unsafe.to_dict()
+        elif self.unsafe and isinstance(self.unsafe, dict):
+            unsafe = self.unsafe
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if account_enabled is not UNSET:
+            field_dict["accountEnabled"] = account_enabled
+        if unsafe is not UNSET:
+            field_dict["unsafe"] = unsafe
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.workspace_hipaa_unsafe import WorkspaceHipaaUnsafe
+
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        account_enabled = d.pop("accountEnabled", d.pop("account_enabled", UNSET))
+
+        _unsafe = d.pop("unsafe", UNSET)
+        unsafe: Union[Unset, WorkspaceHipaaUnsafe]
+        if isinstance(_unsafe, Unset):
+            unsafe = UNSET
+        else:
+            unsafe = WorkspaceHipaaUnsafe.from_dict(_unsafe)
+
+        workspace_hipaa_info = cls(
+            account_enabled=account_enabled,
+            unsafe=unsafe,
+        )
+
+        workspace_hipaa_info.additional_properties = d
+        return workspace_hipaa_info
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/workspace_hipaa_unsafe.py
+++ b/src/blaxel/core/client/models/workspace_hipaa_unsafe.py
@@ -1,0 +1,80 @@
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="WorkspaceHipaaUnsafe")
+
+
+@_attrs_define
+class WorkspaceHipaaUnsafe:
+    """Per-workspace HIPAA opt-out record. Toggled from workspace settings; the backend stamps `updatedBy` and `updatedAt`.
+
+    Attributes:
+        enabled (Union[Unset, bool]): True marks this workspace as HIPAA-unsafe (NOT compliant), overriding the account-
+            level addon. False marks the workspace as HIPAA compliant.
+        updated_at (Union[Unset, str]): RFC3339 timestamp when the opt-out was last toggled. Stamped server-side.
+        updated_by (Union[Unset, str]): User id (sub) of the actor that last toggled this opt-out. Stamped server-side.
+    """
+
+    enabled: Union[Unset, bool] = UNSET
+    updated_at: Union[Unset, str] = UNSET
+    updated_by: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        enabled = self.enabled
+
+        updated_at = self.updated_at
+
+        updated_by = self.updated_by
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if enabled is not UNSET:
+            field_dict["enabled"] = enabled
+        if updated_at is not UNSET:
+            field_dict["updatedAt"] = updated_at
+        if updated_by is not UNSET:
+            field_dict["updatedBy"] = updated_by
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        enabled = d.pop("enabled", UNSET)
+
+        updated_at = d.pop("updatedAt", d.pop("updated_at", UNSET))
+
+        updated_by = d.pop("updatedBy", d.pop("updated_by", UNSET))
+
+        workspace_hipaa_unsafe = cls(
+            enabled=enabled,
+            updated_at=updated_at,
+            updated_by=updated_by,
+        )
+
+        workspace_hipaa_unsafe.additional_properties = d
+        return workspace_hipaa_unsafe
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/workspace_resource_counts.py
+++ b/src/blaxel/core/client/models/workspace_resource_counts.py
@@ -1,0 +1,49 @@
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="WorkspaceResourceCounts")
+
+
+@_attrs_define
+class WorkspaceResourceCounts:
+    """Per-resource counts (agents, functions, models, sandboxes, policies, jobs, volumes, drives, volumetemplates,
+    integrationconnections, previews, customdomains, serviceaccounts, images). Only populated when GetWorkspace is
+    called with ?countResources=true.
+
+    """
+
+    additional_properties: dict[str, int] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        workspace_resource_counts = cls()
+
+        workspace_resource_counts.additional_properties = d
+        return workspace_resource_counts
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> int:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: int) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/client/models/workspace_runtime.py
+++ b/src/blaxel/core/client/models/workspace_runtime.py
@@ -1,9 +1,13 @@
-from typing import Any, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.workspace_sandbox_settings import WorkspaceSandboxSettings
+
 
 T = TypeVar("T", bound="WorkspaceRuntime")
 
@@ -15,31 +19,56 @@ class WorkspaceRuntime:
     Attributes:
         generation (Union[Unset, str]): Infrastructure generation version for the workspace (affects available features
             and deployment behavior) Example: mk3.
+        sandbox (Union[Unset, WorkspaceSandboxSettings]): Workspace-wide sandbox configuration that applies to all
+            sandbox deployments in the workspace.
     """
 
     generation: Union[Unset, str] = UNSET
+    sandbox: Union[Unset, "WorkspaceSandboxSettings"] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         generation = self.generation
+
+        sandbox: Union[Unset, dict[str, Any]] = UNSET
+        if (
+            self.sandbox
+            and not isinstance(self.sandbox, Unset)
+            and not isinstance(self.sandbox, dict)
+        ):
+            sandbox = self.sandbox.to_dict()
+        elif self.sandbox and isinstance(self.sandbox, dict):
+            sandbox = self.sandbox
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if generation is not UNSET:
             field_dict["generation"] = generation
+        if sandbox is not UNSET:
+            field_dict["sandbox"] = sandbox
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        from ..models.workspace_sandbox_settings import WorkspaceSandboxSettings
+
         if not src_dict:
             return None
         d = src_dict.copy()
         generation = d.pop("generation", UNSET)
 
+        _sandbox = d.pop("sandbox", UNSET)
+        sandbox: Union[Unset, WorkspaceSandboxSettings]
+        if isinstance(_sandbox, Unset):
+            sandbox = UNSET
+        else:
+            sandbox = WorkspaceSandboxSettings.from_dict(_sandbox)
+
         workspace_runtime = cls(
             generation=generation,
+            sandbox=sandbox,
         )
 
         workspace_runtime.additional_properties = d

--- a/src/blaxel/core/client/models/workspace_sandbox_settings.py
+++ b/src/blaxel/core/client/models/workspace_sandbox_settings.py
@@ -1,0 +1,65 @@
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="WorkspaceSandboxSettings")
+
+
+@_attrs_define
+class WorkspaceSandboxSettings:
+    """Workspace-wide sandbox configuration that applies to all sandbox deployments in the workspace.
+
+    Attributes:
+        disable_process_logging (Union[Unset, bool]): When true, sandbox deployments in this workspace set
+            SANDBOX_DISABLE_PROCESS_LOGGING=true to disable per-process stdout/stderr logging. Requires sandbox-api
+            v0.2.28+.
+    """
+
+    disable_process_logging: Union[Unset, bool] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        disable_process_logging = self.disable_process_logging
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if disable_process_logging is not UNSET:
+            field_dict["disableProcessLogging"] = disable_process_logging
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+        if not src_dict:
+            return None
+        d = src_dict.copy()
+        disable_process_logging = d.pop(
+            "disableProcessLogging", d.pop("disable_process_logging", UNSET)
+        )
+
+        workspace_sandbox_settings = cls(
+            disable_process_logging=disable_process_logging,
+        )
+
+        workspace_sandbox_settings.additional_properties = d
+        return workspace_sandbox_settings
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/blaxel/core/drive/drive.py
+++ b/src/blaxel/core/drive/drive.py
@@ -19,6 +19,7 @@ from ..client.errors import UnexpectedStatus
 from ..client.models import Drive, DriveSpec, Metadata
 from ..client.models.error import Error
 from ..client.types import UNSET
+from ..common.internal import list_response_items as _list_response_items
 from ..common.settings import settings
 
 
@@ -29,17 +30,6 @@ class DriveAPIError(Exception):
         super().__init__(message)
         self.status_code = status_code
         self.code = code
-
-
-def _list_response_items(response):
-    if response is None:
-        return []
-
-    data = getattr(response, "data", response)
-    if data is UNSET or data is None:
-        return []
-
-    return data
 
 
 class _AsyncDeleteDescriptor:

--- a/src/blaxel/core/drive/drive.py
+++ b/src/blaxel/core/drive/drive.py
@@ -31,6 +31,17 @@ class DriveAPIError(Exception):
         self.code = code
 
 
+def _list_response_items(response):
+    if response is None:
+        return []
+
+    data = getattr(response, "data", response)
+    if data is UNSET or data is None:
+        return []
+
+    return data
+
+
 class _AsyncDeleteDescriptor:
     """Descriptor that provides both class-level and instance-level delete functionality."""
 
@@ -249,7 +260,11 @@ class DriveInstance:
     @classmethod
     async def list(cls) -> list["DriveInstance"]:
         response = await list_drives(client=client)
-        return [cls(drive) for drive in response or []]
+        if isinstance(response, Error):
+            status_code = int(response.code) if response.code is not UNSET else None
+            message = response.message if response.message is not UNSET else response.error
+            raise DriveAPIError(message, status_code=status_code, code=response.error)
+        return [cls(drive) for drive in _list_response_items(response)]
 
     @classmethod
     async def create_if_not_exists(
@@ -401,7 +416,11 @@ class SyncDriveInstance:
     def list(cls) -> List["SyncDriveInstance"]:
         """List all drives synchronously."""
         response = list_drives_sync(client=client)
-        return [cls(drive) for drive in response or []]
+        if isinstance(response, Error):
+            status_code = int(response.code) if response.code is not UNSET else None
+            message = response.message if response.message is not UNSET else response.error
+            raise DriveAPIError(message, status_code=status_code, code=response.error)
+        return [cls(drive) for drive in _list_response_items(response)]
 
     @classmethod
     def create_if_not_exists(

--- a/src/blaxel/core/jobs/__init__.py
+++ b/src/blaxel/core/jobs/__init__.py
@@ -18,18 +18,7 @@ from ..client.models.create_job_execution_request import (
     CreateJobExecutionRequest,
 )
 from ..client.models.job_execution import JobExecution
-from ..client.types import UNSET
-
-
-def _list_response_items(response):
-    if response is None:
-        return []
-
-    data = getattr(response, "data", response)
-    if data is UNSET or data is None:
-        return []
-
-    return data
+from ..common.internal import list_response_items as _list_response_items
 
 
 class BlJobWrapper:

--- a/src/blaxel/core/jobs/__init__.py
+++ b/src/blaxel/core/jobs/__init__.py
@@ -18,6 +18,18 @@ from ..client.models.create_job_execution_request import (
     CreateJobExecutionRequest,
 )
 from ..client.models.job_execution import JobExecution
+from ..client.types import UNSET
+
+
+def _list_response_items(response):
+    if response is None:
+        return []
+
+    data = getattr(response, "data", response)
+    if data is UNSET or data is None:
+        return []
+
+    return data
 
 
 class BlJobWrapper:
@@ -308,7 +320,7 @@ class BlJob:
         if response.status_code != 200:
             raise Exception(f"Failed to list job executions: {response.status_code}")
 
-        return response.parsed or []
+        return _list_response_items(response.parsed)
 
     async def alist_executions(self, limit: int = 20, offset: int = 0) -> List[JobExecution]:
         """
@@ -333,7 +345,7 @@ class BlJob:
         if response.status_code != 200:
             raise Exception(f"Failed to list job executions: {response.status_code}")
 
-        return response.parsed or []
+        return _list_response_items(response.parsed)
 
     def get_execution_status(self, execution_id: str) -> str:
         """

--- a/src/blaxel/core/sandbox/client/api/codegen/get_codegen_reranking_path.py
+++ b/src/blaxel/core/sandbox/client/api/codegen/get_codegen_reranking_path.py
@@ -43,19 +43,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, RerankingResponse] | None:
     if response.status_code == 200:
-        response_200 = RerankingResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = RerankingResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 503:
-        response_503 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_503 = ErrorResponse.from_dict(_response_content)
 
         return response_503
     if client.raise_on_unexpected_status:
@@ -109,6 +149,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -164,6 +205,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -214,6 +256,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -267,6 +310,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/drive/delete_drives_mount_mount_path.py
+++ b/src/blaxel/core/sandbox/client/api/drive/delete_drives_mount_mount_path.py
@@ -25,15 +25,45 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[DriveUnmountResponse, ErrorResponse] | None:
     if response.status_code == 200:
-        response_200 = DriveUnmountResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = DriveUnmountResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -67,6 +97,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -98,6 +129,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -124,6 +156,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -153,6 +186,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/drive/get_drives_mount.py
+++ b/src/blaxel/core/sandbox/client/api/drive/get_drives_mount.py
@@ -23,11 +23,31 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[DriveListResponse, ErrorResponse] | None:
     if response.status_code == 200:
-        response_200 = DriveListResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = DriveListResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -57,6 +77,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -82,6 +103,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -103,6 +125,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -126,6 +149,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/drive/post_drives_mount.py
+++ b/src/blaxel/core/sandbox/client/api/drive/post_drives_mount.py
@@ -74,7 +74,10 @@ def sync_detailed(
     """Attach a drive to a local path
 
      Mounts an agent drive using the blfs binary to a local path, optionally mounting a subpath within
-    the drive
+    the drive. Supports optional UID/GID mapping to remap file ownership between the local sandbox and
+    the filer (always mapped to filer UID/GID 0). Mapping values can be set per-request via
+    uidMap/gidMap fields, or globally via BLFS_UID_MAP/BLFS_GID_MAP environment variables (request
+    values take precedence).
 
     Args:
         body (DriveMountRequest):
@@ -106,7 +109,10 @@ def sync(
     """Attach a drive to a local path
 
      Mounts an agent drive using the blfs binary to a local path, optionally mounting a subpath within
-    the drive
+    the drive. Supports optional UID/GID mapping to remap file ownership between the local sandbox and
+    the filer (always mapped to filer UID/GID 0). Mapping values can be set per-request via
+    uidMap/gidMap fields, or globally via BLFS_UID_MAP/BLFS_GID_MAP environment variables (request
+    values take precedence).
 
     Args:
         body (DriveMountRequest):
@@ -133,7 +139,10 @@ async def asyncio_detailed(
     """Attach a drive to a local path
 
      Mounts an agent drive using the blfs binary to a local path, optionally mounting a subpath within
-    the drive
+    the drive. Supports optional UID/GID mapping to remap file ownership between the local sandbox and
+    the filer (always mapped to filer UID/GID 0). Mapping values can be set per-request via
+    uidMap/gidMap fields, or globally via BLFS_UID_MAP/BLFS_GID_MAP environment variables (request
+    values take precedence).
 
     Args:
         body (DriveMountRequest):
@@ -163,7 +172,10 @@ async def asyncio(
     """Attach a drive to a local path
 
      Mounts an agent drive using the blfs binary to a local path, optionally mounting a subpath within
-    the drive
+    the drive. Supports optional UID/GID mapping to remap file ownership between the local sandbox and
+    the filer (always mapped to filer UID/GID 0). Mapping values can be set per-request via
+    uidMap/gidMap fields, or globally via BLFS_UID_MAP/BLFS_GID_MAP environment variables (request
+    values take precedence).
 
     Args:
         body (DriveMountRequest):

--- a/src/blaxel/core/sandbox/client/api/drive/post_drives_mount.py
+++ b/src/blaxel/core/sandbox/client/api/drive/post_drives_mount.py
@@ -38,15 +38,45 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[DriveMountResponse, ErrorResponse] | None:
     if response.status_code == 200:
-        response_200 = DriveMountResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = DriveMountResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -84,6 +114,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -119,6 +150,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -149,6 +181,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -182,6 +215,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/fastapply/put_codegen_fastapply_path.py
+++ b/src/blaxel/core/sandbox/client/api/fastapply/put_codegen_fastapply_path.py
@@ -39,19 +39,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ApplyEditResponse, ErrorResponse] | None:
     if response.status_code == 200:
-        response_200 = ApplyEditResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = ApplyEditResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 503:
-        response_503 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_503 = ErrorResponse.from_dict(_response_content)
 
         return response_503
     if client.raise_on_unexpected_status:
@@ -121,6 +161,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -189,6 +230,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -252,6 +294,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -318,6 +361,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/delete_filesystem_multipart_upload_id_abort.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/delete_filesystem_multipart_upload_id_abort.py
@@ -25,19 +25,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, SuccessResponse] | None:
     if response.status_code == 200:
-        response_200 = SuccessResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = SuccessResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 404:
-        response_404 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = ErrorResponse.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -71,6 +111,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -102,6 +143,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -128,6 +170,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -157,6 +200,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/delete_filesystem_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/delete_filesystem_path.py
@@ -34,19 +34,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, SuccessResponse] | None:
     if response.status_code == 200:
-        response_200 = SuccessResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = SuccessResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 404:
-        response_404 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = ErrorResponse.from_dict(_response_content)
 
         return response_404
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -82,6 +122,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -116,6 +157,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -145,6 +187,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -177,6 +220,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/delete_filesystem_tree_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/delete_filesystem_tree_path.py
@@ -34,19 +34,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, SuccessResponse] | None:
     if response.status_code == 200:
-        response_200 = SuccessResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = SuccessResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -82,6 +122,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -116,6 +157,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -145,6 +187,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -177,6 +220,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_content_search_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_content_search_path.py
@@ -46,19 +46,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ContentSearchResponse, ErrorResponse] | None:
     if response.status_code == 200:
-        response_200 = ContentSearchResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = ContentSearchResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -102,6 +142,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -148,6 +189,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -189,6 +231,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -233,6 +276,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_find_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_find_path.py
@@ -46,19 +46,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, FindResponse] | None:
     if response.status_code == 200:
-        response_200 = FindResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = FindResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -102,6 +142,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -148,6 +189,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -189,6 +231,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -233,6 +276,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_multipart.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_multipart.py
@@ -23,11 +23,31 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, MultipartListUploadsResponse] | None:
     if response.status_code == 200:
-        response_200 = MultipartListUploadsResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = MultipartListUploadsResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -57,6 +77,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -82,6 +103,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -103,6 +125,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -126,6 +149,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_multipart_upload_id_parts.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_multipart_upload_id_parts.py
@@ -25,19 +25,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, MultipartListPartsResponse] | None:
     if response.status_code == 200:
-        response_200 = MultipartListPartsResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = MultipartListPartsResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 404:
-        response_404 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = ErrorResponse.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -71,6 +111,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -102,6 +143,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -128,6 +170,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -157,6 +200,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_path.py
@@ -36,6 +36,16 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, Union["Directory", "FileWithContent", File]] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
 
         def _parse_response_200(data: object) -> Union["Directory", "FileWithContent", File]:
             try:
@@ -60,19 +70,49 @@ def _parse_response(
 
             return response_200_type_2
 
-        response_200 = _parse_response_200(response.json())
+        response_200 = _parse_response_200(_response_content)
 
         return response_200
     if response.status_code == 404:
-        response_404 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = ErrorResponse.from_dict(_response_content)
 
         return response_404
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -109,6 +149,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +185,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -174,6 +216,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -207,6 +250,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_search_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_search_path.py
@@ -43,19 +43,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, FuzzySearchResponse] | None:
     if response.status_code == 200:
-        response_200 = FuzzySearchResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = FuzzySearchResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -98,6 +138,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -142,6 +183,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -181,6 +223,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -223,6 +266,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_tree_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_tree_path.py
@@ -27,6 +27,16 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, Union["Directory", "FileWithContent", File]] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
 
         def _parse_response_200(data: object) -> Union["Directory", "FileWithContent", File]:
             try:
@@ -51,19 +61,49 @@ def _parse_response(
 
             return response_200_type_2
 
-        response_200 = _parse_response_200(response.json())
+        response_200 = _parse_response_200(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -97,6 +137,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -128,6 +169,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -154,6 +196,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -183,6 +226,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/post_filesystem_multipart_initiate_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/post_filesystem_multipart_initiate_path.py
@@ -39,15 +39,45 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, MultipartInitiateResponse] | None:
     if response.status_code == 200:
-        response_200 = MultipartInitiateResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = MultipartInitiateResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -83,6 +113,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -117,6 +148,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -146,6 +178,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -178,6 +211,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/post_filesystem_multipart_upload_id_complete.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/post_filesystem_multipart_upload_id_complete.py
@@ -39,19 +39,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, SuccessResponse] | None:
     if response.status_code == 200:
-        response_200 = SuccessResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = SuccessResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 404:
-        response_404 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = ErrorResponse.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -87,6 +127,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -121,6 +162,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -150,6 +192,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -182,6 +225,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/put_filesystem_multipart_upload_id_part.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/put_filesystem_multipart_upload_id_part.py
@@ -45,19 +45,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, MultipartUploadPartResponse] | None:
     if response.status_code == 200:
-        response_200 = MultipartUploadPartResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = MultipartUploadPartResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 404:
-        response_404 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = ErrorResponse.from_dict(_response_content)
 
         return response_404
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -95,6 +135,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -132,6 +173,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -164,6 +206,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -199,6 +242,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/put_filesystem_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/put_filesystem_path.py
@@ -39,19 +39,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, SuccessResponse] | None:
     if response.status_code == 200:
-        response_200 = SuccessResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = SuccessResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -87,6 +127,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -121,6 +162,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -150,6 +192,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -182,6 +225,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/filesystem/put_filesystem_tree_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/put_filesystem_tree_path.py
@@ -41,6 +41,16 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, Union["Directory", "FileWithContent", File]] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
 
         def _parse_response_200(data: object) -> Union["Directory", "FileWithContent", File]:
             try:
@@ -65,19 +75,49 @@ def _parse_response(
 
             return response_200_type_2
 
-        response_200 = _parse_response_200(response.json())
+        response_200 = _parse_response_200(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -113,6 +153,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -147,6 +188,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -176,6 +218,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -208,6 +251,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/network/delete_network_process_pid_monitor.py
+++ b/src/blaxel/core/sandbox/client/api/network/delete_network_process_pid_monitor.py
@@ -27,19 +27,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[DeleteNetworkProcessPidMonitorResponse200, ErrorResponse] | None:
     if response.status_code == 200:
-        response_200 = DeleteNetworkProcessPidMonitorResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = DeleteNetworkProcessPidMonitorResponse200.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -73,6 +113,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,6 +145,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -130,6 +172,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -159,6 +202,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/network/delete_network_tunnel.py
+++ b/src/blaxel/core/sandbox/client/api/network/delete_network_tunnel.py
@@ -23,15 +23,45 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, SuccessResponse] | None:
     if response.status_code == 200:
-        response_200 = SuccessResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = SuccessResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -64,6 +94,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -92,6 +123,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -116,6 +148,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -142,6 +175,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/network/get_network_process_pid_ports.py
+++ b/src/blaxel/core/sandbox/client/api/network/get_network_process_pid_ports.py
@@ -27,19 +27,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, GetNetworkProcessPidPortsResponse200] | None:
     if response.status_code == 200:
-        response_200 = GetNetworkProcessPidPortsResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = GetNetworkProcessPidPortsResponse200.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -73,6 +113,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,6 +145,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -130,6 +172,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -159,6 +202,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/network/post_network_process_pid_monitor.py
+++ b/src/blaxel/core/sandbox/client/api/network/post_network_process_pid_monitor.py
@@ -41,19 +41,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, PostNetworkProcessPidMonitorResponse200] | None:
     if response.status_code == 200:
-        response_200 = PostNetworkProcessPidMonitorResponse200.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = PostNetworkProcessPidMonitorResponse200.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -89,6 +129,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -123,6 +164,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -152,6 +194,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -184,6 +227,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/network/put_network_tunnel_config.py
+++ b/src/blaxel/core/sandbox/client/api/network/put_network_tunnel_config.py
@@ -38,19 +38,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, SuccessResponse] | None:
     if response.status_code == 200:
-        response_200 = SuccessResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = SuccessResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -85,6 +125,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -117,6 +158,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +186,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -174,6 +217,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/process/delete_process_identifier.py
+++ b/src/blaxel/core/sandbox/client/api/process/delete_process_identifier.py
@@ -25,19 +25,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, SuccessResponse] | None:
     if response.status_code == 200:
-        response_200 = SuccessResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = SuccessResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 404:
-        response_404 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = ErrorResponse.from_dict(_response_content)
 
         return response_404
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -71,6 +111,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -102,6 +143,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -128,6 +170,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -157,6 +200,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/process/delete_process_identifier_kill.py
+++ b/src/blaxel/core/sandbox/client/api/process/delete_process_identifier_kill.py
@@ -25,19 +25,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, SuccessResponse] | None:
     if response.status_code == 200:
-        response_200 = SuccessResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = SuccessResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 404:
-        response_404 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = ErrorResponse.from_dict(_response_content)
 
         return response_404
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -71,6 +111,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -102,6 +143,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -128,6 +170,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -157,6 +200,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/process/get_process.py
+++ b/src/blaxel/core/sandbox/client/api/process/get_process.py
@@ -20,8 +20,18 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> list["ProcessResponse"] | None:
     if response.status_code == 200:
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
         response_200 = []
-        _response_200 = response.json()
+        _response_200 = _response_content
         for response_200_item_data in _response_200:
             response_200_item = ProcessResponse.from_dict(response_200_item_data)
 
@@ -55,6 +65,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -80,6 +91,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -101,6 +113,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -124,6 +137,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/process/get_process_identifier.py
+++ b/src/blaxel/core/sandbox/client/api/process/get_process_identifier.py
@@ -25,11 +25,31 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, ProcessResponse] | None:
     if response.status_code == 200:
-        response_200 = ProcessResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = ProcessResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 404:
-        response_404 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = ErrorResponse.from_dict(_response_content)
 
         return response_404
     if client.raise_on_unexpected_status:
@@ -63,6 +83,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -94,6 +115,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -120,6 +142,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -149,6 +172,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/process/get_process_identifier_logs.py
+++ b/src/blaxel/core/sandbox/client/api/process/get_process_identifier_logs.py
@@ -25,19 +25,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, ProcessLogs] | None:
     if response.status_code == 200:
-        response_200 = ProcessLogs.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = ProcessLogs.from_dict(_response_content)
 
         return response_200
     if response.status_code == 404:
-        response_404 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_404 = ErrorResponse.from_dict(_response_content)
 
         return response_404
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -71,6 +111,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -102,6 +143,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -128,6 +170,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -157,6 +200,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/process/post_process.py
+++ b/src/blaxel/core/sandbox/client/api/process/post_process.py
@@ -38,19 +38,59 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, ProcessResponse] | None:
     if response.status_code == 200:
-        response_200 = ProcessResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = ProcessResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 400:
-        response_400 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_400 = ErrorResponse.from_dict(_response_content)
 
         return response_400
     if response.status_code == 422:
-        response_422 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_422 = ErrorResponse.from_dict(_response_content)
 
         return response_422
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -85,6 +125,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -117,6 +158,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -144,6 +186,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -174,6 +217,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/system/get_health.py
+++ b/src/blaxel/core/sandbox/client/api/system/get_health.py
@@ -20,7 +20,17 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(*, client: Client, response: httpx.Response) -> HealthResponse | None:
     if response.status_code == 200:
-        response_200 = HealthResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = HealthResponse.from_dict(_response_content)
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -49,6 +59,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -75,6 +86,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -97,6 +109,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -121,6 +134,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/api/system/post_upgrade.py
+++ b/src/blaxel/core/sandbox/client/api/system/post_upgrade.py
@@ -38,11 +38,31 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Union[ErrorResponse, SuccessResponse] | None:
     if response.status_code == 200:
-        response_200 = SuccessResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_200 = SuccessResponse.from_dict(_response_content)
 
         return response_200
     if response.status_code == 500:
-        response_500 = ErrorResponse.from_dict(response.json())
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        response_500 = ErrorResponse.from_dict(_response_content)
 
         return response_500
     if client.raise_on_unexpected_status:
@@ -81,6 +101,7 @@ def sync_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -117,6 +138,7 @@ def sync(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -148,6 +170,7 @@ async def asyncio_detailed(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -182,6 +205,7 @@ async def asyncio(
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/src/blaxel/core/sandbox/client/errors.py
+++ b/src/blaxel/core/sandbox/client/errors.py
@@ -13,4 +13,24 @@ class UnexpectedStatus(Exception):
         )
 
 
-__all__ = ["UnexpectedStatus"]
+class ResponseParseError(Exception):
+    """Raised by api functions when a documented response body cannot be parsed"""
+
+    def __init__(self, status_code: int, content: bytes, content_type: str | None = None):
+        self.status_code = status_code
+        self.content = content
+        self.content_type = content_type
+
+        preview = content[:500].decode(errors="replace")
+        if len(content) > 500:
+            preview = f"{preview}..."
+
+        content_type_text = content_type or "unknown content type"
+        super().__init__(
+            "Could not parse response body for documented status code "
+            f"{status_code} as JSON ({content_type_text}).\n\n"
+            f"Response content:\n{preview}"
+        )
+
+
+__all__ = ["ResponseParseError", "UnexpectedStatus"]

--- a/src/blaxel/core/sandbox/client/models/drive_mount_info.py
+++ b/src/blaxel/core/sandbox/client/models/drive_mount_info.py
@@ -14,14 +14,18 @@ class DriveMountInfo:
     Attributes:
         drive_name (Union[Unset, str]):
         drive_path (Union[Unset, str]):
+        gid_map (Union[Unset, str]): The local GID used for this mount
         mount_path (Union[Unset, str]):
         read_only (Union[Unset, bool]):
+        uid_map (Union[Unset, str]): The local UID used for this mount
     """
 
     drive_name: Union[Unset, str] = UNSET
     drive_path: Union[Unset, str] = UNSET
+    gid_map: Union[Unset, str] = UNSET
     mount_path: Union[Unset, str] = UNSET
     read_only: Union[Unset, bool] = UNSET
+    uid_map: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -29,9 +33,13 @@ class DriveMountInfo:
 
         drive_path = self.drive_path
 
+        gid_map = self.gid_map
+
         mount_path = self.mount_path
 
         read_only = self.read_only
+
+        uid_map = self.uid_map
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -40,10 +48,14 @@ class DriveMountInfo:
             field_dict["driveName"] = drive_name
         if drive_path is not UNSET:
             field_dict["drivePath"] = drive_path
+        if gid_map is not UNSET:
+            field_dict["gidMap"] = gid_map
         if mount_path is not UNSET:
             field_dict["mountPath"] = mount_path
         if read_only is not UNSET:
             field_dict["readOnly"] = read_only
+        if uid_map is not UNSET:
+            field_dict["uidMap"] = uid_map
 
         return field_dict
 
@@ -56,15 +68,21 @@ class DriveMountInfo:
 
         drive_path = d.pop("drivePath", d.pop("drive_path", UNSET))
 
+        gid_map = d.pop("gidMap", d.pop("gid_map", UNSET))
+
         mount_path = d.pop("mountPath", d.pop("mount_path", UNSET))
 
         read_only = d.pop("readOnly", d.pop("read_only", UNSET))
 
+        uid_map = d.pop("uidMap", d.pop("uid_map", UNSET))
+
         drive_mount_info = cls(
             drive_name=drive_name,
             drive_path=drive_path,
+            gid_map=gid_map,
             mount_path=mount_path,
             read_only=read_only,
+            uid_map=uid_map,
         )
 
         drive_mount_info.additional_properties = d

--- a/src/blaxel/core/sandbox/client/models/drive_mount_request.py
+++ b/src/blaxel/core/sandbox/client/models/drive_mount_request.py
@@ -15,13 +15,17 @@ class DriveMountRequest:
         drive_name (str):
         mount_path (str):
         drive_path (Union[Unset, str]): Optional, defaults to "/"
+        gid_map (Union[Unset, str]): Optional, local GID to map (filer GID is always 0)
         read_only (Union[Unset, bool]): Optional, defaults to false
+        uid_map (Union[Unset, str]): Optional, local UID to map (filer UID is always 0)
     """
 
     drive_name: str
     mount_path: str
     drive_path: Union[Unset, str] = UNSET
+    gid_map: Union[Unset, str] = UNSET
     read_only: Union[Unset, bool] = UNSET
+    uid_map: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -31,7 +35,11 @@ class DriveMountRequest:
 
         drive_path = self.drive_path
 
+        gid_map = self.gid_map
+
         read_only = self.read_only
+
+        uid_map = self.uid_map
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -43,8 +51,12 @@ class DriveMountRequest:
         )
         if drive_path is not UNSET:
             field_dict["drivePath"] = drive_path
+        if gid_map is not UNSET:
+            field_dict["gidMap"] = gid_map
         if read_only is not UNSET:
             field_dict["readOnly"] = read_only
+        if uid_map is not UNSET:
+            field_dict["uidMap"] = uid_map
 
         return field_dict
 
@@ -59,13 +71,19 @@ class DriveMountRequest:
 
         drive_path = d.pop("drivePath", d.pop("drive_path", UNSET))
 
+        gid_map = d.pop("gidMap", d.pop("gid_map", UNSET))
+
         read_only = d.pop("readOnly", d.pop("read_only", UNSET))
+
+        uid_map = d.pop("uidMap", d.pop("uid_map", UNSET))
 
         drive_mount_request = cls(
             drive_name=drive_name,
             mount_path=mount_path,
             drive_path=drive_path,
+            gid_map=gid_map,
             read_only=read_only,
+            uid_map=uid_map,
         )
 
         drive_mount_request.additional_properties = d

--- a/src/blaxel/core/sandbox/client/models/drive_mount_response.py
+++ b/src/blaxel/core/sandbox/client/models/drive_mount_response.py
@@ -14,24 +14,30 @@ class DriveMountResponse:
     Attributes:
         drive_name (Union[Unset, str]):
         drive_path (Union[Unset, str]):
+        gid_map (Union[Unset, str]): The local GID used for this mount
         message (Union[Unset, str]):
         mount_path (Union[Unset, str]):
         read_only (Union[Unset, bool]):
         success (Union[Unset, bool]):
+        uid_map (Union[Unset, str]): The local UID used for this mount
     """
 
     drive_name: Union[Unset, str] = UNSET
     drive_path: Union[Unset, str] = UNSET
+    gid_map: Union[Unset, str] = UNSET
     message: Union[Unset, str] = UNSET
     mount_path: Union[Unset, str] = UNSET
     read_only: Union[Unset, bool] = UNSET
     success: Union[Unset, bool] = UNSET
+    uid_map: Union[Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         drive_name = self.drive_name
 
         drive_path = self.drive_path
+
+        gid_map = self.gid_map
 
         message = self.message
 
@@ -41,6 +47,8 @@ class DriveMountResponse:
 
         success = self.success
 
+        uid_map = self.uid_map
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -48,6 +56,8 @@ class DriveMountResponse:
             field_dict["driveName"] = drive_name
         if drive_path is not UNSET:
             field_dict["drivePath"] = drive_path
+        if gid_map is not UNSET:
+            field_dict["gidMap"] = gid_map
         if message is not UNSET:
             field_dict["message"] = message
         if mount_path is not UNSET:
@@ -56,6 +66,8 @@ class DriveMountResponse:
             field_dict["readOnly"] = read_only
         if success is not UNSET:
             field_dict["success"] = success
+        if uid_map is not UNSET:
+            field_dict["uidMap"] = uid_map
 
         return field_dict
 
@@ -68,6 +80,8 @@ class DriveMountResponse:
 
         drive_path = d.pop("drivePath", d.pop("drive_path", UNSET))
 
+        gid_map = d.pop("gidMap", d.pop("gid_map", UNSET))
+
         message = d.pop("message", UNSET)
 
         mount_path = d.pop("mountPath", d.pop("mount_path", UNSET))
@@ -76,13 +90,17 @@ class DriveMountResponse:
 
         success = d.pop("success", UNSET)
 
+        uid_map = d.pop("uidMap", d.pop("uid_map", UNSET))
+
         drive_mount_response = cls(
             drive_name=drive_name,
             drive_path=drive_path,
+            gid_map=gid_map,
             message=message,
             mount_path=mount_path,
             read_only=read_only,
             success=success,
+            uid_map=uid_map,
         )
 
         drive_mount_response.additional_properties = d

--- a/src/blaxel/core/sandbox/client/models/process_request.py
+++ b/src/blaxel/core/sandbox/client/models/process_request.py
@@ -20,7 +20,8 @@ class ProcessRequest:
         env (Union[Unset, ProcessRequestEnv]):  Example: {'{"PORT"': ' "3000"}'}.
         keep_alive (Union[Unset, bool]): Disable scale-to-zero while process runs. Default timeout is 600s (10 minutes).
             Set timeout to 0 for infinite.
-        max_restarts (Union[Unset, int]):  Example: 3.
+        max_restarts (Union[Unset, int]): Maximum number of restarts on failure. Set to a negative value (e.g. -1) for
+            unlimited restarts. Example: 3.
         name (Union[Unset, str]):  Example: my-process.
         restart_on_failure (Union[Unset, bool]):  Example: True.
         timeout (Union[Unset, int]): Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0

--- a/src/blaxel/core/sandbox/default/sandbox.py
+++ b/src/blaxel/core/sandbox/default/sandbox.py
@@ -45,6 +45,17 @@ from .session import SandboxSessions
 from .system import SandboxSystem
 
 
+def _list_response_items(response):
+    if response is None:
+        return []
+
+    data = getattr(response, "data", response)
+    if data is UNSET or data is None:
+        return []
+
+    return data
+
+
 class SandboxAPIError(Exception):
     """Exception raised when sandbox API returns an error."""
 
@@ -357,7 +368,11 @@ class SandboxInstance:
     @classmethod
     async def list(cls) -> List["SandboxInstance"]:
         response = await list_sandboxes(client=client)
-        return [cls(sandbox) for sandbox in response]
+        if isinstance(response, Error):
+            status_code = response.code if response.code is not UNSET else None
+            message = response.message if response.message is not UNSET else response.error
+            raise SandboxAPIError(message, status_code=status_code, code=response.error)
+        return [cls(sandbox) for sandbox in _list_response_items(response)]
 
     @classmethod
     async def update_metadata(

--- a/src/blaxel/core/sandbox/sync/sandbox.py
+++ b/src/blaxel/core/sandbox/sync/sandbox.py
@@ -31,6 +31,7 @@ from ..default.sandbox import (
     NON_REUSABLE_SANDBOX_STATUSES,
     SandboxAPIError,
     _is_sandbox_conflict,
+    _list_response_items,
     _sandbox_name,
 )
 from ..types import (
@@ -297,7 +298,11 @@ class SyncSandboxInstance:
     @classmethod
     def list(cls) -> List["SyncSandboxInstance"]:
         response = list_sandboxes(client=client)
-        return [cls(sandbox) for sandbox in response]
+        if isinstance(response, Error):
+            status_code = response.code if response.code is not UNSET else None
+            message = response.message if response.message is not UNSET else response.error
+            raise SandboxAPIError(message, status_code=status_code, code=response.error)
+        return [cls(sandbox) for sandbox in _list_response_items(response)]
 
     @classmethod
     def update_metadata(

--- a/src/blaxel/core/volume/volume.py
+++ b/src/blaxel/core/volume/volume.py
@@ -30,6 +30,17 @@ class VolumeAPIError(Exception):
         self.code = code
 
 
+def _list_response_items(response):
+    if response is None:
+        return []
+
+    data = getattr(response, "data", response)
+    if data is UNSET or data is None:
+        return []
+
+    return data
+
+
 class _AsyncDeleteDescriptor:
     """Descriptor that provides both class-level and instance-level delete functionality."""
 
@@ -256,7 +267,11 @@ class VolumeInstance:
     @classmethod
     async def list(cls) -> list["VolumeInstance"]:
         response = await list_volumes(client=client)
-        return [cls(volume) for volume in response or []]
+        if isinstance(response, Error):
+            status_code = int(response.code) if response.code is not UNSET else None
+            message = response.message if response.message is not UNSET else response.error
+            raise VolumeAPIError(message, status_code=status_code, code=response.error)
+        return [cls(volume) for volume in _list_response_items(response)]
 
     @classmethod
     async def create_if_not_exists(
@@ -410,7 +425,11 @@ class SyncVolumeInstance:
     def list(cls) -> List["SyncVolumeInstance"]:
         """List all volumes synchronously."""
         response = list_volumes_sync(client=client)
-        return [cls(volume) for volume in response or []]
+        if isinstance(response, Error):
+            status_code = int(response.code) if response.code is not UNSET else None
+            message = response.message if response.message is not UNSET else response.error
+            raise VolumeAPIError(message, status_code=status_code, code=response.error)
+        return [cls(volume) for volume in _list_response_items(response)]
 
     @classmethod
     def create_if_not_exists(

--- a/src/blaxel/core/volume/volume.py
+++ b/src/blaxel/core/volume/volume.py
@@ -18,6 +18,7 @@ from ..client.client import client
 from ..client.models import Metadata, Volume, VolumeSpec
 from ..client.models.error import Error
 from ..client.types import UNSET
+from ..common.internal import list_response_items as _list_response_items
 from ..common.settings import settings
 
 
@@ -28,17 +29,6 @@ class VolumeAPIError(Exception):
         super().__init__(message)
         self.status_code = status_code
         self.code = code
-
-
-def _list_response_items(response):
-    if response is None:
-        return []
-
-    data = getattr(response, "data", response)
-    if data is UNSET or data is None:
-        return []
-
-    return data
 
 
 class _AsyncDeleteDescriptor:

--- a/templates/endpoint_macros.py.jinja
+++ b/templates/endpoint_macros.py.jinja
@@ -167,6 +167,15 @@ Args:
 {% endif %}
 Raises:
     errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+{% set has_json_responses = namespace(value=false) %}
+{% for response in endpoint.responses %}
+{% if response.source.attribute == "response.json()" %}
+{% set has_json_responses.value = true %}
+{% endif %}
+{% endfor %}
+{% if has_json_responses.value %}
+    errors.ResponseParseError: If a documented response body cannot be parsed and Client.raise_on_unexpected_status is True.
+{% endif %}
     httpx.TimeoutException: If the request takes longer than Client.timeout.
 
 Returns:

--- a/templates/endpoint_module.py.jinja
+++ b/templates/endpoint_module.py.jinja
@@ -72,12 +72,26 @@ def _parse_response(*, client: Client, response: httpx.Response) -> {{ return_st
     {% for response in endpoint.responses %}
     if response.status_code == {{ response.status_code.value }}:
         {% if parsed_responses %}{% import "property_templates/" + response.prop.template as prop_template %}
+        {% set response_source = response.source.attribute %}
+        {% if response_source == "response.json()" %}
+        try:
+            _response_content = response.json()
+        except ValueError as exc:
+            if client.raise_on_unexpected_status:
+                raise errors.ResponseParseError(
+                    response.status_code,
+                    response.content,
+                    response.headers.get("Content-Type"),
+                ) from exc
+            return None
+        {% set response_source = "_response_content" %}
+        {% endif %}
         {% if prop_template.construct %}
-        {{ prop_template.construct(response.prop, response.source.attribute) | indent(8) }}
+        {{ prop_template.construct(response.prop, response_source) | indent(8) }}
         {% elif response.source.return_type == response.prop.get_type_string()  %}
-        {{ response.prop.python_name }} = {{ response.source.attribute }}
+        {{ response.prop.python_name }} = {{ response_source }}
         {% else %}
-        {{ response.prop.python_name }} = cast({{ response.prop.get_type_string() }}, {{ response.source.attribute }})
+        {{ response.prop.python_name }} = cast({{ response.prop.get_type_string() }}, {{ response_source }})
         {% endif %}
         return {{ response.prop.python_name }}
         {% else %}

--- a/templates/endpoint_module.py.jinja
+++ b/templates/endpoint_module.py.jinja
@@ -15,6 +15,20 @@ from ... import errors
     arguments, client, kwargs, parse_response, docstring, body_to_kwarg %}
 
 {% set return_string = endpoint.response_type() %}
+{% set returns_legacy_bare_list = namespace(value=false) %}
+{% for response in endpoint.responses %}
+{% if response.prop.get_type_string().endswith("List") %}
+{% set returns_legacy_bare_list.value = true %}
+{% endif %}
+{% endfor %}
+{% if returns_legacy_bare_list.value %}
+{% set legacy_bare_list_return_string = "list[Any]" %}
+{% if return_string.startswith("Union[") %}
+{% set return_string = "Union[" + legacy_bare_list_return_string + ", " + return_string[6:-1] + "]" %}
+{% else %}
+{% set return_string = "Union[" + legacy_bare_list_return_string + ", " + return_string + "]" %}
+{% endif %}
+{% endif %}
 {% set parsed_responses = (endpoint.responses | length > 0) and return_string != "Any" %}
 
 def _get_kwargs(
@@ -88,6 +102,14 @@ def _parse_response(*, client: Client, response: httpx.Response) -> {{ return_st
         {% endif %}
         {% if prop_template.construct %}
         {{ prop_template.construct(response.prop, response_source) | indent(8) }}
+        {% if response.prop.get_type_string().endswith("List") and response_source == "_response_content" %}
+        if isinstance(_response_content, list):
+            if {{ response.prop.python_name }} is None:
+                return []
+            if {{ response.prop.python_name }}.data is UNSET or {{ response.prop.python_name }}.data is None:
+                return []
+            return cast(list[Any], {{ response.prop.python_name }}.data)
+        {% endif %}
         {% elif response.source.return_type == response.prop.get_type_string()  %}
         {{ response.prop.python_name }} = {{ response_source }}
         {% else %}

--- a/templates/errors.py.jinja
+++ b/templates/errors.py.jinja
@@ -11,4 +11,25 @@ class UnexpectedStatus(Exception):
             f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
         )
 
-__all__ = ["UnexpectedStatus"]
+
+class ResponseParseError(Exception):
+    """Raised by api functions when a documented response body cannot be parsed"""
+
+    def __init__(self, status_code: int, content: bytes, content_type: str | None = None):
+        self.status_code = status_code
+        self.content = content
+        self.content_type = content_type
+
+        preview = content[:500].decode(errors="replace")
+        if len(content) > 500:
+            preview = f"{preview}..."
+
+        content_type_text = content_type or "unknown content type"
+        super().__init__(
+            "Could not parse response body for documented status code "
+            f"{status_code} as JSON ({content_type_text}).\n\n"
+            f"Response content:\n{preview}"
+        )
+
+
+__all__ = ["ResponseParseError", "UnexpectedStatus"]

--- a/templates/model.py.jinja
+++ b/templates/model.py.jinja
@@ -26,6 +26,14 @@ if TYPE_CHECKING:
 
 {% set class_name = model.class_info.name %}
 {% set module_name = model.class_info.module_name %}
+{% set accepts_bare_data_array = namespace(value=false) %}
+{% if class_name.endswith("List") %}
+{% for property in model.required_properties + model.optional_properties %}
+{% if property.python_name == "data" %}
+{% set accepts_bare_data_array.value = true %}
+{% endif %}
+{% endfor %}
+{% endif %}
 
 {% from "helpers.jinja" import safe_docstring %}
 
@@ -129,14 +137,25 @@ return field_dict
 {% endif %}
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T | None:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]{% if accepts_bare_data_array.value %} | list[Any]{% endif %}) -> T | None:
     {% for lazy_import in model.lazy_imports %}
         {{ lazy_import }}
     {% endfor %}
 {% if (model.required_properties or model.optional_properties or model.additional_properties) %}
+        {% if accepts_bare_data_array.value %}
+        if isinstance(src_dict, list):
+            d = {"data": src_dict}
+        elif src_dict is None:
+            return None
+        elif not src_dict:
+            d = {}
+        else:
+            d = src_dict.copy()
+        {% else %}
         if not src_dict:
             return None
         d = src_dict.copy()
+        {% endif %}
 {% for property in model.required_properties + model.optional_properties %}
     {% if property.required %}
         {% if property.name != property.python_name %}

--- a/tests/core/test_generated_client_response_parsing.py
+++ b/tests/core/test_generated_client_response_parsing.py
@@ -1,0 +1,134 @@
+import httpx
+import pytest
+
+from blaxel.core.client import errors
+from blaxel.core.client.api.compute import create_sandbox, list_sandboxes
+from blaxel.core.client.client import Client
+from blaxel.core.client.models.sandbox_error import SandboxError
+from blaxel.core.client.models.sandbox_list import SandboxList
+from blaxel.core.sandbox.default import sandbox as sandbox_module
+
+
+def response(status_code: int, content: bytes, content_type: str) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        content=content,
+        headers={"Content-Type": content_type},
+        request=httpx.Request("POST", "https://api.blaxel.test/v0/sandboxes"),
+    )
+
+
+def sandbox_payload(name: str) -> dict:
+    return {
+        "metadata": {"name": name},
+        "spec": {"enabled": True},
+    }
+
+
+def test_documented_html_error_body_raises_sdk_parse_error():
+    client = Client(base_url="https://api.blaxel.test", raise_on_unexpected_status=True)
+    html = b'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"><html></html>'
+
+    with pytest.raises(errors.ResponseParseError) as exc_info:
+        create_sandbox._parse_response(
+            client=client,
+            response=response(403, html, "text/html"),
+        )
+
+    exc = exc_info.value
+    assert exc.status_code == 403
+    assert exc.content == html
+    assert exc.content_type == "text/html"
+    assert "Could not parse response body for documented status code 403 as JSON" in str(exc)
+    assert "<!DOCTYPE HTML" in str(exc)
+
+
+def test_documented_html_error_body_returns_none_when_raises_disabled():
+    client = Client(base_url="https://api.blaxel.test", raise_on_unexpected_status=False)
+
+    parsed = create_sandbox._parse_response(
+        client=client,
+        response=response(403, b"<html></html>", "text/html"),
+    )
+
+    assert parsed is None
+
+
+def test_documented_json_error_body_still_parses_model():
+    client = Client(base_url="https://api.blaxel.test", raise_on_unexpected_status=True)
+    parsed = create_sandbox._parse_response(
+        client=client,
+        response=httpx.Response(
+            403,
+            json={"code": "UNAUTHORIZED", "message": "Authorization failed", "status_code": 403},
+            request=httpx.Request("POST", "https://api.blaxel.test/v0/sandboxes"),
+        ),
+    )
+
+    assert isinstance(parsed, SandboxError)
+    assert parsed.code == "UNAUTHORIZED"
+    assert parsed.message == "Authorization failed"
+    assert parsed.status_code == 403
+
+
+def test_undocumented_status_still_uses_unexpected_status():
+    client = Client(base_url="https://api.blaxel.test", raise_on_unexpected_status=True)
+
+    with pytest.raises(errors.UnexpectedStatus):
+        create_sandbox._parse_response(
+            client=client,
+            response=response(418, b"teapot", "text/plain"),
+        )
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_names"),
+    [
+        ([sandbox_payload("legacy-list-shape")], ["legacy-list-shape"]),
+        ([], []),
+        ({}, []),
+    ],
+)
+def test_paginated_list_model_accepts_legacy_response_shapes(payload, expected_names):
+    client = Client(base_url="https://api.blaxel.test", raise_on_unexpected_status=True)
+
+    parsed = list_sandboxes._parse_response(
+        client=client,
+        response=httpx.Response(
+            200,
+            json=payload,
+            request=httpx.Request("GET", "https://api.blaxel.test/v0/sandboxes"),
+        ),
+    )
+
+    assert isinstance(parsed, SandboxList)
+    assert [sandbox.metadata.name for sandbox in parsed.data] == expected_names
+
+
+def test_paginated_list_model_preserves_json_null_as_none():
+    client = Client(base_url="https://api.blaxel.test", raise_on_unexpected_status=True)
+
+    parsed = list_sandboxes._parse_response(
+        client=client,
+        response=httpx.Response(
+            200,
+            content=b"null",
+            headers={"Content-Type": "application/json"},
+            request=httpx.Request("GET", "https://api.blaxel.test/v0/sandboxes"),
+        ),
+    )
+
+    assert parsed is None
+
+
+@pytest.mark.asyncio
+async def test_sandbox_instance_list_unwraps_paginated_response(monkeypatch):
+    async def fake_list_sandboxes(*, client):
+        return SandboxList.from_dict({"data": [sandbox_payload("wrapped-list-shape")]})
+
+    monkeypatch.setattr(sandbox_module, "list_sandboxes", fake_list_sandboxes)
+
+    sandboxes = await sandbox_module.SandboxInstance.list()
+
+    assert len(sandboxes) == 1
+    assert sandboxes[0].metadata.name == "wrapped-list-shape"

--- a/tests/core/test_generated_client_response_parsing.py
+++ b/tests/core/test_generated_client_response_parsing.py
@@ -294,3 +294,27 @@ async def test_job_alist_executions_unwraps_paginated_response(monkeypatch):
     executions = await BlJob("mk3").alist_executions()
 
     assert executions == []
+
+
+def test_documented_success_html_body_raises_sdk_parse_error():
+    client = Client(base_url="https://api.blaxel.test", raise_on_unexpected_status=True)
+    html = b"<html>edge error page on a 200</html>"
+
+    with pytest.raises(errors.ResponseParseError) as exc_info:
+        create_sandbox._parse_response(
+            client=client,
+            response=response(200, html, "text/html"),
+        )
+
+    assert exc_info.value.status_code == 200
+
+
+def test_documented_success_html_body_returns_none_when_raises_disabled():
+    client = Client(base_url="https://api.blaxel.test", raise_on_unexpected_status=False)
+
+    parsed = create_sandbox._parse_response(
+        client=client,
+        response=response(200, b"<html>edge error page on a 200</html>", "text/html"),
+    )
+
+    assert parsed is None

--- a/tests/core/test_generated_client_response_parsing.py
+++ b/tests/core/test_generated_client_response_parsing.py
@@ -6,11 +6,14 @@ import pytest
 
 import blaxel.core.jobs as job_module
 from blaxel.core.client import errors
+from blaxel.core.client.api.agents import list_agents
 from blaxel.core.client.api.compute import create_sandbox, list_sandboxes
 from blaxel.core.client.client import Client
+from blaxel.core.client.models.agent_list import AgentList
 from blaxel.core.client.models.job_execution_list import JobExecutionList
 from blaxel.core.client.models.sandbox_error import SandboxError
 from blaxel.core.client.models.sandbox_list import SandboxList
+from blaxel.core.client.types import Unset
 from blaxel.core.jobs import BlJob
 from blaxel.core.sandbox.default import sandbox as sandbox_module
 
@@ -28,6 +31,13 @@ def sandbox_payload(name: str) -> dict:
     return {
         "metadata": {"name": name},
         "spec": {"enabled": True},
+    }
+
+
+def agent_payload(name: str) -> dict:
+    return {
+        "metadata": {"name": name},
+        "spec": {},
     }
 
 
@@ -96,19 +106,82 @@ def test_undocumented_status_still_uses_unexpected_status():
     ],
 )
 def test_paginated_list_model_accepts_legacy_response_shapes(payload, expected_names):
+    parsed = SandboxList.from_dict(payload)
+
+    assert parsed is not None
+    assert not isinstance(parsed.data, Unset)
+    assert isinstance(parsed, SandboxList)
+    assert [sandbox.metadata.name for sandbox in parsed.data] == expected_names
+
+
+@pytest.mark.parametrize(
+    ("parser", "payload", "request_url", "expected_names"),
+    [
+        (
+            list_agents._parse_response,
+            [agent_payload("legacy-agent")],
+            "https://api.blaxel.test/v0/agents",
+            ["legacy-agent"],
+        ),
+        (
+            list_sandboxes._parse_response,
+            [sandbox_payload("legacy-sandbox")],
+            "https://api.blaxel.test/v0/sandboxes",
+            ["legacy-sandbox"],
+        ),
+        (
+            list_sandboxes._parse_response,
+            [],
+            "https://api.blaxel.test/v0/sandboxes",
+            [],
+        ),
+    ],
+)
+def test_generated_list_endpoint_preserves_legacy_bare_array_return(
+    parser,
+    payload,
+    request_url,
+    expected_names,
+):
     client = Client(base_url="https://api.blaxel.test", raise_on_unexpected_status=True)
 
-    parsed = list_sandboxes._parse_response(
+    parsed = parser(
         client=client,
         response=httpx.Response(
             200,
             json=payload,
-            request=httpx.Request("GET", "https://api.blaxel.test/v0/sandboxes"),
+            request=httpx.Request("GET", request_url),
         ),
     )
 
-    assert isinstance(parsed, SandboxList)
-    assert [sandbox.metadata.name for sandbox in parsed.data] == expected_names
+    assert isinstance(parsed, list)
+    assert [item.metadata.name for item in parsed] == expected_names
+
+
+def test_generated_list_endpoint_returns_wrapper_for_paginated_response():
+    client = Client(base_url="https://api.blaxel.test", raise_on_unexpected_status=True)
+
+    parsed = list_agents._parse_response(
+        client=client,
+        response=httpx.Response(
+            200,
+            json={
+                "data": [agent_payload("wrapped-agent")],
+                "meta": {
+                    "hasMore": False,
+                    "nextCursor": "",
+                    "total": 1,
+                },
+            },
+            request=httpx.Request("GET", "https://api.blaxel.test/v0/agents"),
+        ),
+    )
+
+    assert isinstance(parsed, AgentList)
+    assert not isinstance(parsed.data, Unset)
+    assert not isinstance(parsed.meta, Unset)
+    assert parsed.data[0].metadata.name == "wrapped-agent"
+    assert parsed.meta.has_more is False
 
 
 def test_paginated_list_model_preserves_json_null_as_none():
@@ -140,6 +213,22 @@ async def test_sandbox_instance_list_unwraps_paginated_response(monkeypatch):
     assert sandboxes[0].metadata.name == "wrapped-list-shape"
 
 
+@pytest.mark.asyncio
+async def test_sandbox_instance_list_preserves_legacy_bare_array_response(monkeypatch):
+    async def fake_list_sandboxes(*, client):
+        response = SandboxList.from_dict([sandbox_payload("legacy-list-shape")])
+        assert response is not None
+        assert not isinstance(response.data, Unset)
+        return response.data
+
+    monkeypatch.setattr(sandbox_module, "list_sandboxes", fake_list_sandboxes)
+
+    sandboxes = await sandbox_module.SandboxInstance.list()
+
+    assert len(sandboxes) == 1
+    assert sandboxes[0].metadata.name == "legacy-list-shape"
+
+
 def test_job_list_executions_unwraps_paginated_response(monkeypatch):
     def fake_list_job_executions(*, job_id, client, limit, offset):
         assert job_id == "mk3"
@@ -148,6 +237,30 @@ def test_job_list_executions_unwraps_paginated_response(monkeypatch):
         return SimpleNamespace(
             status_code=HTTPStatus.OK,
             parsed=JobExecutionList.from_dict({"data": []}),
+        )
+
+    monkeypatch.setattr(
+        job_module.list_job_executions,
+        "sync_detailed",
+        fake_list_job_executions,
+    )
+
+    executions = BlJob("mk3").list_executions()
+
+    assert executions == []
+
+
+def test_job_list_executions_preserves_legacy_bare_array_response(monkeypatch):
+    def fake_list_job_executions(*, job_id, client, limit, offset):
+        assert job_id == "mk3"
+        assert limit == 20
+        assert offset == 0
+        response = JobExecutionList.from_dict([])
+        assert response is not None
+        assert not isinstance(response.data, Unset)
+        return SimpleNamespace(
+            status_code=HTTPStatus.OK,
+            parsed=response.data,
         )
 
     monkeypatch.setattr(

--- a/tests/core/test_generated_client_response_parsing.py
+++ b/tests/core/test_generated_client_response_parsing.py
@@ -1,11 +1,17 @@
+from http import HTTPStatus
+from types import SimpleNamespace
+
 import httpx
 import pytest
 
+import blaxel.core.jobs as job_module
 from blaxel.core.client import errors
 from blaxel.core.client.api.compute import create_sandbox, list_sandboxes
 from blaxel.core.client.client import Client
+from blaxel.core.client.models.job_execution_list import JobExecutionList
 from blaxel.core.client.models.sandbox_error import SandboxError
 from blaxel.core.client.models.sandbox_list import SandboxList
+from blaxel.core.jobs import BlJob
 from blaxel.core.sandbox.default import sandbox as sandbox_module
 
 
@@ -132,3 +138,46 @@ async def test_sandbox_instance_list_unwraps_paginated_response(monkeypatch):
 
     assert len(sandboxes) == 1
     assert sandboxes[0].metadata.name == "wrapped-list-shape"
+
+
+def test_job_list_executions_unwraps_paginated_response(monkeypatch):
+    def fake_list_job_executions(*, job_id, client, limit, offset):
+        assert job_id == "mk3"
+        assert limit == 20
+        assert offset == 0
+        return SimpleNamespace(
+            status_code=HTTPStatus.OK,
+            parsed=JobExecutionList.from_dict({"data": []}),
+        )
+
+    monkeypatch.setattr(
+        job_module.list_job_executions,
+        "sync_detailed",
+        fake_list_job_executions,
+    )
+
+    executions = BlJob("mk3").list_executions()
+
+    assert executions == []
+
+
+@pytest.mark.asyncio
+async def test_job_alist_executions_unwraps_paginated_response(monkeypatch):
+    async def fake_list_job_executions(*, job_id, client, limit, offset):
+        assert job_id == "mk3"
+        assert limit == 20
+        assert offset == 0
+        return SimpleNamespace(
+            status_code=HTTPStatus.OK,
+            parsed=JobExecutionList.from_dict({"data": []}),
+        )
+
+    monkeypatch.setattr(
+        job_module.list_job_executions,
+        "asyncio_detailed",
+        fake_list_job_executions,
+    )
+
+    executions = await BlJob("mk3").alist_executions()
+
+    assert executions == []

--- a/tests/core/test_list_response_unwrap.py
+++ b/tests/core/test_list_response_unwrap.py
@@ -1,0 +1,71 @@
+"""Tests for unwrapping paginated list responses across wrapper list() paths."""
+
+from unittest.mock import patch
+
+from blaxel.core.client.models.drive_list import DriveList
+from blaxel.core.client.models.job_execution import JobExecution
+from blaxel.core.client.models.job_execution_list import JobExecutionList
+from blaxel.core.client.types import UNSET
+from blaxel.core.common.internal import list_response_items
+from blaxel.core.jobs import BlJob
+
+
+class TestListResponseItems:
+    def test_unwraps_paginated_model(self):
+        model = DriveList(data=[{"metadata": {"name": "d1"}, "spec": {}}])
+        assert list_response_items(model) == [{"metadata": {"name": "d1"}, "spec": {}}]
+
+    def test_passes_through_bare_list(self):
+        items = [{"metadata": {"name": "d1"}, "spec": {}}]
+        assert list_response_items(items) == items
+
+    def test_none_response_returns_empty(self):
+        assert list_response_items(None) == []
+
+    def test_unset_data_returns_empty(self):
+        model = DriveList()
+        model.data = UNSET
+        assert list_response_items(model) == []
+
+
+class TestListModelFromDict:
+    def test_from_dict_accepts_bare_array(self):
+        parsed = DriveList.from_dict([{"metadata": {"name": "d1"}, "spec": {}}])
+        assert len(parsed.data) == 1
+        assert parsed.data[0].metadata.name == "d1"
+
+    def test_from_dict_accepts_paginated_object(self):
+        parsed = DriveList.from_dict({"data": [{"metadata": {"name": "d1"}, "spec": {}}]})
+        assert len(parsed.data) == 1
+        assert parsed.data[0].metadata.name == "d1"
+
+    def test_from_dict_empty_dict_yields_no_items(self):
+        parsed = DriveList.from_dict({})
+        assert list_response_items(parsed) == []
+
+
+class _FakeResponse:
+    def __init__(self, status_code, parsed):
+        self.status_code = status_code
+        self.parsed = parsed
+
+
+class TestJobListExecutions:
+    def test_list_executions_unwraps_paginated_model(self):
+        executions = JobExecutionList(
+            data=[JobExecution.from_dict({"metadata": {"name": "e1"}, "spec": {}})]
+        )
+        with patch(
+            "blaxel.core.jobs.list_job_executions.sync_detailed",
+            return_value=_FakeResponse(200, executions),
+        ):
+            result = BlJob("my-job").list_executions()
+        assert len(result) == 1
+        assert isinstance(result[0], JobExecution)
+
+    def test_list_executions_handles_none_parsed(self):
+        with patch(
+            "blaxel.core.jobs.list_job_executions.sync_detailed",
+            return_value=_FakeResponse(200, None),
+        ):
+            assert BlJob("my-job").list_executions() == []

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -36,9 +36,7 @@ def restore_provider_loggers():
         logger.propagate = state["propagate"]
 
 
-def test_suppresses_high_risk_provider_loggers_by_default(
-    monkeypatch, restore_provider_loggers
-):
+def test_suppresses_high_risk_provider_loggers_by_default(monkeypatch, restore_provider_loggers):
     monkeypatch.delenv("BL_ALLOW_PROVIDER_DEBUG_LOGS", raising=False)
 
     for logger_name in PROVIDER_DEBUG_LOGGER_NAMES:
@@ -78,9 +76,7 @@ def test_provider_debug_payload_patterns_do_not_emit_by_default(
     assert stream.getvalue() == ""
 
 
-def test_provider_debug_opt_in_preserves_debug_behavior(
-    monkeypatch, restore_provider_loggers
-):
+def test_provider_debug_opt_in_preserves_debug_behavior(monkeypatch, restore_provider_loggers):
     monkeypatch.setenv("BL_ALLOW_PROVIDER_DEBUG_LOGS", "true")
     stream = io.StringIO()
     handler = logging.StreamHandler(stream)

--- a/tests/core/test_settings_api_version.py
+++ b/tests/core/test_settings_api_version.py
@@ -1,4 +1,5 @@
 """Tests for the Blaxel-Version header in Settings."""
+
 import os
 
 from blaxel.core.common.settings import BLAXEL_API_VERSION, settings

--- a/tests/integration/core/conftest.py
+++ b/tests/integration/core/conftest.py
@@ -24,6 +24,24 @@ def pytest_sessionfinish(session, exitstatus):
 
         print("\n🧹 Cleaning up test resources...")
 
+        async def volume_labels(volume):
+            metadata = getattr(volume, "metadata", None)
+            labels = getattr(metadata, "labels", None) if metadata else None
+            if labels is not None:
+                return labels
+
+            name = getattr(volume, "name", None)
+            if not name:
+                return None
+
+            try:
+                full_volume = await VolumeInstance.get(name)
+            except Exception:
+                return None
+
+            metadata = getattr(full_volume, "metadata", None)
+            return getattr(metadata, "labels", None) if metadata else None
+
         # Clean up sandboxes with test labels
         try:
             sandboxes = await SandboxInstance.list()
@@ -44,7 +62,7 @@ def pytest_sessionfinish(session, exitstatus):
         try:
             volumes = await VolumeInstance.list()
             for vol in volumes:
-                labels = vol.metadata.labels if hasattr(vol, "metadata") and vol.metadata else None
+                labels = await volume_labels(vol)
                 # Labels are stored in additional_properties of MetadataLabels object
                 if labels is not None:
                     props = getattr(labels, "additional_properties", {}) or {}

--- a/tests/integration/core/sandbox/proxy/test_claude.py
+++ b/tests/integration/core/sandbox/proxy/test_claude.py
@@ -15,15 +15,17 @@ pytestmark = pytest.mark.skipif(
     reason="requires ANTHROPIC_API_KEY",
 )
 
-CLAUDE_ENV = " ".join([
-    "export PATH=/usr/local/bin:/usr/bin:/bin",
-    "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY",
-    "HTTP_PROXY=$HTTP_PROXY",
-    "HTTPS_PROXY=$HTTPS_PROXY",
-    "NO_PROXY=$NO_PROXY",
-    "NODE_EXTRA_CA_CERTS=$NODE_EXTRA_CA_CERTS",
-    "SSL_CERT_FILE=$SSL_CERT_FILE",
-])
+CLAUDE_ENV = " ".join(
+    [
+        "export PATH=/usr/local/bin:/usr/bin:/bin",
+        "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY",
+        "HTTP_PROXY=$HTTP_PROXY",
+        "HTTPS_PROXY=$HTTPS_PROXY",
+        "NO_PROXY=$NO_PROXY",
+        "NODE_EXTRA_CA_CERTS=$NODE_EXTRA_CA_CERTS",
+        "SSL_CERT_FILE=$SSL_CERT_FILE",
+    ]
+)
 
 
 @pytest.mark.asyncio(loop_scope="class")
@@ -38,32 +40,36 @@ class TestProxyClaudeCode:
         api_key = os.environ["ANTHROPIC_API_KEY"]
 
         request.cls.sandbox_name = unique_name("proxy-claude")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "envs": [{"name": "ANTHROPIC_API_KEY", "value": api_key}],
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["httpbin.org"],
-                            "headers": {"X-Agent-Test": "claude-injected"},
-                        },
-                    ],
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "envs": [{"name": "ANTHROPIC_API_KEY", "value": api_key}],
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["httpbin.org"],
+                                "headers": {"X-Agent-Test": "claude-injected"},
+                            },
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
 
-        setup = await request.cls.sandbox.process.exec({
-            "command": (
-                "apk add --no-cache curl bash 2>&1 && "
-                "npm install -g @anthropic-ai/claude-code 2>&1 && "
-                "adduser -D -s /bin/bash agent 2>&1"
-            ),
-            "wait_for_completion": True,
-        })
+        setup = await request.cls.sandbox.process.exec(
+            {
+                "command": (
+                    "apk add --no-cache curl bash 2>&1 && "
+                    "npm install -g @anthropic-ai/claude-code 2>&1 && "
+                    "adduser -D -s /bin/bash agent 2>&1"
+                ),
+                "wait_for_completion": True,
+            }
+        )
         if setup.exit_code != 0:
             raise RuntimeError(f"setup failed: {(setup.logs or '')[:500]}")
 
@@ -74,28 +80,32 @@ class TestProxyClaudeCode:
             pass
 
     async def test_agent_reaches_anthropic_api_through_proxy(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                f'su - agent -c "{CLAUDE_ENV} && '
-                "claude --dangerously-skip-permissions -p "
-                '\\"What is 2+2? Reply with ONLY the number.\\" '
-                '--output-format text" 2>&1'
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    f'su - agent -c "{CLAUDE_ENV} && '
+                    "claude --dangerously-skip-permissions -p "
+                    '\\"What is 2+2? Reply with ONLY the number.\\" '
+                    '--output-format text" 2>&1'
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert "4" in (result.logs or "")
 
     async def test_agent_makes_outbound_call_with_header_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                f'su - agent -c "{CLAUDE_ENV} && '
-                "claude --dangerously-skip-permissions -p "
-                '\\"Run: curl -s https://httpbin.org/headers — then print the full JSON output.\\" '
-                '--output-format text" 2>&1'
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    f'su - agent -c "{CLAUDE_ENV} && '
+                    "claude --dangerously-skip-permissions -p "
+                    '\\"Run: curl -s https://httpbin.org/headers — then print the full JSON output.\\" '
+                    '--output-format text" 2>&1'
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert "X-Agent-Test" in (result.logs or "")
         assert "claude-injected" in (result.logs or "")

--- a/tests/integration/core/sandbox/proxy/test_cli_tools.py
+++ b/tests/integration/core/sandbox/proxy/test_cli_tools.py
@@ -21,46 +21,52 @@ class TestProxyCLITools:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("proxy-cli")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["httpbin.org"],
-                            "headers": {
-                                "X-Proxy-Test": "header-injected",
-                                "X-Api-Key": "{{SECRET:test-api-key}}",
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["httpbin.org"],
+                                "headers": {
+                                    "X-Proxy-Test": "header-injected",
+                                    "X-Api-Key": "{{SECRET:test-api-key}}",
+                                },
+                                "body": {
+                                    "injected_field": "body-injected",
+                                    "secret_body": "{{SECRET:test-api-key}}",
+                                },
+                                "secrets": {"test-api-key": "resolved-secret-42"},
                             },
-                            "body": {
-                                "injected_field": "body-injected",
-                                "secret_body": "{{SECRET:test-api-key}}",
-                            },
-                            "secrets": {"test-api-key": "resolved-secret-42"},
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
 
-        install = await request.cls.sandbox.process.exec({
-            "command": "apk add --no-cache curl wget git python3 py3-pip ca-certificates 2>&1",
-            "wait_for_completion": True,
-        })
+        install = await request.cls.sandbox.process.exec(
+            {
+                "command": "apk add --no-cache curl wget git python3 py3-pip ca-certificates 2>&1",
+                "wait_for_completion": True,
+            }
+        )
         if install.exit_code != 0:
             raise RuntimeError(f"apk install failed: {(install.logs or '')[:500]}")
 
-        cert_install = await request.cls.sandbox.process.exec({
-            "command": (
-                '[ -f "$SSL_CERT_FILE" ] && '
-                'cp "$SSL_CERT_FILE" /usr/local/share/ca-certificates/blaxel-proxy.crt && '
-                'update-ca-certificates 2>&1 || echo "no SSL_CERT_FILE"'
-            ),
-            "wait_for_completion": True,
-        })
+        cert_install = await request.cls.sandbox.process.exec(
+            {
+                "command": (
+                    '[ -f "$SSL_CERT_FILE" ] && '
+                    'cp "$SSL_CERT_FILE" /usr/local/share/ca-certificates/blaxel-proxy.crt && '
+                    'update-ca-certificates 2>&1 || echo "no SSL_CERT_FILE"'
+                ),
+                "wait_for_completion": True,
+            }
+        )
         if cert_install.exit_code != 0:
             raise RuntimeError(f"CA cert install failed: {(cert_install.logs or '')[:500]}")
 
@@ -73,10 +79,12 @@ class TestProxyCLITools:
     # ----- curl -----
 
     async def test_curl_get_with_header_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": "curl -s https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "curl -s https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers.get("x-blaxel-request-id") is not None
@@ -84,10 +92,12 @@ class TestProxyCLITools:
         assert headers["x-api-key"] == "resolved-secret-42"
 
     async def test_curl_post_with_body_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": """curl -s -X POST https://httpbin.org/post -H "Content-Type: application/json" -d '{"user_data":"from-curl"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """curl -s -X POST https://httpbin.org/post -H "Content-Type: application/json" -d '{"user_data":"from-curl"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         response = parse_json_output(result.logs)
         assert response["json"]["user_data"] == "from-curl"
@@ -98,10 +108,12 @@ class TestProxyCLITools:
         assert headers["x-proxy-test"] == "header-injected"
 
     async def test_curl_preserves_user_headers(self):
-        result = await self.sandbox.process.exec({
-            "command": 'curl -s -H "X-User-Custom: from-curl" https://httpbin.org/headers',
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": 'curl -s -H "X-User-Custom: from-curl" https://httpbin.org/headers',
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers["x-user-custom"] == "from-curl"
@@ -109,36 +121,47 @@ class TestProxyCLITools:
         assert headers["x-api-key"] == "resolved-secret-42"
 
     async def test_curl_follows_redirects(self):
-        result = await self.sandbox.process.exec({
-            "command": 'curl -s -L -o /dev/null -w "%{http_code}" https://httpbin.org/redirect/1',
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": 'curl -s -L -o /dev/null -w "%{http_code}" https://httpbin.org/redirect/1',
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert (result.logs or "").strip() == "200"
 
     async def test_curl_put_through_proxy(self):
-        result = await self.sandbox.process.exec({
-            "command": """curl -s -X PUT https://httpbin.org/put -H "Content-Type: application/json" -d '{"update":"from-curl"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """curl -s -X PUT https://httpbin.org/put -H "Content-Type: application/json" -d '{"update":"from-curl"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         response = parse_json_output(result.logs)
         assert response["json"]["update"] == "from-curl"
         assert lowercase_keys(response["headers"])["x-proxy-test"] == "header-injected"
 
     async def test_curl_delete_through_proxy(self):
-        result = await self.sandbox.process.exec({
-            "command": "curl -s -X DELETE https://httpbin.org/delete",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "curl -s -X DELETE https://httpbin.org/delete",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
-        assert lowercase_keys(parse_json_output(result.logs)["headers"])["x-proxy-test"] == "header-injected"
+        assert (
+            lowercase_keys(parse_json_output(result.logs)["headers"])["x-proxy-test"]
+            == "header-injected"
+        )
 
     async def test_curl_handles_large_response(self):
-        result = await self.sandbox.process.exec({
-            "command": 'curl -s -o /dev/null -w "%{http_code} %{size_download}" https://httpbin.org/bytes/10240',
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": 'curl -s -o /dev/null -w "%{http_code} %{size_download}" https://httpbin.org/bytes/10240',
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         status_code, size_str = (result.logs or "").strip().split(" ")
         assert status_code == "200"
@@ -147,39 +170,47 @@ class TestProxyCLITools:
     # ----- git -----
 
     async def test_git_clone_public_repo(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "export https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY && "
-                "GIT_SSL_CAINFO=$SSL_CERT_FILE git -c http.proxyAuthMethod=basic "
-                "clone --depth 1 https://github.com/octocat/Hello-World.git /tmp/git-test-repo 2>&1"
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "export https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY && "
+                    "GIT_SSL_CAINFO=$SSL_CERT_FILE git -c http.proxyAuthMethod=basic "
+                    "clone --depth 1 https://github.com/octocat/Hello-World.git /tmp/git-test-repo 2>&1"
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
-        verify = await self.sandbox.process.exec({
-            "command": "ls /tmp/git-test-repo/README",
-            "wait_for_completion": True,
-        })
+        verify = await self.sandbox.process.exec(
+            {
+                "command": "ls /tmp/git-test-repo/README",
+                "wait_for_completion": True,
+            }
+        )
         assert verify.exit_code == 0
 
     async def test_git_ls_remote_through_proxy(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "export https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY && "
-                "GIT_SSL_CAINFO=$SSL_CERT_FILE git -c http.proxyAuthMethod=basic "
-                "ls-remote --heads https://github.com/octocat/Hello-World.git 2>&1"
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "export https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY && "
+                    "GIT_SSL_CAINFO=$SSL_CERT_FILE git -c http.proxyAuthMethod=basic "
+                    "ls-remote --heads https://github.com/octocat/Hello-World.git 2>&1"
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert "refs/heads/" in (result.logs or "")
 
     async def test_proxy_env_vars_visible_to_git(self):
-        result = await self.sandbox.process.exec({
-            "command": "git config --global --list 2>&1; echo '---'; env | grep -i proxy || true",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "git config --global --list 2>&1; echo '---'; env | grep -i proxy || true",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         logs = result.logs or ""
         assert "proxy" in logs.lower() or "HTTPS_PROXY" in logs or "https_proxy" in logs
@@ -187,13 +218,15 @@ class TestProxyCLITools:
     # ----- pip -----
 
     async def test_pip_install_through_proxy(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "pip3 install --break-system-packages --quiet six 2>&1 && "
-                'python3 -c "import six; print(six.__version__)"'
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "pip3 install --break-system-packages --quiet six 2>&1 && "
+                    'python3 -c "import six; print(six.__version__)"'
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert len((result.logs or "").strip()) > 0
 
@@ -202,22 +235,28 @@ class TestProxyCLITools:
     async def test_npm_install_through_proxy(self):
         await self.sandbox.fs.write(
             "/tmp/npm-test/package.json",
-            json.dumps({
-                "name": "proxy-npm-test",
-                "version": "1.0.0",
-                "dependencies": {"is-odd": "^3.0.1"},
-            }),
+            json.dumps(
+                {
+                    "name": "proxy-npm-test",
+                    "version": "1.0.0",
+                    "dependencies": {"is-odd": "^3.0.1"},
+                }
+            ),
         )
 
-        result = await self.sandbox.process.exec({
-            "command": "cd /tmp/npm-test && npm install --no-audit --no-fund 2>&1",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "cd /tmp/npm-test && npm install --no-audit --no-fund 2>&1",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
 
-        verify = await self.sandbox.process.exec({
-            "command": """node -e "console.log(require('/tmp/npm-test/node_modules/is-odd')(3))" """,
-            "wait_for_completion": True,
-        })
+        verify = await self.sandbox.process.exec(
+            {
+                "command": """node -e "console.log(require('/tmp/npm-test/node_modules/is-odd')(3))" """,
+                "wait_for_completion": True,
+            }
+        )
         assert verify.exit_code == 0
         assert (verify.logs or "").strip() == "true"

--- a/tests/integration/core/sandbox/proxy/test_comparison.py
+++ b/tests/integration/core/sandbox/proxy/test_comparison.py
@@ -42,33 +42,37 @@ class TestProxyComparison:
         request.cls.no_proxy_name = unique_name("cmp-noproxy")
 
         proxy_sb, no_proxy_sb = await asyncio.gather(
-            SandboxInstance.create({
-                "name": request.cls.proxy_name,
-                "image": default_image,
-                "region": default_region,
-                "labels": default_labels,
-                "network": {
-                    "proxy": {
-                        "routing": [
-                            {
-                                "destinations": ["httpbin.org"],
-                                "headers": {
-                                    "X-Proxy-Compare": "with-proxy",
-                                    "X-Api-Key": "{{SECRET:cmp-key}}",
+            SandboxInstance.create(
+                {
+                    "name": request.cls.proxy_name,
+                    "image": default_image,
+                    "region": default_region,
+                    "labels": default_labels,
+                    "network": {
+                        "proxy": {
+                            "routing": [
+                                {
+                                    "destinations": ["httpbin.org"],
+                                    "headers": {
+                                        "X-Proxy-Compare": "with-proxy",
+                                        "X-Api-Key": "{{SECRET:cmp-key}}",
+                                    },
+                                    "body": {"injected_field": "proxy-injected"},
+                                    "secrets": {"cmp-key": "comparison-secret-123"},
                                 },
-                                "body": {"injected_field": "proxy-injected"},
-                                "secrets": {"cmp-key": "comparison-secret-123"},
-                            },
-                        ],
+                            ],
+                        },
                     },
-                },
-            }),
-            SandboxInstance.create({
-                "name": request.cls.no_proxy_name,
-                "image": default_image,
-                "region": default_region,
-                "labels": default_labels,
-            }),
+                }
+            ),
+            SandboxInstance.create(
+                {
+                    "name": request.cls.no_proxy_name,
+                    "image": default_image,
+                    "region": default_region,
+                    "labels": default_labels,
+                }
+            ),
         )
         request.cls.proxy_sandbox = proxy_sb
         request.cls.no_proxy_sandbox = no_proxy_sb
@@ -80,10 +84,12 @@ class TestProxyComparison:
 
         # Warm up the proxy path: the proxy config may take a moment to propagate.
         for _ in range(10):
-            warmup = await proxy_sb.process.exec({
-                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-                "wait_for_completion": True,
-            })
+            warmup = await proxy_sb.process.exec(
+                {
+                    "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                    "wait_for_completion": True,
+                }
+            )
             if warmup.exit_code == 0:
                 try:
                     hdr = lowercase_keys(parse_json_output(warmup.logs)["headers"])
@@ -200,8 +206,12 @@ class TestProxyComparison:
         no_proxy_times: list[int] = []
         for _ in range(iterations):
             p, np = await asyncio.gather(
-                _timed_exec(self.proxy_sandbox, "node /tmp/proxy-test.js GET https://httpbin.org/get"),
-                _timed_exec(self.no_proxy_sandbox, "node /tmp/proxy-test.js GET https://httpbin.org/get"),
+                _timed_exec(
+                    self.proxy_sandbox, "node /tmp/proxy-test.js GET https://httpbin.org/get"
+                ),
+                _timed_exec(
+                    self.no_proxy_sandbox, "node /tmp/proxy-test.js GET https://httpbin.org/get"
+                ),
             )
             assert p["exit_code"] == 0
             assert np["exit_code"] == 0
@@ -214,14 +224,10 @@ class TestProxyComparison:
         overhead_pct = (overhead_ms / no_proxy_avg * 100) if no_proxy_avg > 0 else 0.0
 
         print(
-            f"[latency benchmark] proxy avg: {proxy_avg:.0f}ms, "
-            f"no-proxy avg: {no_proxy_avg:.0f}ms"
+            f"[latency benchmark] proxy avg: {proxy_avg:.0f}ms, no-proxy avg: {no_proxy_avg:.0f}ms"
         )
+        print(f"[latency benchmark] overhead: {overhead_ms:.0f}ms ({overhead_pct:.1f}%)")
         print(
-            f"[latency benchmark] overhead: {overhead_ms:.0f}ms ({overhead_pct:.1f}%)"
-        )
-        print(
-            f"[latency benchmark] proxy samples: {proxy_times}, "
-            f"no-proxy samples: {no_proxy_times}"
+            f"[latency benchmark] proxy samples: {proxy_times}, no-proxy samples: {no_proxy_times}"
         )
         assert overhead_ms < 5000

--- a/tests/integration/core/sandbox/proxy/test_create.py
+++ b/tests/integration/core/sandbox/proxy/test_create.py
@@ -12,26 +12,28 @@ pytestmark = pytest.mark.asyncio(loop_scope="module")
 
 async def test_creates_sandbox_with_proxy_routing_and_header_injection(created_sandboxes):
     name = unique_name("proxy-hdr")
-    sandbox = await SandboxInstance.create({
-        "name": name,
-        "image": default_image,
-        "region": default_region,
-        "labels": default_labels,
-        "network": {
-            "proxy": {
-                "routing": [
-                    {
-                        "destinations": ["api.stripe.com"],
-                        "headers": {
-                            "Authorization": "Bearer {{SECRET:stripe-key}}",
-                            "Stripe-Version": "2024-12-18.acacia",
+    sandbox = await SandboxInstance.create(
+        {
+            "name": name,
+            "image": default_image,
+            "region": default_region,
+            "labels": default_labels,
+            "network": {
+                "proxy": {
+                    "routing": [
+                        {
+                            "destinations": ["api.stripe.com"],
+                            "headers": {
+                                "Authorization": "Bearer {{SECRET:stripe-key}}",
+                                "Stripe-Version": "2024-12-18.acacia",
+                            },
+                            "secrets": {"stripe-key": "sk-live-test123"},
                         },
-                        "secrets": {"stripe-key": "sk-live-test123"},
-                    },
-                ],
+                    ],
+                },
             },
-        },
-    })
+        }
+    )
     created_sandboxes.append(name)
 
     assert sandbox.metadata.name == name
@@ -46,24 +48,26 @@ async def test_creates_sandbox_with_proxy_routing_and_header_injection(created_s
 
 async def test_creates_sandbox_with_proxy_body_injection(created_sandboxes):
     name = unique_name("proxy-body")
-    sandbox = await SandboxInstance.create({
-        "name": name,
-        "image": default_image,
-        "region": default_region,
-        "labels": default_labels,
-        "network": {
-            "proxy": {
-                "routing": [
-                    {
-                        "destinations": ["api.stripe.com"],
-                        "headers": {"Authorization": "Bearer {{SECRET:stripe-key}}"},
-                        "body": {"api_key": "{{SECRET:stripe-key}}"},
-                        "secrets": {"stripe-key": "sk-live-test123"},
-                    },
-                ],
+    sandbox = await SandboxInstance.create(
+        {
+            "name": name,
+            "image": default_image,
+            "region": default_region,
+            "labels": default_labels,
+            "network": {
+                "proxy": {
+                    "routing": [
+                        {
+                            "destinations": ["api.stripe.com"],
+                            "headers": {"Authorization": "Bearer {{SECRET:stripe-key}}"},
+                            "body": {"api_key": "{{SECRET:stripe-key}}"},
+                            "secrets": {"stripe-key": "sk-live-test123"},
+                        },
+                    ],
+                },
             },
-        },
-    })
+        }
+    )
     created_sandboxes.append(name)
 
     route = sandbox.spec.network.proxy.routing[0]
@@ -73,37 +77,39 @@ async def test_creates_sandbox_with_proxy_body_injection(created_sandboxes):
 
 async def test_creates_sandbox_with_multiple_proxy_routing_rules(created_sandboxes):
     name = unique_name("proxy-multi")
-    sandbox = await SandboxInstance.create({
-        "name": name,
-        "image": default_image,
-        "region": default_region,
-        "labels": default_labels,
-        "network": {
-            "proxy": {
-                "routing": [
-                    {
-                        "destinations": ["api.stripe.com"],
-                        "headers": {
-                            "Authorization": "Bearer {{SECRET:stripe-key}}",
-                            "Stripe-Version": "2024-12-18.acacia",
-                            "X-Request-Source": "blaxel-sandbox",
+    sandbox = await SandboxInstance.create(
+        {
+            "name": name,
+            "image": default_image,
+            "region": default_region,
+            "labels": default_labels,
+            "network": {
+                "proxy": {
+                    "routing": [
+                        {
+                            "destinations": ["api.stripe.com"],
+                            "headers": {
+                                "Authorization": "Bearer {{SECRET:stripe-key}}",
+                                "Stripe-Version": "2024-12-18.acacia",
+                                "X-Request-Source": "blaxel-sandbox",
+                            },
+                            "body": {"api_key": "{{SECRET:stripe-key}}"},
+                            "secrets": {"stripe-key": "sk-live-test123"},
                         },
-                        "body": {"api_key": "{{SECRET:stripe-key}}"},
-                        "secrets": {"stripe-key": "sk-live-test123"},
-                    },
-                    {
-                        "destinations": ["api.openai.com"],
-                        "headers": {
-                            "Authorization": "Bearer {{SECRET:openai-key}}",
-                            "OpenAI-Organization": "org-abc123",
+                        {
+                            "destinations": ["api.openai.com"],
+                            "headers": {
+                                "Authorization": "Bearer {{SECRET:openai-key}}",
+                                "OpenAI-Organization": "org-abc123",
+                            },
+                            "secrets": {"openai-key": "sk-proj-test789"},
                         },
-                        "secrets": {"openai-key": "sk-proj-test789"},
-                    },
-                ],
-                "bypass": ["*.s3.amazonaws.com"],
+                    ],
+                    "bypass": ["*.s3.amazonaws.com"],
+                },
             },
-        },
-    })
+        }
+    )
     created_sandboxes.append(name)
 
     proxy = sandbox.spec.network.proxy
@@ -121,15 +127,17 @@ async def test_creates_sandbox_with_multiple_proxy_routing_rules(created_sandbox
 
 async def test_creates_sandbox_with_proxy_bypass_only(created_sandboxes):
     name = unique_name("proxy-bypass")
-    sandbox = await SandboxInstance.create({
-        "name": name,
-        "image": default_image,
-        "region": default_region,
-        "labels": default_labels,
-        "network": {
-            "proxy": {"bypass": ["*.s3.amazonaws.com", "169.254.169.254"]},
-        },
-    })
+    sandbox = await SandboxInstance.create(
+        {
+            "name": name,
+            "image": default_image,
+            "region": default_region,
+            "labels": default_labels,
+            "network": {
+                "proxy": {"bypass": ["*.s3.amazonaws.com", "169.254.169.254"]},
+            },
+        }
+    )
     created_sandboxes.append(name)
 
     proxy = sandbox.spec.network.proxy
@@ -139,25 +147,27 @@ async def test_creates_sandbox_with_proxy_bypass_only(created_sandboxes):
 
 async def test_creates_sandbox_with_proxy_and_allowed_domains_combined(created_sandboxes):
     name = unique_name("proxy-fw")
-    sandbox = await SandboxInstance.create({
-        "name": name,
-        "image": default_image,
-        "region": default_region,
-        "labels": default_labels,
-        "network": {
-            "allowedDomains": ["api.stripe.com", "api.openai.com", "*.s3.amazonaws.com"],
-            "proxy": {
-                "routing": [
-                    {
-                        "destinations": ["api.stripe.com"],
-                        "headers": {"Authorization": "Bearer {{SECRET:stripe-key}}"},
-                        "secrets": {"stripe-key": "sk-live-test123"},
-                    },
-                ],
-                "bypass": ["*.s3.amazonaws.com"],
+    sandbox = await SandboxInstance.create(
+        {
+            "name": name,
+            "image": default_image,
+            "region": default_region,
+            "labels": default_labels,
+            "network": {
+                "allowedDomains": ["api.stripe.com", "api.openai.com", "*.s3.amazonaws.com"],
+                "proxy": {
+                    "routing": [
+                        {
+                            "destinations": ["api.stripe.com"],
+                            "headers": {"Authorization": "Bearer {{SECRET:stripe-key}}"},
+                            "secrets": {"stripe-key": "sk-live-test123"},
+                        },
+                    ],
+                    "bypass": ["*.s3.amazonaws.com"],
+                },
             },
-        },
-    })
+        }
+    )
     created_sandboxes.append(name)
 
     network = sandbox.spec.network

--- a/tests/integration/core/sandbox/proxy/test_e2e.py
+++ b/tests/integration/core/sandbox/proxy/test_e2e.py
@@ -24,34 +24,36 @@ class TestProxyEndToEnd:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("proxy-e2e")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["httpbin.org"],
-                            "headers": {
-                                "X-Proxy-Test": "header-injected",
-                                "X-Api-Key": "{{SECRET:test-api-key}}",
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["httpbin.org"],
+                                "headers": {
+                                    "X-Proxy-Test": "header-injected",
+                                    "X-Api-Key": "{{SECRET:test-api-key}}",
+                                },
+                                "body": {
+                                    "injected_field": "body-injected",
+                                    "secret_body": "{{SECRET:test-api-key}}",
+                                },
+                                "secrets": {"test-api-key": "resolved-secret-42"},
                             },
-                            "body": {
-                                "injected_field": "body-injected",
-                                "secret_body": "{{SECRET:test-api-key}}",
+                            {
+                                "destinations": ["*.httpbin.org"],
+                                "headers": {"X-Wildcard-Match": "wildcard-injected"},
                             },
-                            "secrets": {"test-api-key": "resolved-secret-42"},
-                        },
-                        {
-                            "destinations": ["*.httpbin.org"],
-                            "headers": {"X-Wildcard-Match": "wildcard-injected"},
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -60,10 +62,12 @@ class TestProxyEndToEnd:
             pass
 
     async def test_routes_https_requests_through_proxy_with_header_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers.get("x-blaxel-request-id") is not None
@@ -71,10 +75,12 @@ class TestProxyEndToEnd:
         assert headers["x-api-key"] == "resolved-secret-42"
 
     async def test_routes_post_requests_through_proxy_with_body_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": """node /tmp/proxy-test.js POST https://httpbin.org/post '{}' '{"user_data":"original"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """node /tmp/proxy-test.js POST https://httpbin.org/post '{}' '{"user_data":"original"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         response = parse_json_output(result.logs)
         assert response["json"]["user_data"] == "original"
@@ -86,10 +92,12 @@ class TestProxyEndToEnd:
         assert response["json"]["secret_body"] == "resolved-secret-42"
 
     async def test_preserves_user_sent_headers_when_routing(self):
-        result = await self.sandbox.process.exec({
-            "command": """node /tmp/proxy-test.js GET https://httpbin.org/headers '{"X-User-Custom":"my-value"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """node /tmp/proxy-test.js GET https://httpbin.org/headers '{"X-User-Custom":"my-value"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers["x-user-custom"] == "my-value"
@@ -97,65 +105,75 @@ class TestProxyEndToEnd:
         assert headers["x-proxy-test"] == "header-injected"
 
     async def test_does_not_route_local_requests_through_proxy(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "node -e '"
-                'const http = require("http");'
-                "const srv = http.createServer((req, res) => {"
-                'res.writeHead(200, {"Content-Type": "application/json"});'
-                "res.end(JSON.stringify(req.headers));"
-                "});"
-                "srv.listen(19876, () => {"
-                'http.get("http://localhost:19876", (r) => {'
-                'let d = ""; r.on("data", c => d += c);'
-                'r.on("end", () => { console.log(d); srv.close(); });'
-                "});"
-                "});'"
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "node -e '"
+                    'const http = require("http");'
+                    "const srv = http.createServer((req, res) => {"
+                    'res.writeHead(200, {"Content-Type": "application/json"});'
+                    "res.end(JSON.stringify(req.headers));"
+                    "});"
+                    "srv.listen(19876, () => {"
+                    'http.get("http://localhost:19876", (r) => {'
+                    'let d = ""; r.on("data", c => d += c);'
+                    'r.on("end", () => { console.log(d); srv.close(); });'
+                    "});"
+                    "});'"
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = parse_json_output(result.logs)
         assert headers.get("x-blaxel-request-id") is None
         assert headers.get("x-proxy-test") is None
 
     async def test_does_not_inject_headers_for_non_routed_destinations(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://www.google.com",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://www.google.com",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert len((result.logs or "").strip()) > 0
 
     async def test_wildcard_route_matches_subdomain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://beta.httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://beta.httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers["x-wildcard-match"] == "wildcard-injected"
 
     async def test_wildcard_route_does_not_match_bare_domain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers.get("x-wildcard-match") is None
 
     async def test_verifies_proxy_env_vars_are_set(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "node -e '"
-                'const vars = ["HTTP_PROXY","HTTPS_PROXY","NO_PROXY","NODE_EXTRA_CA_CERTS","SSL_CERT_FILE"];'
-                "const result = {};"
-                'vars.forEach(v => result[v] = process.env[v] ? "set" : "unset");'
-                "console.log(JSON.stringify(result));'"
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "node -e '"
+                    'const vars = ["HTTP_PROXY","HTTPS_PROXY","NO_PROXY","NODE_EXTRA_CA_CERTS","SSL_CERT_FILE"];'
+                    "const result = {};"
+                    'vars.forEach(v => result[v] = process.env[v] ? "set" : "unset");'
+                    "console.log(JSON.stringify(result));'"
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         envs = parse_json_output(result.logs)
         assert envs["HTTP_PROXY"] == "set"

--- a/tests/integration/core/sandbox/proxy/test_firewall.py
+++ b/tests/integration/core/sandbox/proxy/test_firewall.py
@@ -34,16 +34,18 @@ class TestFirewallAllowedDomains:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("fw-allow")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "allowedDomains": ["httpbin.org"],
-                "proxy": {"routing": []},
-            },
-        })
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "allowedDomains": ["httpbin.org"],
+                    "proxy": {"routing": []},
+                },
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -52,18 +54,22 @@ class TestFirewallAllowedDomains:
             pass
 
     async def test_allows_requests_to_allowlisted_domain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/get",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/get",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert _logs_contain_host(result.logs, "httpbin.org")
 
     async def test_blocks_requests_to_non_allowlisted_domain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://example.com",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://example.com",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code != 0
 
 
@@ -77,16 +83,18 @@ class TestFirewallForbiddenDomains:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("fw-deny")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "forbiddenDomains": ["example.com"],
-                "proxy": {"routing": []},
-            },
-        })
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "forbiddenDomains": ["example.com"],
+                    "proxy": {"routing": []},
+                },
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -95,18 +103,22 @@ class TestFirewallForbiddenDomains:
             pass
 
     async def test_allows_requests_to_non_forbidden_domain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/get",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/get",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert _logs_contain_host(result.logs, "httpbin.org")
 
     async def test_blocks_requests_to_forbidden_domain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://example.com",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://example.com",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code != 0
 
 
@@ -120,17 +132,19 @@ class TestFirewallCombined:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("fw-combo")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "allowedDomains": ["httpbin.org", "example.com"],
-                "forbiddenDomains": ["example.com"],
-                "proxy": {"routing": []},
-            },
-        })
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "allowedDomains": ["httpbin.org", "example.com"],
+                    "forbiddenDomains": ["example.com"],
+                    "proxy": {"routing": []},
+                },
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -139,10 +153,12 @@ class TestFirewallCombined:
             pass
 
     async def test_allowed_domains_takes_precedence_over_forbidden_domains(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/get",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/get",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert "httpbin.org" in (result.logs or "")
 
@@ -157,23 +173,25 @@ class TestFirewallWithProxyRouting:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("fw-proxy")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "allowedDomains": ["httpbin.org"],
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["httpbin.org"],
-                            "headers": {"X-Firewall-Test": "allowed-and-injected"},
-                        },
-                    ],
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "allowedDomains": ["httpbin.org"],
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["httpbin.org"],
+                                "headers": {"X-Firewall-Test": "allowed-and-injected"},
+                            },
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -182,17 +200,21 @@ class TestFirewallWithProxyRouting:
             pass
 
     async def test_injects_headers_for_allowlisted_and_routed_domain(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers["x-firewall-test"] == "allowed-and-injected"
 
     async def test_blocks_non_allowlisted_domain_even_without_routing(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://example.com",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://example.com",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code != 0

--- a/tests/integration/core/sandbox/proxy/test_get_delete.py
+++ b/tests/integration/core/sandbox/proxy/test_get_delete.py
@@ -17,27 +17,29 @@ pytestmark = pytest.mark.asyncio(loop_scope="module")
 
 async def test_retrieves_sandbox_with_proxy_and_validates_config(created_sandboxes):
     name = unique_name("proxy-get")
-    await SandboxInstance.create({
-        "name": name,
-        "image": default_image,
-        "region": default_region,
-        "labels": default_labels,
-        "network": {
-            "proxy": {
-                "routing": [
-                    {
-                        "destinations": ["api.openai.com"],
-                        "headers": {
-                            "Authorization": "Bearer {{SECRET:openai-key}}",
-                            "OpenAI-Organization": "org-abc123",
+    await SandboxInstance.create(
+        {
+            "name": name,
+            "image": default_image,
+            "region": default_region,
+            "labels": default_labels,
+            "network": {
+                "proxy": {
+                    "routing": [
+                        {
+                            "destinations": ["api.openai.com"],
+                            "headers": {
+                                "Authorization": "Bearer {{SECRET:openai-key}}",
+                                "OpenAI-Organization": "org-abc123",
+                            },
+                            "secrets": {"openai-key": "sk-proj-test789"},
                         },
-                        "secrets": {"openai-key": "sk-proj-test789"},
-                    },
-                ],
-                "bypass": ["169.254.169.254"],
+                    ],
+                    "bypass": ["169.254.169.254"],
+                },
             },
-        },
-    })
+        }
+    )
     created_sandboxes.append(name)
 
     retrieved = await SandboxInstance.get(name)
@@ -55,12 +57,14 @@ async def test_retrieves_sandbox_with_proxy_and_validates_config(created_sandbox
 
 async def test_returns_no_proxy_config_when_sandbox_has_none(created_sandboxes):
     name = unique_name("proxy-none")
-    await SandboxInstance.create({
-        "name": name,
-        "image": default_image,
-        "region": default_region,
-        "labels": default_labels,
-    })
+    await SandboxInstance.create(
+        {
+            "name": name,
+            "image": default_image,
+            "region": default_region,
+            "labels": default_labels,
+        }
+    )
     created_sandboxes.append(name)
 
     retrieved = await SandboxInstance.get(name)
@@ -71,23 +75,25 @@ async def test_returns_no_proxy_config_when_sandbox_has_none(created_sandboxes):
 
 async def test_deletes_sandbox_with_proxy_configuration():
     name = unique_name("proxy-del")
-    await SandboxInstance.create({
-        "name": name,
-        "image": default_image,
-        "region": default_region,
-        "labels": default_labels,
-        "network": {
-            "proxy": {
-                "routing": [
-                    {
-                        "destinations": ["api.stripe.com"],
-                        "headers": {"Authorization": "Bearer {{SECRET:stripe-key}}"},
-                        "secrets": {"stripe-key": "sk-live-test123"},
-                    },
-                ],
+    await SandboxInstance.create(
+        {
+            "name": name,
+            "image": default_image,
+            "region": default_region,
+            "labels": default_labels,
+            "network": {
+                "proxy": {
+                    "routing": [
+                        {
+                            "destinations": ["api.stripe.com"],
+                            "headers": {"Authorization": "Bearer {{SECRET:stripe-key}}"},
+                            "secrets": {"stripe-key": "sk-live-test123"},
+                        },
+                    ],
+                },
             },
-        },
-    })
+        }
+    )
 
     await SandboxInstance.delete(name)
     deleted = await wait_for_sandbox_deletion(name, max_attempts=60)

--- a/tests/integration/core/sandbox/proxy/test_python.py
+++ b/tests/integration/core/sandbox/proxy/test_python.py
@@ -24,37 +24,41 @@ class TestProxyPythonRequests:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("proxy-py")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": "blaxel/py-app:latest",
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["httpbin.org"],
-                            "headers": {
-                                "X-Proxy-Test": "header-injected",
-                                "X-Api-Key": "{{SECRET:test-api-key}}",
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": "blaxel/py-app:latest",
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["httpbin.org"],
+                                "headers": {
+                                    "X-Proxy-Test": "header-injected",
+                                    "X-Api-Key": "{{SECRET:test-api-key}}",
+                                },
+                                "body": {
+                                    "injected_field": "body-injected",
+                                    "secret_body": "{{SECRET:test-api-key}}",
+                                },
+                                "secrets": {"test-api-key": "resolved-secret-42"},
                             },
-                            "body": {
-                                "injected_field": "body-injected",
-                                "secret_body": "{{SECRET:test-api-key}}",
-                            },
-                            "secrets": {"test-api-key": "resolved-secret-42"},
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
 
         await request.cls.sandbox.fs.write("/tmp/proxy-test.py", PYTHON_HELPER_SCRIPT)
 
-        pip_result = await request.cls.sandbox.process.exec({
-            "command": "pip install --break-system-packages requests 2>&1",
-            "wait_for_completion": True,
-        })
+        pip_result = await request.cls.sandbox.process.exec(
+            {
+                "command": "pip install --break-system-packages requests 2>&1",
+                "wait_for_completion": True,
+            }
+        )
         if pip_result.exit_code != 0:
             raise RuntimeError(f"pip install failed: {(pip_result.logs or '')[:500]}")
 
@@ -65,10 +69,12 @@ class TestProxyPythonRequests:
             pass
 
     async def test_python_requests_get_with_header_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": "python3 /tmp/proxy-test.py GET https://httpbin.org/headers 2>&1",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "python3 /tmp/proxy-test.py GET https://httpbin.org/headers 2>&1",
+                "wait_for_completion": True,
+            }
+        )
         if result.exit_code != 0:
             raise RuntimeError(f"python3 exited {result.exit_code}: {(result.logs or '')[:1500]}")
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
@@ -77,10 +83,12 @@ class TestProxyPythonRequests:
         assert headers["x-api-key"] == "resolved-secret-42"
 
     async def test_python_requests_post_with_body_injection(self):
-        result = await self.sandbox.process.exec({
-            "command": """python3 /tmp/proxy-test.py POST https://httpbin.org/post '{}' '{"user_data":"from-python"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """python3 /tmp/proxy-test.py POST https://httpbin.org/post '{}' '{"user_data":"from-python"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         response = parse_json_output(result.logs)
         assert response["json"]["user_data"] == "from-python"
@@ -88,10 +96,12 @@ class TestProxyPythonRequests:
         assert response["json"]["secret_body"] == "resolved-secret-42"
 
     async def test_python_requests_preserves_user_headers(self):
-        result = await self.sandbox.process.exec({
-            "command": """python3 /tmp/proxy-test.py GET https://httpbin.org/headers '{"X-User-Custom":"from-python"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """python3 /tmp/proxy-test.py GET https://httpbin.org/headers '{"X-User-Custom":"from-python"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers["x-user-custom"] == "from-python"

--- a/tests/integration/core/sandbox/proxy/test_secrets.py
+++ b/tests/integration/core/sandbox/proxy/test_secrets.py
@@ -24,40 +24,42 @@ class TestSecretsReplacementValidation:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("proxy-sec")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["httpbin.org"],
-                            "headers": {
-                                "X-Token": "Bearer {{SECRET:api-token}}",
-                                "X-Multi": "{{SECRET:part-a}}-{{SECRET:part-b}}",
-                                "X-Plain": "no-secret-here",
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["httpbin.org"],
+                                "headers": {
+                                    "X-Token": "Bearer {{SECRET:api-token}}",
+                                    "X-Multi": "{{SECRET:part-a}}-{{SECRET:part-b}}",
+                                    "X-Plain": "no-secret-here",
+                                },
+                                "body": {
+                                    "secret_key": "{{SECRET:api-token}}",
+                                    "composite": "prefix-{{SECRET:part-a}}-suffix",
+                                },
+                                "secrets": {
+                                    "api-token": "tok_live_abc123",
+                                    "part-a": "ALPHA",
+                                    "part-b": "BETA",
+                                },
                             },
-                            "body": {
-                                "secret_key": "{{SECRET:api-token}}",
-                                "composite": "prefix-{{SECRET:part-a}}-suffix",
+                            {
+                                "destinations": ["*.example.com"],
+                                "headers": {"X-Other-Secret": "{{SECRET:other-key}}"},
+                                "secrets": {"other-key": "other-value-999"},
                             },
-                            "secrets": {
-                                "api-token": "tok_live_abc123",
-                                "part-a": "ALPHA",
-                                "part-b": "BETA",
-                            },
-                        },
-                        {
-                            "destinations": ["*.example.com"],
-                            "headers": {"X-Other-Secret": "{{SECRET:other-key}}"},
-                            "secrets": {"other-key": "other-value-999"},
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -66,29 +68,35 @@ class TestSecretsReplacementValidation:
             pass
 
     async def test_resolves_secret_in_headers_to_actual_value(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers["x-token"] == "Bearer tok_live_abc123"
         assert headers["x-plain"] == "no-secret-here"
 
     async def test_resolves_multiple_secret_placeholders_in_single_header(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers["x-multi"] == "ALPHA-BETA"
 
     async def test_resolves_secret_in_post_body_fields(self):
-        result = await self.sandbox.process.exec({
-            "command": """node /tmp/proxy-test.js POST https://httpbin.org/post '{}' '{"user_field":"untouched"}'""",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": """node /tmp/proxy-test.js POST https://httpbin.org/post '{}' '{"user_field":"untouched"}'""",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         response = parse_json_output(result.logs)
         assert response["json"]["user_field"] == "untouched"
@@ -96,56 +104,66 @@ class TestSecretsReplacementValidation:
         assert response["json"]["composite"] == "prefix-ALPHA-suffix"
 
     async def test_does_not_leak_secrets_from_one_route_to_another(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers.get("x-other-secret") is None
 
     async def test_does_not_expose_raw_secret_template_on_the_wire(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         assert "{{SECRET:" not in (result.logs or "")
 
     async def test_resolves_secret_in_user_sent_headers(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "node /tmp/proxy-test.js GET https://httpbin.org/headers "
-                """'{"X-User-Token":"{{SECRET:api-token}}","X-User-Combo":"pre-{{SECRET:part-a}}-post"}'"""
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "node /tmp/proxy-test.js GET https://httpbin.org/headers "
+                    """'{"X-User-Token":"{{SECRET:api-token}}","X-User-Combo":"pre-{{SECRET:part-a}}-post"}'"""
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers["x-user-token"] == "tok_live_abc123"
         assert headers["x-user-combo"] == "pre-ALPHA-post"
 
     async def test_resolves_secret_in_user_sent_post_body(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "node /tmp/proxy-test.js POST https://httpbin.org/post "
-                """'{}' '{"api_key":"{{SECRET:api-token}}","mixed":"hello-{{SECRET:part-b}}-world"}'"""
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "node /tmp/proxy-test.js POST https://httpbin.org/post "
+                    """'{}' '{"api_key":"{{SECRET:api-token}}","mixed":"hello-{{SECRET:part-b}}-world"}'"""
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         response = parse_json_output(result.logs)
         assert response["json"]["api_key"] == "tok_live_abc123"
         assert response["json"]["mixed"] == "hello-BETA-world"
 
     async def test_does_not_resolve_secrets_from_different_route_in_user_headers(self):
-        result = await self.sandbox.process.exec({
-            "command": (
-                "node /tmp/proxy-test.js GET https://httpbin.org/headers "
-                """'{"X-Wrong-Route":"{{SECRET:other-key}}"}'"""
-            ),
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": (
+                    "node /tmp/proxy-test.js GET https://httpbin.org/headers "
+                    """'{"X-Wrong-Route":"{{SECRET:other-key}}"}'"""
+                ),
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers["x-wrong-route"] == "{{SECRET:other-key}}"

--- a/tests/integration/core/sandbox/proxy/test_wildcard.py
+++ b/tests/integration/core/sandbox/proxy/test_wildcard.py
@@ -24,23 +24,25 @@ class TestProxyWildcardDestination:
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
     async def setup_sandbox(self, request):
         request.cls.sandbox_name = unique_name("proxy-wild")
-        request.cls.sandbox = await SandboxInstance.create({
-            "name": request.cls.sandbox_name,
-            "image": default_image,
-            "region": default_region,
-            "labels": default_labels,
-            "network": {
-                "proxy": {
-                    "routing": [
-                        {
-                            "destinations": ["*"],
-                            "headers": {"X-Global-Auth": "Bearer {{SECRET:global-key}}"},
-                            "secrets": {"global-key": "global-token-xyz"},
-                        },
-                    ],
+        request.cls.sandbox = await SandboxInstance.create(
+            {
+                "name": request.cls.sandbox_name,
+                "image": default_image,
+                "region": default_region,
+                "labels": default_labels,
+                "network": {
+                    "proxy": {
+                        "routing": [
+                            {
+                                "destinations": ["*"],
+                                "headers": {"X-Global-Auth": "Bearer {{SECRET:global-key}}"},
+                                "secrets": {"global-key": "global-token-xyz"},
+                            },
+                        ],
+                    },
                 },
-            },
-        })
+            }
+        )
         await request.cls.sandbox.fs.write("/tmp/proxy-test.js", PROXY_HELPER_SCRIPT)
         yield
         try:
@@ -49,10 +51,12 @@ class TestProxyWildcardDestination:
             pass
 
     async def test_applies_global_rule_to_httpbin(self):
-        result = await self.sandbox.process.exec({
-            "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
-            "wait_for_completion": True,
-        })
+        result = await self.sandbox.process.exec(
+            {
+                "command": "node /tmp/proxy-test.js GET https://httpbin.org/headers",
+                "wait_for_completion": True,
+            }
+        )
         assert result.exit_code == 0
         headers = lowercase_keys(parse_json_output(result.logs)["headers"])
         assert headers["x-global-auth"] == "Bearer global-token-xyz"

--- a/tests/integration/livekit/test_model.py
+++ b/tests/integration/livekit/test_model.py
@@ -29,7 +29,9 @@ async def _created_livekit_kwargs(provider_type: str, model: str, **kwargs):
         patch("blaxel.livekit.model.AsyncOpenAI", return_value=openai_client),
         patch("blaxel.livekit.model.openai.LLM", return_value=llm) as llm_factory,
     ):
-        result = await get_livekit_model("https://example.com/models/test", provider_type, model, **kwargs)
+        result = await get_livekit_model(
+            "https://example.com/models/test", provider_type, model, **kwargs
+        )
 
     assert result is llm
     return llm_factory.call_args.kwargs


### PR DESCRIPTION
- Cursor-based pagination support across list endpoints, non-breaking: generated clients and wrappers accept both today's bare-array responses and the new paginated `*List` objects, preserving the legacy return shape until the platform migration completes
- Hardens generated response parsing: documented statuses with non-JSON bodies raise `ResponseParseError` (status, content type, body preview) instead of `JSONDecodeError` (ENG-2802)
- Regenerated against current definitions; shared list-unwrap helper; parsing + unwrap test coverage

Version pinning + auto-paging iterators (#145's design) remain follow-up; this is the bridge.
