### PR TITLE
Send Python SDK user agent on control-plane requests

### DIFF
--- a/src/blaxel/core/common/autoload.py
+++ b/src/blaxel/core/common/autoload.py
@@ -21,11 +21,17 @@ def telemetry() -> None:
 def autoload() -> None:
     client.with_base_url(settings.base_url)
     client.with_auth(settings.auth)
-    # Send the Blaxel-Version header on every control-plane request so list
-    # endpoints return cursor-paginated `{data, meta}` responses (>= 2026-04-28).
-    # Without it the API falls back to legacy bare-array listings and pagination
-    # (limit/cursor/next_page) is silently ignored.
-    client.with_headers({"Blaxel-Version": settings.api_version})
+    # Send SDK-identifying headers on every control-plane request so backend
+    # observability can classify Python SDK traffic and list endpoints return
+    # cursor-paginated `{data, meta}` responses (>= 2026-04-28). Without the
+    # User-Agent httpx falls back to `python-httpx/<version>`, which is tracked
+    # as a generic API request instead of SDK usage.
+    client.with_headers(
+        {
+            "Blaxel-Version": settings.api_version,
+            "User-Agent": settings.headers["User-Agent"],
+        }
+    )
 
     # Register response interceptors for authentication error handling
     # Access the underlying httpx clients and add event hooks

--- a/tests/core/test_environment.py
+++ b/tests/core/test_environment.py
@@ -123,6 +123,19 @@ def test_autoload_functionality():
             raise
 
 
+def test_autoload_sets_control_plane_user_agent():
+    """Control-plane requests should carry the Python SDK User-Agent."""
+    from blaxel.core.client import client
+    from blaxel.core.common.autoload import autoload
+    from blaxel.core.common.settings import settings
+
+    autoload()
+
+    assert client._headers["Blaxel-Version"] == settings.api_version
+    assert client._headers["User-Agent"] == settings.headers["User-Agent"]
+    assert client._headers["User-Agent"].startswith("blaxel/sdk/python/")
+
+
 def test_settings_properties():
     """Test that settings has the expected properties."""
     from blaxel.core.common.settings import settings


### PR DESCRIPTION
## Summary
- Add the Python SDK User-Agent to the generated control-plane client during autoload
- Keep sending Blaxel-Version for paginated control-plane endpoints
- Cover the autoload header behavior in tests

## Why
Sandbox creation through the Python SDK was reaching PostHog as `request_origin=api` with `request_user_agent=python-httpx/...`, so backend observability could not extract `sdk-version` or `sdk-language=python`.

## Tests
- `pytest tests/core/test_environment.py tests/core/test_settings_api_version.py -q`
- `ruff format --check src/blaxel/core/common/autoload.py tests/core/test_environment.py`
- `ruff check src/blaxel/core/common/autoload.py tests/core/test_environment.py`

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds the Python SDK User-Agent header to the generated control-plane client during autoload, alongside the existing Blaxel-Version header. Adds a test verifying both headers are set.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9379bb697991e338c7f59215980d521af454adb4.</sup>
<!-- /MENDRAL_SUMMARY -->