### PR TITLE
feat(sandbox): paginate schedules and schedule executions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ async for sandbox in page.auto_paging_iter():
     print(sandbox.metadata.name)
 ```
 
-The same shape is used by `DriveInstance.list()`, `VolumeInstance.list()`, and job execution listing. Sync APIs expose the same fields, with a synchronous `next_page()`:
+The same shape is used by `DriveInstance.list()`, `VolumeInstance.list()`, job execution listing, and the sandbox-scoped `sandbox.schedules.list()` / `sandbox.schedules.executions()`. Sync APIs expose the same fields, with a synchronous `next_page()`:
 
 ```python
 from blaxel.core import SyncDriveInstance

--- a/src/blaxel/core/sandbox/default/schedule.py
+++ b/src/blaxel/core/sandbox/default/schedule.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Union
 
 from ...client import errors
 from ...client.api.compute.create_sandbox_schedule import (
@@ -26,7 +26,11 @@ from ...client.models import (
     SandboxScheduleEntry,
     SandboxScheduleExecution,
 )
-from ...client.types import Unset
+from ...client.pagination import (
+    AsyncPaginatedList,
+    make_async_paginated_list,
+    normalize_cursor,
+)
 
 
 # A schedule entry is a flat record (id/type/value/input) with no sub-resource
@@ -52,20 +56,36 @@ class SandboxSchedules:
         type_: str | None = None,
         limit: int | None = None,
         cursor: str | None = None,
-    ) -> List[SandboxScheduleEntry]:
-        kwargs: Dict[str, Any] = {}
+    ) -> AsyncPaginatedList[SandboxScheduleEntry]:
+        """List one page of the sandbox's schedules.
+
+        Returns an ``AsyncPaginatedList`` exposing ``.data``, ``.meta``,
+        ``.has_more``, ``.next_cursor``, ``.next_page()`` and
+        ``.auto_paging_iter()``. Filters (``q``, ``type_``, ``limit``) are kept
+        when advancing to the next page.
+        """
+        filters: Dict[str, Any] = {}
         if q is not None:
-            kwargs["q"] = q
+            filters["q"] = q
         if type_ is not None:
-            kwargs["type_"] = ListSandboxSchedulesType(type_)
+            filters["type_"] = ListSandboxSchedulesType(type_)
         if limit is not None:
-            kwargs["limit"] = limit
-        if cursor is not None:
-            kwargs["cursor"] = cursor
-        response = await list_sandbox_schedules(self.sandbox_name, client=client, **kwargs)
-        if response is None:
-            raise errors.UnexpectedStatus(400, b"Failed to list schedules")
-        return [] if isinstance(response.data, Unset) else (response.data or [])
+            filters["limit"] = limit
+
+        async def fetch_page(page_cursor: str | None):
+            response = await list_sandbox_schedules(
+                self.sandbox_name,
+                client=client,
+                cursor=normalize_cursor(page_cursor),
+                **filters,
+            )
+            if response is None:
+                raise errors.UnexpectedStatus(400, b"Failed to list schedules")
+            return make_async_paginated_list(
+                response, mapper=lambda item: item, fetch_next=fetch_page
+            )
+
+        return await fetch_page(cursor)
 
     async def create(
         self, schedule: Union[SandboxScheduleEntry, Dict[str, Any]]
@@ -107,17 +127,31 @@ class SandboxSchedules:
         q: str | None = None,
         limit: int | None = None,
         cursor: str | None = None,
-    ) -> List[SandboxScheduleExecution]:
-        kwargs: Dict[str, Any] = {}
+    ) -> AsyncPaginatedList[SandboxScheduleExecution]:
+        """List one page of schedule executions, newest first.
+
+        Returns an ``AsyncPaginatedList`` exposing ``.data``, ``.meta``,
+        ``.has_more``, ``.next_cursor``, ``.next_page()`` and
+        ``.auto_paging_iter()``. Executions are sandbox-scoped across all
+        schedules; filter by ``schedule_id`` on the records to isolate one.
+        """
+        filters: Dict[str, Any] = {}
         if q is not None:
-            kwargs["q"] = q
+            filters["q"] = q
         if limit is not None:
-            kwargs["limit"] = limit
-        if cursor is not None:
-            kwargs["cursor"] = cursor
-        response = await list_sandbox_schedule_executions(
-            self.sandbox_name, client=client, **kwargs
-        )
-        if response is None:
-            raise errors.UnexpectedStatus(400, b"Failed to list schedule executions")
-        return [] if isinstance(response.data, Unset) else (response.data or [])
+            filters["limit"] = limit
+
+        async def fetch_page(page_cursor: str | None):
+            response = await list_sandbox_schedule_executions(
+                self.sandbox_name,
+                client=client,
+                cursor=normalize_cursor(page_cursor),
+                **filters,
+            )
+            if response is None:
+                raise errors.UnexpectedStatus(400, b"Failed to list schedule executions")
+            return make_async_paginated_list(
+                response, mapper=lambda item: item, fetch_next=fetch_page
+            )
+
+        return await fetch_page(cursor)

--- a/src/blaxel/core/sandbox/sync/schedule.py
+++ b/src/blaxel/core/sandbox/sync/schedule.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Union
 
 from ...client import errors
 from ...client.api.compute.create_sandbox_schedule import sync as create_sandbox_schedule
@@ -16,7 +16,11 @@ from ...client.models import (
     SandboxScheduleEntry,
     SandboxScheduleExecution,
 )
-from ...client.types import Unset
+from ...client.pagination import (
+    PaginatedList,
+    make_paginated_list,
+    normalize_cursor,
+)
 
 
 # A schedule entry is a flat record (id/type/value/input) with no sub-resource
@@ -42,20 +46,36 @@ class SyncSandboxSchedules:
         type_: str | None = None,
         limit: int | None = None,
         cursor: str | None = None,
-    ) -> List[SandboxScheduleEntry]:
-        kwargs: Dict[str, Any] = {}
+    ) -> PaginatedList[SandboxScheduleEntry]:
+        """List one page of the sandbox's schedules.
+
+        Returns a ``PaginatedList`` exposing ``.data``, ``.meta``,
+        ``.has_more``, ``.next_cursor``, ``.next_page()`` and
+        ``.auto_paging_iter()``. Filters (``q``, ``type_``, ``limit``) are kept
+        when advancing to the next page.
+        """
+        filters: Dict[str, Any] = {}
         if q is not None:
-            kwargs["q"] = q
+            filters["q"] = q
         if type_ is not None:
-            kwargs["type_"] = ListSandboxSchedulesType(type_)
+            filters["type_"] = ListSandboxSchedulesType(type_)
         if limit is not None:
-            kwargs["limit"] = limit
-        if cursor is not None:
-            kwargs["cursor"] = cursor
-        response = list_sandbox_schedules(self.sandbox_name, client=client, **kwargs)
-        if response is None:
-            raise errors.UnexpectedStatus(400, b"Failed to list schedules")
-        return [] if isinstance(response.data, Unset) else (response.data or [])
+            filters["limit"] = limit
+
+        def fetch_page(page_cursor: str | None):
+            response = list_sandbox_schedules(
+                self.sandbox_name,
+                client=client,
+                cursor=normalize_cursor(page_cursor),
+                **filters,
+            )
+            if response is None:
+                raise errors.UnexpectedStatus(400, b"Failed to list schedules")
+            return make_paginated_list(
+                response, mapper=lambda item: item, fetch_next=fetch_page
+            )
+
+        return fetch_page(cursor)
 
     def create(self, schedule: Union[SandboxScheduleEntry, Dict[str, Any]]) -> SandboxScheduleEntry:
         if isinstance(schedule, dict):
@@ -95,15 +115,31 @@ class SyncSandboxSchedules:
         q: str | None = None,
         limit: int | None = None,
         cursor: str | None = None,
-    ) -> List[SandboxScheduleExecution]:
-        kwargs: Dict[str, Any] = {}
+    ) -> PaginatedList[SandboxScheduleExecution]:
+        """List one page of schedule executions, newest first.
+
+        Returns a ``PaginatedList`` exposing ``.data``, ``.meta``,
+        ``.has_more``, ``.next_cursor``, ``.next_page()`` and
+        ``.auto_paging_iter()``. Executions are sandbox-scoped across all
+        schedules; filter by ``schedule_id`` on the records to isolate one.
+        """
+        filters: Dict[str, Any] = {}
         if q is not None:
-            kwargs["q"] = q
+            filters["q"] = q
         if limit is not None:
-            kwargs["limit"] = limit
-        if cursor is not None:
-            kwargs["cursor"] = cursor
-        response = list_sandbox_schedule_executions(self.sandbox_name, client=client, **kwargs)
-        if response is None:
-            raise errors.UnexpectedStatus(400, b"Failed to list schedule executions")
-        return [] if isinstance(response.data, Unset) else (response.data or [])
+            filters["limit"] = limit
+
+        def fetch_page(page_cursor: str | None):
+            response = list_sandbox_schedule_executions(
+                self.sandbox_name,
+                client=client,
+                cursor=normalize_cursor(page_cursor),
+                **filters,
+            )
+            if response is None:
+                raise errors.UnexpectedStatus(400, b"Failed to list schedule executions")
+            return make_paginated_list(
+                response, mapper=lambda item: item, fetch_next=fetch_page
+            )
+
+        return fetch_page(cursor)

--- a/tests/core/test_controlplane_pagination.py
+++ b/tests/core/test_controlplane_pagination.py
@@ -310,6 +310,79 @@ def test_job_execution_offset_is_only_sent_on_first_page(monkeypatch):
     assert calls[1]["offset"] == 0
 
 
+@pytest.mark.asyncio
+async def test_sandbox_schedules_list_returns_page_with_next_page(monkeypatch):
+    from blaxel.core.client.models.sandbox_schedule_entry import SandboxScheduleEntry
+    from blaxel.core.client.models.sandbox_schedule_entry_list import (
+        SandboxScheduleEntryList,
+    )
+    from blaxel.core.sandbox.default.schedule import SandboxSchedules
+
+    pages = [
+        SandboxScheduleEntryList(
+            data=[SandboxScheduleEntry(id="schedule-0")],
+            meta=PaginationMeta(has_more=True, next_cursor="cursor-2"),
+        ),
+        SandboxScheduleEntryList(
+            data=[SandboxScheduleEntry(id="schedule-1")],
+            meta=PaginationMeta(has_more=False),
+        ),
+    ]
+    calls = []
+
+    async def fake_list(sandbox_name, *, client, cursor=UNSET, limit=UNSET, **kwargs):
+        calls.append((sandbox_name, cursor, limit))
+        return pages.pop(0)
+
+    monkeypatch.setattr(
+        "blaxel.core.sandbox.default.schedule.list_sandbox_schedules", fake_list
+    )
+
+    schedules = SandboxSchedules(Sandbox(metadata=Metadata(name="sbx"), spec=SandboxSpec()))
+    page = await schedules.list(limit=1)
+    next_page = await page.next_page()
+
+    assert [s.id for s in page.data] == ["schedule-0"]
+    assert page.has_more is True
+    assert page.next_cursor == "cursor-2"
+    assert [s.id for s in next_page.data] == ["schedule-1"]
+    assert next_page.has_more is False
+    assert calls == [("sbx", UNSET, 1), ("sbx", "cursor-2", 1)]
+
+
+def test_sandbox_schedule_executions_auto_paging_iter(monkeypatch):
+    from blaxel.core.client.models.sandbox_schedule_execution import (
+        SandboxScheduleExecution,
+    )
+    from blaxel.core.client.models.sandbox_schedule_execution_list import (
+        SandboxScheduleExecutionList,
+    )
+    from blaxel.core.sandbox.sync.schedule import SyncSandboxSchedules
+
+    pages = [
+        SandboxScheduleExecutionList(
+            data=[SandboxScheduleExecution(id="exec-a")],
+            meta=PaginationMeta(has_more=True, next_cursor="cursor-2"),
+        ),
+        SandboxScheduleExecutionList(
+            data=[SandboxScheduleExecution(id="exec-b")],
+            meta=PaginationMeta(has_more=False),
+        ),
+    ]
+
+    def fake_list(sandbox_name, *, client, cursor=UNSET, limit=UNSET, **kwargs):
+        return pages.pop(0)
+
+    monkeypatch.setattr(
+        "blaxel.core.sandbox.sync.schedule.list_sandbox_schedule_executions", fake_list
+    )
+
+    schedules = SyncSandboxSchedules(Sandbox(metadata=Metadata(name="sbx"), spec=SandboxSpec()))
+    executions = list(schedules.executions(limit=1).auto_paging_iter())
+
+    assert [e.id for e in executions] == ["exec-a", "exec-b"]
+
+
 def test_client_with_headers_merges_existing_headers():
     client = Client(headers={"Blaxel-Version": "2026-04-28"})
 


### PR DESCRIPTION
## What

`sandbox.schedules.list()` and `sandbox.schedules.executions()` now return a paginated page instead of a bare list.

## Why

These were the last sandbox list methods still returning a plain array. They now match the pagination contract already used by `VolumeInstance.list()`, `DriveInstance.list()`, and job execution listing, so large schedule and execution histories can be walked page by page.

## Details

The returned page still behaves like a list for the current page, and adds the standard helpers:

- `.data`, `.meta`, `.has_more`, `.next_cursor`
- `.next_page()`
- `.auto_paging_iter()` to walk every page

Async (`SandboxSchedules`) and sync (`SyncSandboxSchedules`) wrappers both updated. Filters (`q`, `type_`, `limit`) are preserved across pages.

## Tests

Added offline unit tests for the paginated schedule list and execution auto-paging; existing pagination suite stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sdk-python/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Converts `sandbox.schedules.list()` and `sandbox.schedules.executions()` from returning bare lists to returning `(Async)PaginatedList` pages with `.data`, `.meta`, `.has_more`, `.next_cursor`, `.next_page()`, and `.auto_paging_iter()`, matching the existing pagination pattern used by other list endpoints.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 00cf714f061daa53b7a730833a555c0ee679705d.</sup>
<!-- /MENDRAL_SUMMARY -->