### PR TITLE
fix(auth): clear errors for missing BL_WORKSPACE/BL_API_KEY (ENG-2253)

### DIFF
--- a/src/blaxel/core/authentication/__init__.py
+++ b/src/blaxel/core/authentication/__init__.py
@@ -7,9 +7,29 @@ import yaml
 from .apikey import ApiKey
 from .clientcredentials import ClientCredentials
 from .devicemode import DeviceMode
-from .types import BlaxelAuth, CredentialsType
+from .types import BlaxelAuth, CredentialsError, CredentialsType, MissingCredentials
 
 logger = getLogger(__name__)
+
+
+def _missing_credentials_message() -> str:
+    """Build an actionable message naming exactly which piece is missing."""
+    has_workspace = bool(os.environ.get("BL_WORKSPACE"))
+    has_api_key = bool(os.environ.get("BL_API_KEY"))
+    if has_workspace and not has_api_key:
+        return (
+            "Blaxel API key is missing. Set the BL_API_KEY environment variable, "
+            "or run `bl login`, to authenticate (BL_WORKSPACE is already set)."
+        )
+    if has_api_key and not has_workspace:
+        return (
+            "Blaxel workspace is missing. Set the BL_WORKSPACE environment variable, "
+            "or run `bl login`, to authenticate (BL_API_KEY is already set)."
+        )
+    return (
+        "No Blaxel credentials found. Set the BL_API_KEY and BL_WORKSPACE "
+        "environment variables, or run `bl login`."
+    )
 
 
 def get_credentials() -> CredentialsType | None:
@@ -23,11 +43,17 @@ def get_credentials() -> CredentialsType | None:
     def get_workspace():
         if os.environ.get("BL_WORKSPACE"):
             return os.environ.get("BL_WORKSPACE")
-        home_dir = Path.home()
-        config_path = home_dir / ".blaxel" / "config.yaml"
-        with open(config_path, encoding="utf-8") as f:
-            config_json = yaml.safe_load(f)
-        return config_json.get("context", {}).get("workspace")
+        try:
+            home_dir = Path.home()
+            config_path = home_dir / ".blaxel" / "config.yaml"
+            with open(config_path, encoding="utf-8") as f:
+                config_json = yaml.safe_load(f) or {}
+            return config_json.get("context", {}).get("workspace")
+        except Exception:
+            # No config file (e.g. running in a fresh sandbox with only
+            # BL_API_KEY set) must not crash credential resolution; the
+            # missing workspace is reported clearly at request time instead.
+            return None
 
     if os.environ.get("BL_API_KEY"):
         return CredentialsType(api_key=os.environ.get("BL_API_KEY"), workspace=get_workspace())
@@ -82,7 +108,11 @@ def auth(env: str, base_url: str) -> BlaxelAuth:
     credentials = get_credentials()
 
     if not credentials:
-        return None
+        # Never return None: a sentinel that raises a clear CredentialsError on
+        # use keeps `import blaxel` working while turning the old cryptic
+        # AttributeError / server-side "workspace is required" into an
+        # actionable message.
+        return MissingCredentials(base_url, message=_missing_credentials_message())
 
     if credentials.api_key:
         logger.debug("Using API key for authentication")
@@ -99,4 +129,11 @@ def auth(env: str, base_url: str) -> BlaxelAuth:
     return BlaxelAuth(credentials, credentials.workspace, base_url)
 
 
-__all__ = ["BlaxelAuth", "CredentialsType"]
+__all__ = [
+    "BlaxelAuth",
+    "CredentialsError",
+    "CredentialsType",
+    "MissingCredentials",
+    "get_credentials",
+    "auth",
+]

--- a/src/blaxel/core/authentication/apikey.py
+++ b/src/blaxel/core/authentication/apikey.py
@@ -21,9 +21,10 @@ class ApiKey(BlaxelAuth):
         Returns:
             dict: A dictionary of headers with API key and workspace.
         """
+        workspace = self._ensure_workspace()
         return {
             "X-Blaxel-Authorization": f"Bearer {self.credentials.api_key}",
-            "X-Blaxel-Workspace": self.workspace_name,
+            "X-Blaxel-Workspace": workspace,
         }
 
     def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
@@ -36,8 +37,9 @@ class ApiKey(BlaxelAuth):
         Yields:
             Request: The authenticated request.
         """
+        workspace = self._ensure_workspace()
         request.headers["X-Blaxel-Authorization"] = f"Bearer {self.credentials.api_key}"
-        request.headers["X-Blaxel-Workspace"] = self.workspace_name
+        request.headers["X-Blaxel-Workspace"] = workspace
         yield request
 
     @property

--- a/src/blaxel/core/authentication/clientcredentials.py
+++ b/src/blaxel/core/authentication/clientcredentials.py
@@ -40,12 +40,13 @@ class ClientCredentials(BlaxelAuth):
         Raises:
             Exception: If token refresh fails.
         """
+        workspace = self._ensure_workspace()
         err = self.get_token()
         if err:
             raise err
         return {
             "X-Blaxel-Authorization": f"Bearer {self.credentials.access_token}",
-            "X-Blaxel-Workspace": self.workspace_name,
+            "X-Blaxel-Workspace": workspace,
         }
 
     def _request_token(self, remaining_retries: int = 3) -> Exception | None:
@@ -108,9 +109,10 @@ class ClientCredentials(BlaxelAuth):
         Raises:
             Exception: If token refresh fails.
         """
+        workspace = self._ensure_workspace()
         self.get_token()
         request.headers["X-Blaxel-Authorization"] = f"Bearer {self.credentials.access_token}"
-        request.headers["X-Blaxel-Workspace"] = self.workspace_name
+        request.headers["X-Blaxel-Workspace"] = workspace
         yield request
 
     @property

--- a/src/blaxel/core/authentication/devicemode.py
+++ b/src/blaxel/core/authentication/devicemode.py
@@ -92,12 +92,13 @@ class DeviceMode(BlaxelAuth):
         Raises:
             Exception: If token refresh fails.
         """
+        workspace = self._ensure_workspace()
         err = self.refresh_if_needed()
         if err:
             raise err
         return {
             "X-Blaxel-Authorization": f"Bearer {self.credentials.access_token}",
-            "X-Blaxel-Workspace": self.workspace_name,
+            "X-Blaxel-Workspace": workspace,
         }
 
     def refresh_if_needed(self) -> Exception | None:
@@ -138,12 +139,13 @@ class DeviceMode(BlaxelAuth):
         Raises:
             Exception: If token refresh fails.
         """
+        workspace = self._ensure_workspace()
         err = self.refresh_if_needed()
         if err:
             return err
 
         request.headers["X-Blaxel-Authorization"] = f"Bearer {self.credentials.access_token}"
-        request.headers["X-Blaxel-Workspace"] = self.workspace_name
+        request.headers["X-Blaxel-Workspace"] = workspace
         yield request
 
     def do_refresh(self) -> Exception | None:

--- a/src/blaxel/core/authentication/types.py
+++ b/src/blaxel/core/authentication/types.py
@@ -6,6 +6,15 @@ from httpx import Auth
 from pydantic import BaseModel, Field
 
 
+class CredentialsError(Exception):
+    """Raised when Blaxel credentials are missing or incomplete.
+
+    Surfaced eagerly with an actionable message (which env var / login step is
+    missing) instead of letting a ``None`` value reach httpx header encoding or
+    a misleading server-side error.
+    """
+
+
 class CredentialsType(BaseModel):
     """Represents authentication credentials for the API"""
 
@@ -35,6 +44,52 @@ class BlaxelAuth(Auth):
     def get_headers(self) -> Dict[str, str]:
         return {}
 
+    def _ensure_workspace(self) -> str:
+        """Return the workspace name, raising a clear error if it is missing.
+
+        Called before emitting the ``X-Blaxel-Workspace`` header so a ``None``
+        workspace never reaches httpx (which would raise an opaque
+        ``'NoneType' object has no attribute 'encode'``).
+        """
+        if not self.workspace_name:
+            raise CredentialsError(
+                "Blaxel workspace is missing. Set the BL_WORKSPACE environment "
+                "variable, or run `bl login`, to authenticate your requests."
+            )
+        return self.workspace_name
+
     @property
     def token(self):
         raise NotImplementedError("Subclasses must implement the token property")
+
+
+class MissingCredentials(BlaxelAuth):
+    """Auth placeholder used when no usable Blaxel credentials were resolved.
+
+    Construction is side-effect free, so ``import blaxel`` succeeds without
+    credentials. The actionable error is raised only when the auth object is
+    actually used to build a request (headers, auth flow, or token access),
+    which is what every controlplane, run, and sandbox call goes through.
+    """
+
+    def __init__(self, base_url: str = "", message: str | None = None):
+        self.credentials = CredentialsType()
+        self.workspace_name = None
+        self.base_url = base_url
+        self._message = message or (
+            "No Blaxel credentials found. Set the BL_API_KEY and BL_WORKSPACE "
+            "environment variables, or run `bl login`."
+        )
+
+    def _raise(self):
+        raise CredentialsError(self._message)
+
+    def get_headers(self) -> Dict[str, str]:
+        self._raise()
+
+    def auth_flow(self, request):
+        self._raise()
+
+    @property
+    def token(self):
+        self._raise()

--- a/tests/core/test_authentication_env_vars.py
+++ b/tests/core/test_authentication_env_vars.py
@@ -1,0 +1,112 @@
+"""Unit tests for env-var credential error handling (ENG-2253).
+
+Covers the three reported failure modes when BL_WORKSPACE / BL_API_KEY are
+missing or partially set: instead of a cryptic httpx ``'NoneType' has no
+encode`` error, an import-time ``FileNotFoundError``, or a misleading
+server-side "workspace is required" message, the SDK must fail fast with a
+clear, actionable ``CredentialsError``.
+"""
+
+import httpx
+import pytest
+
+from blaxel.core.authentication import (
+    CredentialsError,
+    MissingCredentials,
+    auth,
+    get_credentials,
+)
+from blaxel.core.authentication.apikey import ApiKey
+
+BASE_URL = "https://api.blaxel.ai/v0"
+
+
+@pytest.fixture
+def no_config(monkeypatch, tmp_path):
+    """Point Path.home() at an empty dir so no ~/.blaxel/config.yaml is found."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def clear_auth_env(monkeypatch):
+    """Remove every auth-related env var so each test controls its own state."""
+    for var in ("BL_API_KEY", "BL_WORKSPACE", "BL_CLIENT_CREDENTIALS", "BL_ENV"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_get_credentials_missing_config_does_not_raise(no_config, clear_auth_env, monkeypatch):
+    """Root cause of import-time crash: only BL_API_KEY set with no config file.
+
+    ``get_workspace()`` used to open a non-existent config and raise
+    FileNotFoundError, breaking ``import blaxel`` entirely.
+    """
+    monkeypatch.setenv("BL_API_KEY", "fake-key")
+    creds = get_credentials()
+    assert creds is not None
+    assert creds.api_key == "fake-key"
+    assert creds.workspace is None
+
+
+def test_apikey_without_workspace_get_headers_raises(no_config, clear_auth_env, monkeypatch):
+    """Case 1: BL_API_KEY set, BL_WORKSPACE missing -> clear error, never a None header."""
+    monkeypatch.setenv("BL_API_KEY", "fake-key")
+    a = auth("prod", BASE_URL)
+    assert isinstance(a, ApiKey)
+    with pytest.raises(CredentialsError) as exc:
+        a.get_headers()
+    assert "BL_WORKSPACE" in str(exc.value)
+
+
+def test_apikey_without_workspace_auth_flow_raises(no_config, clear_auth_env, monkeypatch):
+    """Case 1, real httpx path: the auth_flow must raise instead of encoding a None header."""
+    monkeypatch.setenv("BL_API_KEY", "fake-key")
+    a = auth("prod", BASE_URL)
+    req = httpx.Request("GET", f"{BASE_URL}/sandboxes")
+    with pytest.raises(CredentialsError):
+        next(a.auth_flow(req))
+
+
+def test_workspace_only_names_missing_api_key(no_config, clear_auth_env, monkeypatch):
+    """Case 2: BL_WORKSPACE set, BL_API_KEY missing -> error names the API key, not workspace."""
+    monkeypatch.setenv("BL_WORKSPACE", "my-workspace")
+    a = auth("prod", BASE_URL)
+    assert isinstance(a, MissingCredentials)
+    with pytest.raises(CredentialsError) as exc:
+        a.get_headers()
+    assert "BL_API_KEY" in str(exc.value)
+
+
+def test_no_credentials_clear_error(no_config, clear_auth_env):
+    """Neither var set, no config -> clear error naming both vars; token access also raises."""
+    a = auth("prod", BASE_URL)
+    assert isinstance(a, MissingCredentials)
+    with pytest.raises(CredentialsError) as exc:
+        a.get_headers()
+    msg = str(exc.value)
+    assert "BL_API_KEY" in msg and "BL_WORKSPACE" in msg
+    with pytest.raises(CredentialsError):
+        _ = a.token
+
+
+def test_both_set_builds_clean_headers(no_config, clear_auth_env, monkeypatch):
+    """Control: both present -> normal headers, no None values reach httpx."""
+    monkeypatch.setenv("BL_API_KEY", "fake-key")
+    monkeypatch.setenv("BL_WORKSPACE", "my-workspace")
+    a = auth("prod", BASE_URL)
+    headers = a.get_headers()
+    assert headers["X-Blaxel-Workspace"] == "my-workspace"
+    assert headers["X-Blaxel-Authorization"] == "Bearer fake-key"
+    assert None not in headers.values()
+    # and the real httpx encoding path no longer crashes
+    encoded = dict(httpx.Headers(headers))
+    assert encoded["x-blaxel-workspace"] == "my-workspace"
+
+
+def test_settings_headers_clear_error_without_credentials(no_config, clear_auth_env):
+    """Settings.headers must surface CredentialsError, not AttributeError on a None auth."""
+    from blaxel.core.common.settings import Settings
+
+    s = Settings()
+    with pytest.raises(CredentialsError):
+        _ = s.headers


### PR DESCRIPTION
Fixes ENG-2253.

- Missing or partial credentials gave cryptic errors: a missing workspace crashed httpx, a missing config file crashed at import, and missing credentials raised an unrelated error or a misleading server-side "workspace is required".
- The SDK now resolves credentials safely and raises one clear error naming exactly what to set (BL_API_KEY, BL_WORKSPACE, or `bl login`) before any request goes out.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces cryptic `None`-propagation failures (httpx encode crash, import-time `FileNotFoundError`, misleading server-side error) with a `MissingCredentials` sentinel and `CredentialsError` that names exactly which env var is missing. Adds `_ensure_workspace()` guard on every header/auth-flow path, and covers the three failure modes with unit tests.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0b408f6737a887e1858c6b4ee4043e99382153c6.</sup>
<!-- /MENDRAL_SUMMARY -->