### PR TITLE
Harden sandbox reads during resume

### DIFF
--- a/src/blaxel/core/sandbox/default/drive.py
+++ b/src/blaxel/core/sandbox/default/drive.py
@@ -4,7 +4,7 @@ from ...common.settings import settings
 from ..client.api.drive.delete_drives_mount_mount_path import (
     asyncio as delete_drives_mount,
 )
-from ..client.api.drive.get_drives_mount import asyncio as get_drives_mount
+from ..client.api.drive.get_drives_mount import asyncio_detailed as get_drives_mount
 from ..client.api.drive.post_drives_mount import asyncio as post_drives_mount
 from ..client.client import Client
 from ..client.models import (
@@ -14,7 +14,7 @@ from ..client.models import (
     DriveUnmountResponse,
     ErrorResponse,
 )
-from ..transient_retry import retry_on_transient_reset_async
+from ..transient_retry import retry_on_transient_sandbox_read_async
 from ..types import SandboxConfiguration
 from .action import SandboxAction
 
@@ -102,18 +102,19 @@ class SandboxDrive(SandboxAction):
             List of DriveMountInfo for each mounted drive
         """
 
-        async def list_once() -> List[DriveMountInfo]:
+        async def list_once():
             client = Client(
                 base_url=self.url,
                 headers={**settings.headers, **self.sandbox_config.headers},
             )
 
             async with client:
-                response = await get_drives_mount(client=client)
-                if response is None:
-                    raise Exception("Failed to list drives")
-                if isinstance(response, ErrorResponse):
-                    raise Exception(f"List drives failed: {response.error}")
-                return list(response.mounts) if response.mounts else []
+                return await get_drives_mount(client=client)
 
-        return await retry_on_transient_reset_async(list_once)
+        api_response = await retry_on_transient_sandbox_read_async(list_once)
+        response = api_response.parsed
+        if response is None:
+            raise Exception("Failed to list drives")
+        if isinstance(response, ErrorResponse):
+            raise Exception(f"List drives failed: {response.error}")
+        return list(response.mounts) if response.mounts else []

--- a/src/blaxel/core/sandbox/default/drive.py
+++ b/src/blaxel/core/sandbox/default/drive.py
@@ -106,6 +106,7 @@ class SandboxDrive(SandboxAction):
             client = Client(
                 base_url=self.url,
                 headers={**settings.headers, **self.sandbox_config.headers},
+                raise_on_unexpected_status=False,
             )
 
             async with client:

--- a/src/blaxel/core/sandbox/default/network.py
+++ b/src/blaxel/core/sandbox/default/network.py
@@ -1,7 +1,10 @@
 import httpx
 
+from ..transient_retry import retry_on_transient_sandbox_read_async
 from ..types import SandboxConfiguration
 from .action import SandboxAction
+
+IDEMPOTENT_READ_METHODS = {"GET", "HEAD", "OPTIONS"}
 
 
 class SandboxNetwork(SandboxAction):
@@ -24,4 +27,7 @@ class SandboxNetwork(SandboxAction):
         normalized_path = path if path.startswith("/") else f"/{path}"
         url = f"/port/{port}{normalized_path}"
         client = self.get_client()
-        return await client.request(method, url, **kwargs)
+        fetch_once = lambda: client.request(method, url, **kwargs)
+        if method.upper() in IDEMPOTENT_READ_METHODS:
+            return await retry_on_transient_sandbox_read_async(fetch_once)
+        return await fetch_once()

--- a/src/blaxel/core/sandbox/default/system.py
+++ b/src/blaxel/core/sandbox/default/system.py
@@ -1,8 +1,9 @@
 from ...common.settings import settings
-from ..client.api.system.get_health import asyncio as get_health
+from ..client.api.system.get_health import asyncio_detailed as get_health
 from ..client.api.system.post_upgrade import asyncio as post_upgrade
 from ..client.client import Client
 from ..client.models import ErrorResponse, HealthResponse, SuccessResponse, UpgradeRequest
+from ..transient_retry import retry_on_transient_sandbox_read_async
 from ..types import SandboxConfiguration
 from .action import SandboxAction
 
@@ -57,13 +58,16 @@ class SandboxSystem(SandboxAction):
         Returns:
             HealthResponse with system status information
         """
-        client = Client(
-            base_url=self.url,
-            headers={**settings.headers, **self.sandbox_config.headers},
-        )
+        async def health_once():
+            client = Client(
+                base_url=self.url,
+                headers={**settings.headers, **self.sandbox_config.headers},
+            )
 
-        async with client:
-            response = await get_health(client=client)
-            if response is None:
-                raise Exception("Failed to get health status")
-            return response
+            async with client:
+                return await get_health(client=client)
+
+        api_response = await retry_on_transient_sandbox_read_async(health_once)
+        if api_response.parsed is None:
+            raise Exception("Failed to get health status")
+        return api_response.parsed

--- a/src/blaxel/core/sandbox/default/system.py
+++ b/src/blaxel/core/sandbox/default/system.py
@@ -58,10 +58,12 @@ class SandboxSystem(SandboxAction):
         Returns:
             HealthResponse with system status information
         """
+
         async def health_once():
             client = Client(
                 base_url=self.url,
                 headers={**settings.headers, **self.sandbox_config.headers},
+                raise_on_unexpected_status=False,
             )
 
             async with client:

--- a/src/blaxel/core/sandbox/sync/drive.py
+++ b/src/blaxel/core/sandbox/sync/drive.py
@@ -4,7 +4,7 @@ from ...common.settings import settings
 from ..client.api.drive.delete_drives_mount_mount_path import (
     sync as delete_drives_mount,
 )
-from ..client.api.drive.get_drives_mount import sync as get_drives_mount
+from ..client.api.drive.get_drives_mount import sync_detailed as get_drives_mount
 from ..client.api.drive.post_drives_mount import sync as post_drives_mount
 from ..client.client import Client
 from ..client.models import (
@@ -14,7 +14,7 @@ from ..client.models import (
     DriveUnmountResponse,
     ErrorResponse,
 )
-from ..transient_retry import retry_on_transient_reset
+from ..transient_retry import retry_on_transient_sandbox_read
 from ..types import SandboxConfiguration
 from .action import SyncSandboxAction
 
@@ -102,18 +102,19 @@ class SyncSandboxDrive(SyncSandboxAction):
             List of DriveMountInfo for each mounted drive
         """
 
-        def list_once() -> List[DriveMountInfo]:
+        def list_once():
             client = Client(
                 base_url=self.url,
                 headers={**settings.headers, **self.sandbox_config.headers},
             )
 
             with client:
-                response = get_drives_mount(client=client)
-                if response is None:
-                    raise Exception("Failed to list drives")
-                if isinstance(response, ErrorResponse):
-                    raise Exception(f"List drives failed: {response.error}")
-                return list(response.mounts) if response.mounts else []
+                return get_drives_mount(client=client)
 
-        return retry_on_transient_reset(list_once)
+        api_response = retry_on_transient_sandbox_read(list_once)
+        response = api_response.parsed
+        if response is None:
+            raise Exception("Failed to list drives")
+        if isinstance(response, ErrorResponse):
+            raise Exception(f"List drives failed: {response.error}")
+        return list(response.mounts) if response.mounts else []

--- a/src/blaxel/core/sandbox/sync/drive.py
+++ b/src/blaxel/core/sandbox/sync/drive.py
@@ -106,6 +106,7 @@ class SyncSandboxDrive(SyncSandboxAction):
             client = Client(
                 base_url=self.url,
                 headers={**settings.headers, **self.sandbox_config.headers},
+                raise_on_unexpected_status=False,
             )
 
             with client:

--- a/src/blaxel/core/sandbox/sync/network.py
+++ b/src/blaxel/core/sandbox/sync/network.py
@@ -1,7 +1,10 @@
 import httpx
 
+from ..transient_retry import retry_on_transient_sandbox_read
 from ..types import SandboxConfiguration
 from .action import SyncSandboxAction
+
+IDEMPOTENT_READ_METHODS = {"GET", "HEAD", "OPTIONS"}
 
 
 class SyncSandboxNetwork(SyncSandboxAction):
@@ -22,4 +25,7 @@ class SyncSandboxNetwork(SyncSandboxAction):
         normalized_path = path if path.startswith("/") else f"/{path}"
         url = f"/port/{port}{normalized_path}"
         with self.get_client() as client:
-            return client.request(method, url, **kwargs)
+            fetch_once = lambda: client.request(method, url, **kwargs)
+            if method.upper() in IDEMPOTENT_READ_METHODS:
+                return retry_on_transient_sandbox_read(fetch_once)
+            return fetch_once()

--- a/src/blaxel/core/sandbox/sync/system.py
+++ b/src/blaxel/core/sandbox/sync/system.py
@@ -1,8 +1,9 @@
 from ...common.settings import settings
-from ..client.api.system.get_health import sync as get_health
+from ..client.api.system.get_health import sync_detailed as get_health
 from ..client.api.system.post_upgrade import sync as post_upgrade
 from ..client.client import Client
 from ..client.models import ErrorResponse, HealthResponse, SuccessResponse, UpgradeRequest
+from ..transient_retry import retry_on_transient_sandbox_read
 from ..types import SandboxConfiguration
 from .action import SyncSandboxAction
 
@@ -57,13 +58,16 @@ class SyncSandboxSystem(SyncSandboxAction):
         Returns:
             HealthResponse with system status information
         """
-        client = Client(
-            base_url=self.url,
-            headers={**settings.headers, **self.sandbox_config.headers},
-        )
+        def health_once():
+            client = Client(
+                base_url=self.url,
+                headers={**settings.headers, **self.sandbox_config.headers},
+            )
 
-        with client:
-            response = get_health(client=client)
-            if response is None:
-                raise Exception("Failed to get health status")
-            return response
+            with client:
+                return get_health(client=client)
+
+        api_response = retry_on_transient_sandbox_read(health_once)
+        if api_response.parsed is None:
+            raise Exception("Failed to get health status")
+        return api_response.parsed

--- a/src/blaxel/core/sandbox/sync/system.py
+++ b/src/blaxel/core/sandbox/sync/system.py
@@ -58,10 +58,12 @@ class SyncSandboxSystem(SyncSandboxAction):
         Returns:
             HealthResponse with system status information
         """
+
         def health_once():
             client = Client(
                 base_url=self.url,
                 headers={**settings.headers, **self.sandbox_config.headers},
+                raise_on_unexpected_status=False,
             )
 
             with client:

--- a/src/blaxel/core/sandbox/transient_retry.py
+++ b/src/blaxel/core/sandbox/transient_retry.py
@@ -2,6 +2,7 @@ import asyncio
 import random
 import time
 from collections.abc import Awaitable, Callable, Iterator
+from http import HTTPStatus
 from typing import TypeVar
 
 import httpx
@@ -33,6 +34,13 @@ TRANSIENT_ERROR_CODES = {
 
 DEFAULT_BASE_DELAY_SECONDS = 0.2
 DEFAULT_MAX_DELAY_SECONDS = 2.0
+TRANSIENT_SANDBOX_READ_STATUSES = {
+    425,
+    429,
+    502,
+    503,
+    504,
+}
 
 
 def _walk_error_chain(error: BaseException) -> Iterator[BaseException]:
@@ -87,6 +95,22 @@ def is_transient_reset_error(error: BaseException) -> bool:
     return any(marker in message for message in messages for marker in TRANSIENT_RESET_MARKERS)
 
 
+def _coerce_status_code(status: object) -> int | None:
+    if isinstance(status, HTTPStatus):
+        return int(status.value)
+    if isinstance(status, int):
+        return status
+    return None
+
+
+def is_transient_sandbox_read_response(response: object) -> bool:
+    """True for gateway responses that can happen while a sandbox resumes."""
+    status_code = _coerce_status_code(getattr(response, "status_code", None))
+    if status_code is None:
+        return False
+    return status_code in TRANSIENT_SANDBOX_READ_STATUSES
+
+
 def _backoff_delay_seconds(
     attempt: int,
     base_delay_seconds: float,
@@ -120,6 +144,34 @@ async def retry_on_transient_reset_async(
                 await asyncio.sleep(delay)
 
 
+async def retry_on_transient_sandbox_read_async(
+    fn: Callable[[], Awaitable[T]],
+    *,
+    retries: int | None = None,
+    base_delay_seconds: float = DEFAULT_BASE_DELAY_SECONDS,
+    max_delay_seconds: float = DEFAULT_MAX_DELAY_SECONDS,
+) -> T:
+    retry_budget = settings.sandbox_read_retries if retries is None else retries
+    attempt = 0
+    while True:
+        try:
+            result = await fn()
+        except Exception as error:
+            attempt += 1
+            if retry_budget <= 0 or attempt > retry_budget or not is_transient_reset_error(error):
+                raise
+        else:
+            if not is_transient_sandbox_read_response(result):
+                return result
+            attempt += 1
+            if retry_budget <= 0 or attempt > retry_budget:
+                return result
+
+        delay = _backoff_delay_seconds(attempt, base_delay_seconds, max_delay_seconds)
+        if delay:
+            await asyncio.sleep(delay)
+
+
 def retry_on_transient_reset(
     fn: Callable[[], T],
     *,
@@ -139,3 +191,31 @@ def retry_on_transient_reset(
             delay = _backoff_delay_seconds(attempt, base_delay_seconds, max_delay_seconds)
             if delay:
                 time.sleep(delay)
+
+
+def retry_on_transient_sandbox_read(
+    fn: Callable[[], T],
+    *,
+    retries: int | None = None,
+    base_delay_seconds: float = DEFAULT_BASE_DELAY_SECONDS,
+    max_delay_seconds: float = DEFAULT_MAX_DELAY_SECONDS,
+) -> T:
+    retry_budget = settings.sandbox_read_retries if retries is None else retries
+    attempt = 0
+    while True:
+        try:
+            result = fn()
+        except Exception as error:
+            attempt += 1
+            if retry_budget <= 0 or attempt > retry_budget or not is_transient_reset_error(error):
+                raise
+        else:
+            if not is_transient_sandbox_read_response(result):
+                return result
+            attempt += 1
+            if retry_budget <= 0 or attempt > retry_budget:
+                return result
+
+        delay = _backoff_delay_seconds(attempt, base_delay_seconds, max_delay_seconds)
+        if delay:
+            time.sleep(delay)

--- a/tests/core/test_sandbox_transient_retry.py
+++ b/tests/core/test_sandbox_transient_retry.py
@@ -1,17 +1,24 @@
 import asyncio
+from http import HTTPStatus
 from typing import Any, cast
 
 import httpx
 import pytest
 
 from blaxel.core.common.settings import settings
+from blaxel.core.sandbox.client.types import Response
 from blaxel.core.sandbox.default.filesystem import SandboxFileSystem
+from blaxel.core.sandbox.default.network import SandboxNetwork
 from blaxel.core.sandbox.default.process import SandboxProcess
 from blaxel.core.sandbox.sync.filesystem import SyncSandboxFileSystem
+from blaxel.core.sandbox.sync.network import SyncSandboxNetwork
 from blaxel.core.sandbox.transient_retry import (
     is_transient_reset_error,
+    is_transient_sandbox_read_response,
     retry_on_transient_reset,
     retry_on_transient_reset_async,
+    retry_on_transient_sandbox_read,
+    retry_on_transient_sandbox_read_async,
 )
 from blaxel.core.sandbox.types import ResponseError
 
@@ -65,6 +72,13 @@ class AsyncSequenceClient:
             raise result
         return result
 
+    async def request(self, *args, **kwargs):
+        self.calls += 1
+        result = self.results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
 
 class SyncSequenceClient:
     def __init__(self, *results):
@@ -84,11 +98,25 @@ class SyncSequenceClient:
             raise result
         return result
 
+    def request(self, *args, **kwargs):
+        self.calls += 1
+        result = self.results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
 
 def ok_json_response(data):
     return httpx.Response(
         200,
         json=data,
+        request=httpx.Request("GET", "https://sandbox.test"),
+    )
+
+
+def status_response(status_code: int) -> httpx.Response:
+    return httpx.Response(
+        status_code,
         request=httpx.Request("GET", "https://sandbox.test"),
     )
 
@@ -158,6 +186,19 @@ def test_classifier_rejects_application_responses():
     assert not is_transient_reset_error(app_error_response())
 
 
+def test_read_response_classifier_accepts_resume_gateway_statuses():
+    assert is_transient_sandbox_read_response(status_response(502))
+    assert is_transient_sandbox_read_response(status_response(503))
+    assert is_transient_sandbox_read_response(
+        Response(status_code=HTTPStatus.SERVICE_UNAVAILABLE, content=b"", headers={}, parsed=None)
+    )
+
+
+def test_read_response_classifier_rejects_application_statuses():
+    assert not is_transient_sandbox_read_response(status_response(500))
+    assert not is_transient_sandbox_read_response(status_response(404))
+
+
 @pytest.mark.asyncio
 async def test_real_httpx_transport_drop_is_classified_transient():
     async with LoopbackFaultServer(close_without_response) as server:
@@ -211,6 +252,23 @@ async def test_async_retry_recovers_once():
     assert calls == 2
 
 
+@pytest.mark.asyncio
+async def test_async_sandbox_read_retry_recovers_from_resume_status():
+    calls = 0
+
+    async def flaky_gateway():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return status_response(503)
+        return status_response(200)
+
+    response = await retry_on_transient_sandbox_read_async(flaky_gateway, retries=1)
+
+    assert response.status_code == 200
+    assert calls == 2
+
+
 def test_sync_retry_recovers_once():
     calls = 0
 
@@ -222,6 +280,22 @@ def test_sync_retry_recovers_once():
         return "ok"
 
     assert retry_on_transient_reset(flaky, retries=1) == "ok"
+    assert calls == 2
+
+
+def test_sync_sandbox_read_retry_recovers_from_resume_status():
+    calls = 0
+
+    def flaky_gateway():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return status_response(502)
+        return status_response(200)
+
+    response = retry_on_transient_sandbox_read(flaky_gateway, retries=1)
+
+    assert response.status_code == 200
     assert calls == 2
 
 
@@ -252,6 +326,32 @@ async def test_async_filesystem_read_retries_transport_reset(monkeypatch):
     assert client.calls == 2
 
 
+@pytest.mark.asyncio
+async def test_async_network_fetch_retries_resume_gateway_status(monkeypatch):
+    monkeypatch.setenv("BL_SANDBOX_READ_RETRIES", "1")
+    client = AsyncSequenceClient(status_response(503), status_response(200))
+    network = cast(Any, object.__new__(SandboxNetwork))
+    network.get_client = lambda: client
+
+    response = await network.fetch(8080, "/health")
+
+    assert response.status_code == 200
+    assert client.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_async_network_fetch_does_not_retry_post_status(monkeypatch):
+    monkeypatch.setenv("BL_SANDBOX_READ_RETRIES", "1")
+    client = AsyncSequenceClient(status_response(503), status_response(200))
+    network = cast(Any, object.__new__(SandboxNetwork))
+    network.get_client = lambda: client
+
+    response = await network.fetch(8080, "/mutate", method="POST")
+
+    assert response.status_code == 503
+    assert client.calls == 1
+
+
 def test_sync_filesystem_read_retries_transport_reset(monkeypatch):
     monkeypatch.setenv("BL_SANDBOX_READ_RETRIES", "1")
     client = SyncSequenceClient(
@@ -262,6 +362,18 @@ def test_sync_filesystem_read_retries_transport_reset(monkeypatch):
     filesystem.get_client = lambda: client
 
     assert filesystem.read("/file.txt") == "hello"
+    assert client.calls == 2
+
+
+def test_sync_network_fetch_retries_resume_gateway_status(monkeypatch):
+    monkeypatch.setenv("BL_SANDBOX_READ_RETRIES", "1")
+    client = SyncSequenceClient(status_response(502), status_response(200))
+    network = cast(Any, object.__new__(SyncSandboxNetwork))
+    network.get_client = lambda: client
+
+    response = network.fetch(8080, "/health")
+
+    assert response.status_code == 200
     assert client.calls == 2
 
 

--- a/tests/core/test_sandbox_transient_retry.py
+++ b/tests/core/test_sandbox_transient_retry.py
@@ -1,5 +1,6 @@
 import asyncio
 from http import HTTPStatus
+from types import SimpleNamespace
 from typing import Any, cast
 
 import httpx
@@ -7,11 +8,15 @@ import pytest
 
 from blaxel.core.common.settings import settings
 from blaxel.core.sandbox.client.types import Response
+from blaxel.core.sandbox.default.drive import SandboxDrive
 from blaxel.core.sandbox.default.filesystem import SandboxFileSystem
 from blaxel.core.sandbox.default.network import SandboxNetwork
 from blaxel.core.sandbox.default.process import SandboxProcess
+from blaxel.core.sandbox.default.system import SandboxSystem
+from blaxel.core.sandbox.sync.drive import SyncSandboxDrive
 from blaxel.core.sandbox.sync.filesystem import SyncSandboxFileSystem
 from blaxel.core.sandbox.sync.network import SyncSandboxNetwork
+from blaxel.core.sandbox.sync.system import SyncSandboxSystem
 from blaxel.core.sandbox.transient_retry import (
     is_transient_reset_error,
     is_transient_sandbox_read_response,
@@ -337,6 +342,173 @@ async def test_async_network_fetch_retries_resume_gateway_status(monkeypatch):
 
     assert response.status_code == 200
     assert client.calls == 2
+
+
+class GeneratedClientContext:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_async_drive_list_exposes_transient_response_to_retry(monkeypatch):
+    from blaxel.core.sandbox.default import drive as drive_module
+
+    clients = []
+    responses = [
+        Response(status_code=503, content=b"", headers={}, parsed=None),
+        Response(
+            status_code=200,
+            content=b"",
+            headers={},
+            parsed=SimpleNamespace(mounts=[]),
+        ),
+    ]
+
+    def make_client(**kwargs):
+        client = GeneratedClientContext(**kwargs)
+        clients.append(client)
+        return client
+
+    async def get_drives_mount(**kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(drive_module, "Client", make_client)
+    monkeypatch.setattr(drive_module, "get_drives_mount", get_drives_mount)
+    monkeypatch.setattr(drive_module, "settings", SimpleNamespace(headers={}))
+    monkeypatch.setenv("BL_SANDBOX_READ_RETRIES", "1")
+
+    drive = cast(Any, object.__new__(SandboxDrive))
+    drive.sandbox_config = SimpleNamespace(
+        force_url="https://sandbox.test",
+        headers={},
+        metadata=None,
+    )
+
+    assert await drive.list() == []
+    assert len(clients) == 2
+    assert all(client.kwargs["raise_on_unexpected_status"] is False for client in clients)
+
+
+def test_sync_drive_list_exposes_transient_response_to_retry(monkeypatch):
+    from blaxel.core.sandbox.sync import drive as drive_module
+
+    clients = []
+    responses = [
+        Response(status_code=502, content=b"", headers={}, parsed=None),
+        Response(
+            status_code=200,
+            content=b"",
+            headers={},
+            parsed=SimpleNamespace(mounts=[]),
+        ),
+    ]
+
+    def make_client(**kwargs):
+        client = GeneratedClientContext(**kwargs)
+        clients.append(client)
+        return client
+
+    def get_drives_mount(**kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(drive_module, "Client", make_client)
+    monkeypatch.setattr(drive_module, "get_drives_mount", get_drives_mount)
+    monkeypatch.setattr(drive_module, "settings", SimpleNamespace(headers={}))
+    monkeypatch.setenv("BL_SANDBOX_READ_RETRIES", "1")
+
+    drive = cast(Any, object.__new__(SyncSandboxDrive))
+    drive.sandbox_config = SimpleNamespace(
+        force_url="https://sandbox.test",
+        headers={},
+        metadata=None,
+    )
+
+    assert drive.list() == []
+    assert len(clients) == 2
+    assert all(client.kwargs["raise_on_unexpected_status"] is False for client in clients)
+
+
+@pytest.mark.asyncio
+async def test_async_health_exposes_transient_response_to_retry(monkeypatch):
+    from blaxel.core.sandbox.default import system as system_module
+
+    clients = []
+    expected = object()
+    responses = [
+        Response(status_code=504, content=b"", headers={}, parsed=None),
+        Response(status_code=200, content=b"", headers={}, parsed=expected),
+    ]
+
+    def make_client(**kwargs):
+        client = GeneratedClientContext(**kwargs)
+        clients.append(client)
+        return client
+
+    async def get_health(**kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(system_module, "Client", make_client)
+    monkeypatch.setattr(system_module, "get_health", get_health)
+    monkeypatch.setattr(system_module, "settings", SimpleNamespace(headers={}))
+    monkeypatch.setenv("BL_SANDBOX_READ_RETRIES", "1")
+
+    system = cast(Any, object.__new__(SandboxSystem))
+    system.sandbox_config = SimpleNamespace(
+        force_url="https://sandbox.test",
+        headers={},
+        metadata=None,
+    )
+
+    assert await system.health() is expected
+    assert len(clients) == 2
+    assert all(client.kwargs["raise_on_unexpected_status"] is False for client in clients)
+
+
+def test_sync_health_exposes_transient_response_to_retry(monkeypatch):
+    from blaxel.core.sandbox.sync import system as system_module
+
+    clients = []
+    expected = object()
+    responses = [
+        Response(status_code=429, content=b"", headers={}, parsed=None),
+        Response(status_code=200, content=b"", headers={}, parsed=expected),
+    ]
+
+    def make_client(**kwargs):
+        client = GeneratedClientContext(**kwargs)
+        clients.append(client)
+        return client
+
+    def get_health(**kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(system_module, "Client", make_client)
+    monkeypatch.setattr(system_module, "get_health", get_health)
+    monkeypatch.setattr(system_module, "settings", SimpleNamespace(headers={}))
+    monkeypatch.setenv("BL_SANDBOX_READ_RETRIES", "1")
+
+    system = cast(Any, object.__new__(SyncSandboxSystem))
+    system.sandbox_config = SimpleNamespace(
+        force_url="https://sandbox.test",
+        headers={},
+        metadata=None,
+    )
+
+    assert system.health() is expected
+    assert len(clients) == 2
+    assert all(client.kwargs["raise_on_unexpected_status"] is False for client in clients)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes ENG-2972

## Summary

Fixes #142.

This makes idempotent sandbox reads survive the short gateway window that can happen while a standby sandbox resumes. The existing retry helper already covered transport resets. This extends the same bounded policy to transient gateway responses.

Covered paths:

- `sandbox.fetch()` for GET, HEAD, and OPTIONS
- sync `sandbox.fetch()` for the same read methods
- async and sync drive `list()`
- async and sync system `health()`

Mutating calls such as POST fetches, drive mount, drive unmount, and system upgrade are left unchanged so the SDK does not replay side effects.

## Notes

The retry classifier is intentionally narrow. It only treats 425, 429, 502, 503, and 504 as retryable sandbox read responses. Other HTTP responses still return or fail as before.

## Tests

- `uv run --group test pytest tests/core/test_sandbox_transient_retry.py -q`
- `uv run --group test pytest tests/core/test_sandbox_transient_retry.py tests/core/test_sandbox.py tests/core/test_sandbox_network.py -q`
- `uv run --group dev ruff check src/blaxel/core/sandbox/transient_retry.py src/blaxel/core/sandbox/default/network.py src/blaxel/core/sandbox/sync/network.py src/blaxel/core/sandbox/default/drive.py src/blaxel/core/sandbox/sync/drive.py src/blaxel/core/sandbox/default/system.py src/blaxel/core/sandbox/sync/system.py tests/core/test_sandbox_transient_retry.py`
- `uv run python -m compileall -q src/blaxel/core/sandbox tests/core/test_sandbox_transient_retry.py`
- `git diff --check`

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Follow-up fix that adds `raise_on_unexpected_status=False` to generated client instantiation in drive and system modules (async+sync), and switches to `_detailed` API variants so transient HTTP responses (502/503/504 etc.) are exposed to the retry logic instead of being swallowed by `UnexpectedStatus` exceptions.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 458b6787e0da6384bc2d03fe912f13b951dd5399.</sup>
<!-- /MENDRAL_SUMMARY -->
