### PR TITLE
feat(core): add external ID filters for root resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 ARGS:= $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+SANDBOX_REF ?= main
+CONTROLPLANE_REF ?= main
 
 # Get git commit hash automatically
 GIT_COMMIT := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
@@ -12,7 +14,7 @@ sdk-sandbox:
 	@curl -H "Authorization: token $$(gh auth token)" \
 		-H "Accept: application/vnd.github.v3.raw" \
 		-o ./definition.yml \
-		https://api.github.com/repos/blaxel-ai/sandbox/contents/sandbox-api/docs/openapi.yml?ref=main
+		https://api.github.com/repos/blaxel-ai/sandbox/contents/sandbox-api/docs/openapi.yml?ref=$(SANDBOX_REF)
 	rm -rf src/blaxel/core/sandbox/client/api src/blaxel/core/sandbox/client/models
 	.venv/bin/openapi-python-client generate \
 		--path=definition.yml \
@@ -30,7 +32,7 @@ sdk-controlplane:
 	@curl -H "Authorization: token $$(gh auth token)" \
 		-H "Accept: application/vnd.github.v3.raw" \
 		-o ./definition.yml \
-		https://api.github.com/repos/blaxel-ai/controlplane/contents/api/api/definitions/controlplane.yml?ref=main
+		https://api.github.com/repos/blaxel-ai/controlplane/contents/api/api/definitions/controlplane.yml?ref=$(CONTROLPLANE_REF)
 	rm -rf src/blaxel/core/client/api src/blaxel/core/client/models
 	.venv/bin/openapi-python-client generate \
 		--path=definition.yml \

--- a/src/blaxel/core/client/api/agents/list_agents.py
+++ b/src/blaxel/core/client/api/agents/list_agents.py
@@ -19,6 +19,7 @@ def _get_kwargs(
     sort: Union[Unset, ListAgentsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListAgentsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -39,6 +40,8 @@ def _get_kwargs(
         json_anchor = anchor.value
 
     params["anchor"] = json_anchor
+
+    params["externalId"] = external_id
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -93,6 +96,7 @@ def sync_detailed(
     sort: Union[Unset, ListAgentsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListAgentsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[AgentList, Error]]:
     """List all agents
 
@@ -107,6 +111,7 @@ def sync_detailed(
         sort (Union[Unset, ListAgentsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListAgentsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -122,6 +127,7 @@ def sync_detailed(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     )
 
     response = client.get_httpx_client().request(
@@ -139,6 +145,7 @@ def sync(
     sort: Union[Unset, ListAgentsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListAgentsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Union[AgentList, Error] | None:
     """List all agents
 
@@ -153,6 +160,7 @@ def sync(
         sort (Union[Unset, ListAgentsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListAgentsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -169,6 +177,7 @@ def sync(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     ).parsed
 
 
@@ -180,6 +189,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListAgentsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListAgentsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[AgentList, Error]]:
     """List all agents
 
@@ -194,6 +204,7 @@ async def asyncio_detailed(
         sort (Union[Unset, ListAgentsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListAgentsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -209,6 +220,7 @@ async def asyncio_detailed(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -224,6 +236,7 @@ async def asyncio(
     sort: Union[Unset, ListAgentsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListAgentsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Union[AgentList, Error] | None:
     """List all agents
 
@@ -238,6 +251,7 @@ async def asyncio(
         sort (Union[Unset, ListAgentsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListAgentsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -255,5 +269,6 @@ async def asyncio(
             sort=sort,
             q=q,
             anchor=anchor,
+            external_id=external_id,
         )
     ).parsed

--- a/src/blaxel/core/client/api/functions/list_functions.py
+++ b/src/blaxel/core/client/api/functions/list_functions.py
@@ -19,6 +19,7 @@ def _get_kwargs(
     sort: Union[Unset, ListFunctionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -39,6 +40,8 @@ def _get_kwargs(
         json_anchor = anchor.value
 
     params["anchor"] = json_anchor
+
+    params["externalId"] = external_id
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -95,6 +98,7 @@ def sync_detailed(
     sort: Union[Unset, ListFunctionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[Error, FunctionList]]:
     """List all MCP servers
 
@@ -109,6 +113,7 @@ def sync_detailed(
         sort (Union[Unset, ListFunctionsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListFunctionsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -124,6 +129,7 @@ def sync_detailed(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     )
 
     response = client.get_httpx_client().request(
@@ -141,6 +147,7 @@ def sync(
     sort: Union[Unset, ListFunctionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Union[Error, FunctionList] | None:
     """List all MCP servers
 
@@ -155,6 +162,7 @@ def sync(
         sort (Union[Unset, ListFunctionsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListFunctionsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -171,6 +179,7 @@ def sync(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     ).parsed
 
 
@@ -182,6 +191,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListFunctionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[Error, FunctionList]]:
     """List all MCP servers
 
@@ -196,6 +206,7 @@ async def asyncio_detailed(
         sort (Union[Unset, ListFunctionsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListFunctionsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -211,6 +222,7 @@ async def asyncio_detailed(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -226,6 +238,7 @@ async def asyncio(
     sort: Union[Unset, ListFunctionsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListFunctionsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Union[Error, FunctionList] | None:
     """List all MCP servers
 
@@ -240,6 +253,7 @@ async def asyncio(
         sort (Union[Unset, ListFunctionsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListFunctionsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -257,5 +271,6 @@ async def asyncio(
             sort=sort,
             q=q,
             anchor=anchor,
+            external_id=external_id,
         )
     ).parsed

--- a/src/blaxel/core/client/api/integrations/list_integration_connections.py
+++ b/src/blaxel/core/client/api/integrations/list_integration_connections.py
@@ -7,13 +7,23 @@ from ... import errors
 from ...client import Client
 from ...models.error import Error
 from ...models.integration_connection import IntegrationConnection
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    external_id: Union[Unset, str] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["externalId"] = external_id
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/integrations/connections",
+        "params": params,
     }
 
     return _kwargs
@@ -63,11 +73,15 @@ def _build_response(
 def sync_detailed(
     *,
     client: Client,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[Error, list["IntegrationConnection"]]]:
     """List integration connections
 
      Returns all configured integration connections in the workspace. Each connection stores credentials
     and settings for an external service (LLM provider, API, database).
+
+    Args:
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -77,7 +91,9 @@ def sync_detailed(
         Response[Union[Error, list['IntegrationConnection']]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        external_id=external_id,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -89,11 +105,15 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Union[Error, list["IntegrationConnection"]] | None:
     """List integration connections
 
      Returns all configured integration connections in the workspace. Each connection stores credentials
     and settings for an external service (LLM provider, API, database).
+
+    Args:
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -105,17 +125,22 @@ def sync(
 
     return sync_detailed(
         client=client,
+        external_id=external_id,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Client,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[Error, list["IntegrationConnection"]]]:
     """List integration connections
 
      Returns all configured integration connections in the workspace. Each connection stores credentials
     and settings for an external service (LLM provider, API, database).
+
+    Args:
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -125,7 +150,9 @@ async def asyncio_detailed(
         Response[Union[Error, list['IntegrationConnection']]]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        external_id=external_id,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -135,11 +162,15 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Union[Error, list["IntegrationConnection"]] | None:
     """List integration connections
 
      Returns all configured integration connections in the workspace. Each connection stores credentials
     and settings for an external service (LLM provider, API, database).
+
+    Args:
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -152,5 +183,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            external_id=external_id,
         )
     ).parsed

--- a/src/blaxel/core/client/api/jobs/list_jobs.py
+++ b/src/blaxel/core/client/api/jobs/list_jobs.py
@@ -18,6 +18,7 @@ def _get_kwargs(
     sort: Union[Unset, ListJobsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListJobsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -38,6 +39,8 @@ def _get_kwargs(
         json_anchor = anchor.value
 
     params["anchor"] = json_anchor
+
+    params["externalId"] = external_id
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -78,6 +81,7 @@ def sync_detailed(
     sort: Union[Unset, ListJobsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListJobsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Response[JobList]:
     """List batch jobs
 
@@ -92,6 +96,7 @@ def sync_detailed(
         sort (Union[Unset, ListJobsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListJobsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -107,6 +112,7 @@ def sync_detailed(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     )
 
     response = client.get_httpx_client().request(
@@ -124,6 +130,7 @@ def sync(
     sort: Union[Unset, ListJobsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListJobsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> JobList | None:
     """List batch jobs
 
@@ -138,6 +145,7 @@ def sync(
         sort (Union[Unset, ListJobsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListJobsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -154,6 +162,7 @@ def sync(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     ).parsed
 
 
@@ -165,6 +174,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListJobsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListJobsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Response[JobList]:
     """List batch jobs
 
@@ -179,6 +189,7 @@ async def asyncio_detailed(
         sort (Union[Unset, ListJobsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListJobsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -194,6 +205,7 @@ async def asyncio_detailed(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -209,6 +221,7 @@ async def asyncio(
     sort: Union[Unset, ListJobsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListJobsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> JobList | None:
     """List batch jobs
 
@@ -223,6 +236,7 @@ async def asyncio(
         sort (Union[Unset, ListJobsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListJobsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -240,5 +254,6 @@ async def asyncio(
             sort=sort,
             q=q,
             anchor=anchor,
+            external_id=external_id,
         )
     ).parsed

--- a/src/blaxel/core/client/api/models/list_models.py
+++ b/src/blaxel/core/client/api/models/list_models.py
@@ -19,6 +19,7 @@ def _get_kwargs(
     sort: Union[Unset, ListModelsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListModelsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -39,6 +40,8 @@ def _get_kwargs(
         json_anchor = anchor.value
 
     params["anchor"] = json_anchor
+
+    params["externalId"] = external_id
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -93,6 +96,7 @@ def sync_detailed(
     sort: Union[Unset, ListModelsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListModelsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[Error, ModelList]]:
     """List model endpoints
 
@@ -107,6 +111,7 @@ def sync_detailed(
         sort (Union[Unset, ListModelsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListModelsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -122,6 +127,7 @@ def sync_detailed(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     )
 
     response = client.get_httpx_client().request(
@@ -139,6 +145,7 @@ def sync(
     sort: Union[Unset, ListModelsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListModelsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Union[Error, ModelList] | None:
     """List model endpoints
 
@@ -153,6 +160,7 @@ def sync(
         sort (Union[Unset, ListModelsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListModelsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -169,6 +177,7 @@ def sync(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     ).parsed
 
 
@@ -180,6 +189,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListModelsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListModelsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[Error, ModelList]]:
     """List model endpoints
 
@@ -194,6 +204,7 @@ async def asyncio_detailed(
         sort (Union[Unset, ListModelsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListModelsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -209,6 +220,7 @@ async def asyncio_detailed(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -224,6 +236,7 @@ async def asyncio(
     sort: Union[Unset, ListModelsSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListModelsAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Union[Error, ModelList] | None:
     """List model endpoints
 
@@ -238,6 +251,7 @@ async def asyncio(
         sort (Union[Unset, ListModelsSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListModelsAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -255,5 +269,6 @@ async def asyncio(
             sort=sort,
             q=q,
             anchor=anchor,
+            external_id=external_id,
         )
     ).parsed

--- a/src/blaxel/core/client/api/policies/list_policies.py
+++ b/src/blaxel/core/client/api/policies/list_policies.py
@@ -18,6 +18,7 @@ def _get_kwargs(
     sort: Union[Unset, ListPoliciesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -38,6 +39,8 @@ def _get_kwargs(
         json_anchor = anchor.value
 
     params["anchor"] = json_anchor
+
+    params["externalId"] = external_id
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -78,6 +81,7 @@ def sync_detailed(
     sort: Union[Unset, ListPoliciesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Response[PolicyList]:
     """List governance policies
 
@@ -92,6 +96,7 @@ def sync_detailed(
         sort (Union[Unset, ListPoliciesSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListPoliciesAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -107,6 +112,7 @@ def sync_detailed(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     )
 
     response = client.get_httpx_client().request(
@@ -124,6 +130,7 @@ def sync(
     sort: Union[Unset, ListPoliciesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> PolicyList | None:
     """List governance policies
 
@@ -138,6 +145,7 @@ def sync(
         sort (Union[Unset, ListPoliciesSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListPoliciesAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -154,6 +162,7 @@ def sync(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     ).parsed
 
 
@@ -165,6 +174,7 @@ async def asyncio_detailed(
     sort: Union[Unset, ListPoliciesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> Response[PolicyList]:
     """List governance policies
 
@@ -179,6 +189,7 @@ async def asyncio_detailed(
         sort (Union[Unset, ListPoliciesSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListPoliciesAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -194,6 +205,7 @@ async def asyncio_detailed(
         sort=sort,
         q=q,
         anchor=anchor,
+        external_id=external_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -209,6 +221,7 @@ async def asyncio(
     sort: Union[Unset, ListPoliciesSort] = UNSET,
     q: Union[Unset, str] = UNSET,
     anchor: Union[Unset, ListPoliciesAnchor] = UNSET,
+    external_id: Union[Unset, str] = UNSET,
 ) -> PolicyList | None:
     """List governance policies
 
@@ -223,6 +236,7 @@ async def asyncio(
         sort (Union[Unset, ListPoliciesSort]):
         q (Union[Unset, str]):
         anchor (Union[Unset, ListPoliciesAnchor]):
+        external_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -240,5 +254,6 @@ async def asyncio(
             sort=sort,
             q=q,
             anchor=anchor,
+            external_id=external_id,
         )
     ).parsed

--- a/src/blaxel/core/common/autoload.py
+++ b/src/blaxel/core/common/autoload.py
@@ -21,11 +21,17 @@ def telemetry() -> None:
 def autoload() -> None:
     client.with_base_url(settings.base_url)
     client.with_auth(settings.auth)
-    # Send the Blaxel-Version header on every control-plane request so list
-    # endpoints return cursor-paginated `{data, meta}` responses (>= 2026-04-28).
-    # Without it the API falls back to legacy bare-array listings and pagination
-    # (limit/cursor/next_page) is silently ignored.
-    client.with_headers({"Blaxel-Version": settings.api_version})
+    # Send SDK-identifying headers on every control-plane request so backend
+    # observability can classify Python SDK traffic and list endpoints return
+    # cursor-paginated `{data, meta}` responses (>= 2026-04-28). Without the
+    # User-Agent httpx falls back to `python-httpx/<version>`, which is tracked
+    # as a generic API request instead of SDK usage.
+    client.with_headers(
+        {
+            "Blaxel-Version": settings.api_version,
+            "User-Agent": settings.headers["User-Agent"],
+        }
+    )
 
     # Register response interceptors for authentication error handling
     # Access the underlying httpx clients and add event hooks

--- a/src/blaxel/core/common/autoload.py
+++ b/src/blaxel/core/common/autoload.py
@@ -29,7 +29,7 @@ def autoload() -> None:
     client.with_headers(
         {
             "Blaxel-Version": settings.api_version,
-            "User-Agent": settings.headers["User-Agent"],
+            "User-Agent": settings.user_agent,
         }
     )
 

--- a/src/blaxel/core/common/settings.py
+++ b/src/blaxel/core/common/settings.py
@@ -118,11 +118,16 @@ class Settings:
         return _get_int_env("BL_SANDBOX_READ_RETRIES", 5)
 
     @property
+    def user_agent(self) -> str:
+        """Get the SDK User-Agent without reading credentials."""
+        os_arch = _get_os_arch()
+        return f"blaxel/sdk/python/{self.version} ({os_arch}) blaxel/{self.commit}"
+
+    @property
     def headers(self) -> Dict[str, str]:
         """Get the headers for API requests."""
         headers = self.auth.get_headers()
-        os_arch = _get_os_arch()
-        headers["User-Agent"] = f"blaxel/sdk/python/{self.version} ({os_arch}) blaxel/{self.commit}"
+        headers["User-Agent"] = self.user_agent
         headers["Blaxel-Version"] = self.api_version
         return headers
 

--- a/tests/core/test_authentication_env_vars.py
+++ b/tests/core/test_authentication_env_vars.py
@@ -110,3 +110,16 @@ def test_settings_headers_clear_error_without_credentials(no_config, clear_auth_
     s = Settings()
     with pytest.raises(CredentialsError):
         _ = s.headers
+
+
+def test_autoload_does_not_read_credentials(no_config, clear_auth_env):
+    """Import-time setup should stay lazy when credentials are missing."""
+    from blaxel.core.client import client
+    from blaxel.core.common.autoload import autoload
+    from blaxel.core.common.settings import Settings
+
+    autoload()
+
+    current_settings = Settings()
+    assert client._headers["Blaxel-Version"] == current_settings.api_version
+    assert client._headers["User-Agent"] == current_settings.user_agent

--- a/tests/core/test_environment.py
+++ b/tests/core/test_environment.py
@@ -123,6 +123,19 @@ def test_autoload_functionality():
             raise
 
 
+def test_autoload_sets_control_plane_user_agent():
+    """Control-plane requests should carry the Python SDK User-Agent."""
+    from blaxel.core.client import client
+    from blaxel.core.common.autoload import autoload
+    from blaxel.core.common.settings import settings
+
+    autoload()
+
+    assert client._headers["Blaxel-Version"] == settings.api_version
+    assert client._headers["User-Agent"] == settings.headers["User-Agent"]
+    assert client._headers["User-Agent"].startswith("blaxel/sdk/python/")
+
+
 def test_settings_properties():
     """Test that settings has the expected properties."""
     from blaxel.core.common.settings import settings

--- a/tests/core/test_environment.py
+++ b/tests/core/test_environment.py
@@ -132,7 +132,7 @@ def test_autoload_sets_control_plane_user_agent():
     autoload()
 
     assert client._headers["Blaxel-Version"] == settings.api_version
-    assert client._headers["User-Agent"] == settings.headers["User-Agent"]
+    assert client._headers["User-Agent"] == settings.user_agent
     assert client._headers["User-Agent"].startswith("blaxel/sdk/python/")
 
 

--- a/tests/core/test_remaining_root_external_id.py
+++ b/tests/core/test_remaining_root_external_id.py
@@ -1,0 +1,28 @@
+"""Tests for external_id list filters on remaining root resources."""
+
+import pytest
+
+from blaxel.core.client.api.agents import list_agents
+from blaxel.core.client.api.functions import list_functions
+from blaxel.core.client.api.integrations import list_integration_connections
+from blaxel.core.client.api.jobs import list_jobs
+from blaxel.core.client.api.models import list_models
+from blaxel.core.client.api.policies import list_policies
+
+
+@pytest.mark.parametrize(
+    ("module", "url"),
+    [
+        (list_agents, "/agents"),
+        (list_functions, "/functions"),
+        (list_integration_connections, "/integrations/connections"),
+        (list_jobs, "/jobs"),
+        (list_models, "/models"),
+        (list_policies, "/policies"),
+    ],
+)
+def test_remaining_root_list_external_id_query_param(module, url):
+    kwargs = module._get_kwargs(external_id="remaining-root-external-id")
+
+    assert kwargs["url"] == url
+    assert kwargs["params"]["externalId"] == "remaining-root-external-id"

--- a/tests/integration/core/remaining_root_external_id_list_live_smoke.py
+++ b/tests/integration/core/remaining_root_external_id_list_live_smoke.py
@@ -1,0 +1,38 @@
+import asyncio
+import random
+import string
+
+from blaxel.core.client.api.agents.list_agents import asyncio as list_agents
+from blaxel.core.client.api.functions.list_functions import asyncio as list_functions
+from blaxel.core.client.api.integrations.list_integration_connections import (
+    asyncio as list_integration_connections,
+)
+from blaxel.core.client.api.jobs.list_jobs import asyncio as list_jobs
+from blaxel.core.client.api.models.list_models import asyncio as list_models
+from blaxel.core.client.api.policies.list_policies import asyncio as list_policies
+from blaxel.core.client.client import client
+
+suffix = "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))
+missing = f"missing-{suffix}"
+
+
+async def main():
+    checks = [
+        ("agents", lambda: list_agents(client=client, external_id=missing, limit=1)),
+        ("functions", lambda: list_functions(client=client, external_id=missing, limit=1)),
+        (
+            "integration_connections",
+            lambda: list_integration_connections(client=client, external_id=missing),
+        ),
+        ("jobs", lambda: list_jobs(client=client, external_id=missing, limit=1)),
+        ("models", lambda: list_models(client=client, external_id=missing, limit=1)),
+        ("policies", lambda: list_policies(client=client, external_id=missing, limit=1)),
+    ]
+    for label, check in checks:
+        result = await check()
+        if result is None:
+            raise AssertionError(f"{label} external_id list returned None")
+        print(f"{label} external_id list filter smoke passed")
+
+
+asyncio.run(main())

--- a/tests/integration/core/remaining_root_external_id_list_live_smoke.py
+++ b/tests/integration/core/remaining_root_external_id_list_live_smoke.py
@@ -32,6 +32,11 @@ async def main():
         result = await check()
         if result is None:
             raise AssertionError(f"{label} external_id list returned None")
+        data = getattr(result, "data", []) or []
+        if len(data) != 0:
+            raise AssertionError(
+                f"{label} external_id filter returned {len(data)} resource(s) for missing external_id {missing}"
+            )
         print(f"{label} external_id list filter smoke passed")
 
 

--- a/tests/integration/core/remaining_root_external_id_list_live_smoke.py
+++ b/tests/integration/core/remaining_root_external_id_list_live_smoke.py
@@ -11,6 +11,7 @@ from blaxel.core.client.api.jobs.list_jobs import asyncio as list_jobs
 from blaxel.core.client.api.models.list_models import asyncio as list_models
 from blaxel.core.client.api.policies.list_policies import asyncio as list_policies
 from blaxel.core.client.client import client
+from blaxel.core.client.models.error import Error
 
 suffix = "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))
 missing = f"missing-{suffix}"
@@ -32,7 +33,9 @@ async def main():
         result = await check()
         if result is None:
             raise AssertionError(f"{label} external_id list returned None")
-        data = getattr(result, "data", []) or []
+        if isinstance(result, Error):
+            raise AssertionError(f"{label} external_id list returned error: {result}")
+        data = result if isinstance(result, list) else (getattr(result, "data", []) or [])
         if len(data) != 0:
             raise AssertionError(
                 f"{label} external_id filter returned {len(data)} resource(s) for missing external_id {missing}"


### PR DESCRIPTION
Fixes ENG-3170

## Summary
- regenerate control-plane list clients with external_id query support for agents, functions, integration connections, jobs, models, and policies
- allow sdk-controlplane generation from a configurable CONTROLPLANE_REF
- add unit coverage for external_id query serialization and a dev smoke script for remaining root-resource filters

## Verification
- BL_ENV=dev .venv/bin/pytest tests/core/test_remaining_root_external_id.py tests/core/test_drive_volume_external_id.py -q
- BL_ENV=dev .venv/bin/python tests/integration/core/remaining_root_external_id_list_live_smoke.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API client parameters and header changes; default behavior unchanged when `external_id` is omitted.
> 
> **Overview**
> Adds **`external_id`** filtering to control-plane list APIs for agents, functions, integration connections, jobs, models, and policies (serialized as the `externalId` query parameter on the regenerated OpenAPI clients).
> 
> The **Makefile** now accepts **`SANDBOX_REF`** and **`CONTROLPLANE_REF`** (default `main`) when downloading OpenAPI specs for SDK regeneration.
> 
> **Import-time client setup** now sets both **`Blaxel-Version`** and a Blaxel **`User-Agent`** via a new **`settings.user_agent`** property so control-plane traffic is identifiable in observability and **`autoload()`** does not need to read credentials just to build headers. Unit tests cover `externalId` serialization and credential-free autoload; an integration smoke script exercises live list calls with a non-matching `external_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79f2b4c0617e98fa61015e67af7f1445f62585a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->