### PR TITLE
fix: make create_if_not_exists survive the post-delete window

### DIFF
--- a/src/blaxel/core/sandbox/default/sandbox.py
+++ b/src/blaxel/core/sandbox/default/sandbox.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+import time
 import uuid
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Union
@@ -64,9 +66,25 @@ NON_REUSABLE_SANDBOX_STATUSES = {
     "DEACTIVATING",
 }
 
+# Statuses that resolve on their own (a delete or deactivation in flight). The control
+# plane keeps answering 409 to creates while the record is in one of these, so retrying
+# instantly burns the whole attempt budget inside the window. Terminal statuses
+# (FAILED, TERMINATED) accept a create immediately and are not listed here.
+TRANSIENT_SANDBOX_STATUSES = {
+    "TERMINATING",
+    "DELETING",
+    "DEACTIVATING",
+}
+TRANSIENT_STATUS_MAX_WAIT_SECONDS = 30.0
+TRANSIENT_STATUS_POLL_SECONDS = 0.5
+
 
 def _is_sandbox_conflict(error: SandboxAPIError) -> bool:
     return error.status_code == 409 or error.code in {409, "409", "SANDBOX_ALREADY_EXISTS"}
+
+
+def _is_sandbox_not_found(error: SandboxAPIError) -> bool:
+    return error.status_code == 404 or error.code in {404, "404"}
 
 
 def _sandbox_name(
@@ -357,6 +375,10 @@ class SandboxInstance:
     @classmethod
     async def list(cls) -> List["SandboxInstance"]:
         response = await list_sandboxes(client=client)
+        if isinstance(response, Error):
+            status_code = response.code if response.code is not UNSET else None
+            message = response.message if response.message is not UNSET else response.error
+            raise SandboxAPIError(message, status_code=status_code, code=response.error)
         return [cls(sandbox) for sandbox in response]
 
     @classmethod
@@ -520,7 +542,9 @@ class SandboxInstance:
     ) -> "SandboxInstance":
         """Create a sandbox if it doesn't exist, otherwise return existing."""
         attempts = 3
-        for _ in range(attempts):
+        last_status = "unknown"
+        for attempt in range(attempts):
+            final_attempt = attempt == attempts - 1
             try:
                 return await cls.create(sandbox, create_if_not_exist=True)
             except SandboxAPIError as e:
@@ -531,11 +555,56 @@ class SandboxInstance:
                 if not name:
                     raise ValueError("Sandbox name is required")
 
-                sandbox_instance = await cls.get(name)
+                try:
+                    sandbox_instance = await cls.get(name)
+                except SandboxAPIError as get_error:
+                    if _is_sandbox_not_found(get_error):
+                        # The record vanished between the create conflict and this status
+                        # check (its deletion just finished); give the control plane a
+                        # beat and retry.
+                        last_status = "vanished"
+                        if not final_attempt:
+                            await asyncio.sleep(TRANSIENT_STATUS_POLL_SECONDS)
+                        continue
+                    raise
+
                 if str(sandbox_instance.status) not in NON_REUSABLE_SANDBOX_STATUSES:
                     return sandbox_instance
 
-        raise RuntimeError(f"Unable to create sandbox after {attempts} attempts.")
+                # A delete or deactivation in flight rejects creates until it finishes;
+                # wait it out instead of burning the remaining attempts inside the window.
+                # No point waiting after the last attempt: nothing will use the result.
+                last_status = str(sandbox_instance.status)
+                if last_status in TRANSIENT_SANDBOX_STATUSES and not final_attempt:
+                    await cls._wait_while_dying(name)
+
+        raise RuntimeError(
+            f"Unable to create sandbox after {attempts} attempts."
+            f" Last conflicting status: {last_status}."
+        )
+
+    @classmethod
+    async def _wait_while_dying(cls, name: str) -> None:
+        """Poll until an in-flight delete/deactivation settles or the record disappears.
+
+        Bounded by TRANSIENT_STATUS_MAX_WAIT_SECONDS. Errors from get (e.g. 404 once
+        the record is gone) end the wait: the caller's create retry decides next.
+        """
+        deadline = time.monotonic() + TRANSIENT_STATUS_MAX_WAIT_SECONDS
+        while time.monotonic() < deadline:
+            await asyncio.sleep(TRANSIENT_STATUS_POLL_SECONDS)
+            try:
+                current = await cls.get(name)
+            except Exception:
+                return
+            status = str(current.status)
+            if status not in TRANSIENT_SANDBOX_STATUSES:
+                return
+            logger.debug(
+                "Sandbox %s still %s; waiting for the record to settle before recreating",
+                name,
+                status,
+            )
 
     @classmethod
     async def from_session(

--- a/src/blaxel/core/sandbox/sync/sandbox.py
+++ b/src/blaxel/core/sandbox/sync/sandbox.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import uuid
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Union
@@ -29,8 +30,12 @@ from ...client.types import UNSET
 from ...common.settings import settings
 from ..default.sandbox import (
     NON_REUSABLE_SANDBOX_STATUSES,
+    TRANSIENT_SANDBOX_STATUSES,
+    TRANSIENT_STATUS_MAX_WAIT_SECONDS,
+    TRANSIENT_STATUS_POLL_SECONDS,
     SandboxAPIError,
     _is_sandbox_conflict,
+    _is_sandbox_not_found,
     _sandbox_name,
 )
 from ..types import (
@@ -297,6 +302,10 @@ class SyncSandboxInstance:
     @classmethod
     def list(cls) -> List["SyncSandboxInstance"]:
         response = list_sandboxes(client=client)
+        if isinstance(response, Error):
+            status_code = response.code if response.code is not UNSET else None
+            message = response.message if response.message is not UNSET else response.error
+            raise SandboxAPIError(message, status_code=status_code, code=response.error)
         return [cls(sandbox) for sandbox in response]
 
     @classmethod
@@ -434,7 +443,9 @@ class SyncSandboxInstance:
         cls, sandbox: Union[Sandbox, SandboxCreateConfiguration, Dict[str, Any]]
     ) -> "SyncSandboxInstance":
         attempts = 3
-        for _ in range(attempts):
+        last_status = "unknown"
+        for attempt in range(attempts):
+            final_attempt = attempt == attempts - 1
             try:
                 return cls.create(sandbox, create_if_not_exist=True)
             except SandboxAPIError as e:
@@ -445,11 +456,56 @@ class SyncSandboxInstance:
                 if not name:
                     raise ValueError("Sandbox name is required")
 
-                sandbox_instance = cls.get(name)
+                try:
+                    sandbox_instance = cls.get(name)
+                except SandboxAPIError as get_error:
+                    if _is_sandbox_not_found(get_error):
+                        # The record vanished between the create conflict and this status
+                        # check (its deletion just finished); give the control plane a
+                        # beat and retry.
+                        last_status = "vanished"
+                        if not final_attempt:
+                            time.sleep(TRANSIENT_STATUS_POLL_SECONDS)
+                        continue
+                    raise
+
                 if str(sandbox_instance.status) not in NON_REUSABLE_SANDBOX_STATUSES:
                     return sandbox_instance
 
-        raise RuntimeError(f"Unable to create sandbox after {attempts} attempts.")
+                # A delete or deactivation in flight rejects creates until it finishes;
+                # wait it out instead of burning the remaining attempts inside the window.
+                # No point waiting after the last attempt: nothing will use the result.
+                last_status = str(sandbox_instance.status)
+                if last_status in TRANSIENT_SANDBOX_STATUSES and not final_attempt:
+                    cls._wait_while_dying(name)
+
+        raise RuntimeError(
+            f"Unable to create sandbox after {attempts} attempts."
+            f" Last conflicting status: {last_status}."
+        )
+
+    @classmethod
+    def _wait_while_dying(cls, name: str) -> None:
+        """Poll until an in-flight delete/deactivation settles or the record disappears.
+
+        Bounded by TRANSIENT_STATUS_MAX_WAIT_SECONDS. Errors from get (e.g. 404 once
+        the record is gone) end the wait: the caller's create retry decides next.
+        """
+        deadline = time.monotonic() + TRANSIENT_STATUS_MAX_WAIT_SECONDS
+        while time.monotonic() < deadline:
+            time.sleep(TRANSIENT_STATUS_POLL_SECONDS)
+            try:
+                current = cls.get(name)
+            except Exception:
+                return
+            status = str(current.status)
+            if status not in TRANSIENT_SANDBOX_STATUSES:
+                return
+            logger.debug(
+                "Sandbox %s still %s; waiting for the record to settle before recreating",
+                name,
+                status,
+            )
 
     @classmethod
     def from_session(

--- a/tests/core/test_sandbox.py
+++ b/tests/core/test_sandbox.py
@@ -251,11 +251,8 @@ async def test_create_if_not_exists_accepts_conflict_error_codes(code):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "status",
-    ["FAILED", "TERMINATED", "TERMINATING", "DELETING", "DEACTIVATING"],
-)
-async def test_create_if_not_exists_retries_for_non_reusable_statuses(status):
+@pytest.mark.parametrize("status", ["FAILED", "TERMINATED"])
+async def test_create_if_not_exists_retries_immediately_for_terminal_statuses(status):
     replacement = sandbox_instance("stale")
 
     with (
@@ -268,10 +265,99 @@ async def test_create_if_not_exists_retries_for_non_reusable_statuses(status):
         result = await SandboxInstance.create_if_not_exists({"name": "stale"})
 
         assert result is replacement
+        assert mock_get.await_count == 1
         assert mock_create.await_args_list == [
             call({"name": "stale"}, create_if_not_exist=True),
             call({"name": "stale"}, create_if_not_exist=True),
         ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["TERMINATING", "DELETING", "DEACTIVATING"])
+async def test_create_if_not_exists_waits_out_dying_record_before_retrying(status, monkeypatch):
+    import blaxel.core.sandbox.default.sandbox as default_sandbox
+
+    monkeypatch.setattr(default_sandbox, "TRANSIENT_STATUS_POLL_SECONDS", 0.001)
+    replacement = sandbox_instance("dying")
+
+    with (
+        patch.object(SandboxInstance, "create", new_callable=AsyncMock) as mock_create,
+        patch.object(SandboxInstance, "get", new_callable=AsyncMock) as mock_get,
+    ):
+        mock_create.side_effect = [conflict_error(), replacement]
+        mock_get.side_effect = [
+            sandbox_instance("dying", status),
+            sandbox_instance("dying", status),
+            sandbox_instance("dying", "TERMINATED"),
+            sandbox_instance("dying", "TERMINATED"),
+        ]
+
+        result = await SandboxInstance.create_if_not_exists({"name": "dying"})
+
+        assert result is replacement
+        assert mock_create.await_count == 2
+        # initial status check plus at least one poll while the record was dying
+        assert mock_get.await_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_create_if_not_exists_retries_when_record_vanishes_before_status_check(
+    monkeypatch,
+):
+    import blaxel.core.sandbox.default.sandbox as default_sandbox
+
+    monkeypatch.setattr(default_sandbox, "TRANSIENT_STATUS_POLL_SECONDS", 0.001)
+    replacement = sandbox_instance("vanished")
+
+    with (
+        patch.object(SandboxInstance, "create", new_callable=AsyncMock) as mock_create,
+        patch.object(SandboxInstance, "get", new_callable=AsyncMock) as mock_get,
+    ):
+        mock_create.side_effect = [conflict_error(), replacement]
+        mock_get.side_effect = SandboxAPIError("Sandbox not found", status_code=404)
+
+        result = await SandboxInstance.create_if_not_exists({"name": "vanished"})
+
+        assert result is replacement
+        assert mock_create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_if_not_exists_propagates_non_404_status_check_errors():
+    with (
+        patch.object(SandboxInstance, "create", new_callable=AsyncMock) as mock_create,
+        patch.object(SandboxInstance, "get", new_callable=AsyncMock) as mock_get,
+    ):
+        mock_create.side_effect = [conflict_error()]
+        mock_get.side_effect = SandboxAPIError("internal error", status_code=500)
+
+        with pytest.raises(SandboxAPIError, match="internal error"):
+            await SandboxInstance.create_if_not_exists({"name": "broken"})
+
+
+@pytest.mark.asyncio
+async def test_create_if_not_exists_retries_promptly_when_dying_record_disappears(
+    monkeypatch,
+):
+    import blaxel.core.sandbox.default.sandbox as default_sandbox
+
+    monkeypatch.setattr(default_sandbox, "TRANSIENT_STATUS_POLL_SECONDS", 0.001)
+    replacement = sandbox_instance("gone")
+
+    with (
+        patch.object(SandboxInstance, "create", new_callable=AsyncMock) as mock_create,
+        patch.object(SandboxInstance, "get", new_callable=AsyncMock) as mock_get,
+    ):
+        mock_create.side_effect = [conflict_error(), replacement]
+        mock_get.side_effect = [
+            sandbox_instance("gone", "DELETING"),
+            SandboxAPIError("not found", status_code=404),
+        ]
+
+        result = await SandboxInstance.create_if_not_exists({"name": "gone"})
+
+        assert result is replacement
+        assert mock_create.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -290,6 +376,26 @@ async def test_create_if_not_exists_handles_recreate_race_after_terminal_status(
         assert result is winner
         assert mock_create.await_count == 2
         assert mock_get.await_args_list == [call("race"), call("race")]
+
+
+@pytest.mark.asyncio
+async def test_create_if_not_exists_gives_up_when_record_stays_dying(monkeypatch):
+    import blaxel.core.sandbox.default.sandbox as default_sandbox
+
+    monkeypatch.setattr(default_sandbox, "TRANSIENT_STATUS_POLL_SECONDS", 0.001)
+    monkeypatch.setattr(default_sandbox, "TRANSIENT_STATUS_MAX_WAIT_SECONDS", 0.01)
+
+    with (
+        patch.object(SandboxInstance, "create", new_callable=AsyncMock) as mock_create,
+        patch.object(SandboxInstance, "get", new_callable=AsyncMock) as mock_get,
+    ):
+        mock_create.side_effect = conflict_error()
+        mock_get.return_value = sandbox_instance("stuck", "DELETING")
+
+        with pytest.raises(RuntimeError, match="Last conflicting status: DELETING"):
+            await SandboxInstance.create_if_not_exists({"name": "stuck"})
+
+        assert mock_create.await_count == 3
 
 
 @pytest.mark.asyncio
@@ -415,11 +521,8 @@ def test_sync_create_if_not_exists_accepts_conflict_error_codes(code):
         mock_get.assert_called_once_with("existing")
 
 
-@pytest.mark.parametrize(
-    "status",
-    ["FAILED", "TERMINATED", "TERMINATING", "DELETING", "DEACTIVATING"],
-)
-def test_sync_create_if_not_exists_retries_for_non_reusable_statuses(status):
+@pytest.mark.parametrize("status", ["FAILED", "TERMINATED"])
+def test_sync_create_if_not_exists_retries_immediately_for_terminal_statuses(status):
     replacement = sandbox_instance("stale", cls=SyncSandboxInstance)
 
     with (
@@ -432,10 +535,62 @@ def test_sync_create_if_not_exists_retries_for_non_reusable_statuses(status):
         result = SyncSandboxInstance.create_if_not_exists({"name": "stale"})
 
         assert result is replacement
+        assert mock_get.call_count == 1
         assert mock_create.call_args_list == [
             call({"name": "stale"}, create_if_not_exist=True),
             call({"name": "stale"}, create_if_not_exist=True),
         ]
+
+
+@pytest.mark.parametrize("status", ["TERMINATING", "DELETING", "DEACTIVATING"])
+def test_sync_create_if_not_exists_waits_out_dying_record_before_retrying(status, monkeypatch):
+    import blaxel.core.sandbox.sync.sandbox as sync_sandbox
+
+    monkeypatch.setattr(sync_sandbox, "TRANSIENT_STATUS_POLL_SECONDS", 0.001)
+    replacement = sandbox_instance("dying", cls=SyncSandboxInstance)
+
+    with (
+        patch.object(SyncSandboxInstance, "create") as mock_create,
+        patch.object(SyncSandboxInstance, "get") as mock_get,
+    ):
+        mock_create.side_effect = [conflict_error(), replacement]
+        mock_get.side_effect = [
+            sandbox_instance("dying", status, cls=SyncSandboxInstance),
+            sandbox_instance("dying", status, cls=SyncSandboxInstance),
+            sandbox_instance("dying", "TERMINATED", cls=SyncSandboxInstance),
+            sandbox_instance("dying", "TERMINATED", cls=SyncSandboxInstance),
+        ]
+
+        result = SyncSandboxInstance.create_if_not_exists({"name": "dying"})
+
+        assert result is replacement
+        assert mock_create.call_count == 2
+        # initial status check plus at least one poll while the record was dying
+        assert mock_get.call_count >= 2
+
+
+def test_sync_create_if_not_exists_retries_promptly_when_dying_record_disappears(
+    monkeypatch,
+):
+    import blaxel.core.sandbox.sync.sandbox as sync_sandbox
+
+    monkeypatch.setattr(sync_sandbox, "TRANSIENT_STATUS_POLL_SECONDS", 0.001)
+    replacement = sandbox_instance("gone", cls=SyncSandboxInstance)
+
+    with (
+        patch.object(SyncSandboxInstance, "create") as mock_create,
+        patch.object(SyncSandboxInstance, "get") as mock_get,
+    ):
+        mock_create.side_effect = [conflict_error(), replacement]
+        mock_get.side_effect = [
+            sandbox_instance("gone", "DELETING", cls=SyncSandboxInstance),
+            SandboxAPIError("Sandbox not found", status_code=404),
+        ]
+
+        result = SyncSandboxInstance.create_if_not_exists({"name": "gone"})
+
+        assert result is replacement
+        assert mock_create.call_count == 2
 
 
 def test_sync_create_if_not_exists_handles_recreate_race_after_terminal_status():
@@ -456,6 +611,58 @@ def test_sync_create_if_not_exists_handles_recreate_race_after_terminal_status()
         assert result is winner
         assert mock_create.call_count == 2
         assert mock_get.call_args_list == [call("race"), call("race")]
+
+
+def test_sync_create_if_not_exists_retries_when_record_vanishes_before_status_check(
+    monkeypatch,
+):
+    import blaxel.core.sandbox.sync.sandbox as sync_sandbox
+
+    monkeypatch.setattr(sync_sandbox, "TRANSIENT_STATUS_POLL_SECONDS", 0.001)
+    replacement = sandbox_instance("vanished", cls=SyncSandboxInstance)
+
+    with (
+        patch.object(SyncSandboxInstance, "create") as mock_create,
+        patch.object(SyncSandboxInstance, "get") as mock_get,
+    ):
+        mock_create.side_effect = [conflict_error(), replacement]
+        mock_get.side_effect = SandboxAPIError("Sandbox not found", status_code=404)
+
+        result = SyncSandboxInstance.create_if_not_exists({"name": "vanished"})
+
+        assert result is replacement
+        assert mock_create.call_count == 2
+
+
+def test_sync_create_if_not_exists_propagates_non_404_status_check_errors():
+    with (
+        patch.object(SyncSandboxInstance, "create") as mock_create,
+        patch.object(SyncSandboxInstance, "get") as mock_get,
+    ):
+        mock_create.side_effect = [conflict_error()]
+        mock_get.side_effect = SandboxAPIError("internal error", status_code=500)
+
+        with pytest.raises(SandboxAPIError, match="internal error"):
+            SyncSandboxInstance.create_if_not_exists({"name": "broken"})
+
+
+def test_sync_create_if_not_exists_gives_up_when_record_stays_dying(monkeypatch):
+    import blaxel.core.sandbox.sync.sandbox as sync_sandbox
+
+    monkeypatch.setattr(sync_sandbox, "TRANSIENT_STATUS_POLL_SECONDS", 0.001)
+    monkeypatch.setattr(sync_sandbox, "TRANSIENT_STATUS_MAX_WAIT_SECONDS", 0.01)
+
+    with (
+        patch.object(SyncSandboxInstance, "create") as mock_create,
+        patch.object(SyncSandboxInstance, "get") as mock_get,
+    ):
+        mock_create.side_effect = conflict_error()
+        mock_get.return_value = sandbox_instance("stuck", "DELETING", cls=SyncSandboxInstance)
+
+        with pytest.raises(RuntimeError, match="Last conflicting status: DELETING"):
+            SyncSandboxInstance.create_if_not_exists({"name": "stuck"})
+
+        assert mock_create.call_count == 3
 
 
 def test_sync_create_if_not_exists_stops_after_bounded_attempts():


### PR DESCRIPTION
- create_if_not_exists (async and sync) no longer fails when called right after deleting a sandbox with the same name. Transient records (DELETING / TERMINATING / DEACTIVATING) are now polled (0.5s, 30s bound) until the deletion settles before the next create attempt, and a record that vanishes between the create conflict and the status check retries instead of raising "Sandbox not found" (both failure modes reproduced live).
- Before: delete-then-recreate failed deterministically on the published SDK (0/3 live rounds); after: 100% success against the live platform. The failure error now reports the last conflicting status.
- Trade-off: a record permanently stuck in a dying state now takes up to ~61s to fail (two bounded waits) instead of failing instantly with the wrong error.

Same fix on the TypeScript side: blaxel-ai/sdk-typescript#333

ENG-2967

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds retry-with-backoff logic to `create_if_not_exists` (async and sync) so it survives the transient window after a sandbox deletion. When a sandbox is in DELETING/TERMINATING/DEACTIVATING state, the method now polls until the record settles rather than burning retry attempts. Also handles the 404 race where a record vanishes between conflict and status check.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 659379ecb1f16714875cc9cbd407defb40a40d99.</sup>
<!-- /MENDRAL_SUMMARY -->