### PR TITLE
fix: report only unhandled SDK exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ import blaxel.telemetry
 
 ### Error tracking
 
-The SDK includes error tracking that captures exceptions originating from the SDK itself (not your application code). It collects data including the error type, message, stack trace, SDK version, workspace name, and so on. No user or application data is collected.
+The SDK includes error tracking for unhandled exceptions originating from the SDK itself (not your application code). It collects a sanitized error type and HTTP/error code, package-relative SDK stack frames, SDK version, commit, and workspace name. It does not collect application stack frames, raw exception messages, response bodies, or local filesystem paths.
 
 Error tracking is off by default since v0.2.46. To explicitly disable it in older versions:
 

--- a/src/blaxel/core/common/sentry.py
+++ b/src/blaxel/core/common/sentry.py
@@ -1,13 +1,17 @@
+import asyncio
 import atexit
 import builtins
 import json
 import logging
 import sys
 import threading
+import time
 import traceback
 import uuid
 from asyncio import CancelledError
 from datetime import datetime, timezone
+from pathlib import Path
+from queue import Full, Queue
 from typing import Any
 from urllib.parse import urlparse
 
@@ -15,21 +19,31 @@ import httpx
 
 from .settings import settings
 
+try:
+    from exceptiongroup import BaseExceptionGroup as BackportBaseExceptionGroup
+except ImportError:  # The backport is optional and only needed on Python 3.10.
+    BackportBaseExceptionGroup = None
+
 logger = logging.getLogger(__name__)
 
 # Lightweight Sentry client using httpx - only captures SDK errors
 _sentry_initialized = False
-_captured_exceptions: set = set()  # Track already captured exceptions to avoid duplicates
 
 # Parsed DSN components
 _sentry_config: dict[str, str] | None = None
 
-# Queue for pending events
-_pending_events: list[dict[str, Any]] = []
-_flush_lock = threading.Lock()
+# Bounded queue for last-chance background capture.
+_MAX_CAPTURE_EVENTS = 100
+_BACKGROUND_CAPTURE_STOP = object()
+_background_worker_init_lock = threading.Lock()
+_handler_registration_lock = threading.Lock()
+_background_capture_queue: Queue[Any] = Queue(maxsize=_MAX_CAPTURE_EVENTS)
+_background_capture_thread: threading.Thread | None = None
 _handlers_registered = False
 _original_excepthook = None
 _original_threading_excepthook = None
+_original_unraisablehook = None
+_original_asyncio_call_exception_handler = None
 
 # Exceptions that are part of normal control flow and should not be captured
 _IGNORED_EXCEPTIONS = (
@@ -43,6 +57,14 @@ _IGNORED_EXCEPTIONS = (
 
 # Optional dependencies that may not be installed - import errors for these are expected
 _OPTIONAL_DEPENDENCIES = ("opentelemetry",)
+_SAFE_ERROR_CODES = {
+    "DRIVE_ALREADY_EXISTS",
+    "NOT_FOUND",
+    "SANDBOX_ALREADY_EXISTS",
+    "VOLUME_ALREADY_ATTACHED",
+    "VOLUME_ALREADY_EXISTS",
+    "WORKLOAD_UNAVAILABLE",
+}
 
 # Optional blaxel framework integration subpackages. Importing any of these
 # requires installing the matching extra (e.g. ``pip install blaxel[openai]``).
@@ -72,34 +94,57 @@ _OPTIONAL_INTEGRATION_ENTRYPOINT_MODULES = {
     "blaxel.telemetry": ("exporters", "instrumentation", "log", "manager", "span"),
 }
 
-# Filesystem fragments used to detect an import error raised while loading one of
-# the optional integration packages above (covers both POSIX and Windows paths).
-_OPTIONAL_INTEGRATION_PATHS = tuple(
-    f"blaxel/{pkg.rsplit('.', 1)[-1]}/" for pkg in _OPTIONAL_INTEGRATION_PACKAGES
-) + tuple(f"blaxel\\{pkg.rsplit('.', 1)[-1]}\\" for pkg in _OPTIONAL_INTEGRATION_PACKAGES)
+# Resolve frames against the package that supplied this module. Matching arbitrary
+# path substrings such as ``blaxel/`` can misclassify application code and report
+# exceptions that did not originate in the installed SDK.
+_SDK_PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+_OPTIONAL_INTEGRATION_ROOTS = tuple(
+    _SDK_PACKAGE_ROOT / package.rsplit(".", 1)[-1] for package in _OPTIONAL_INTEGRATION_PACKAGES
+)
+_builtin_exception_group = getattr(builtins, "BaseExceptionGroup", None)
+_EXCEPTION_GROUP_TYPES = tuple(
+    dict.fromkeys(
+        group_type
+        for group_type in (_builtin_exception_group, BackportBaseExceptionGroup)
+        if group_type is not None
+    )
+)
 
-# SDK path patterns to identify errors originating from our SDK
-_SDK_PATTERNS = [
-    "blaxel/",
-    "blaxel\\",
-    "site-packages/blaxel",
-    "site-packages\\blaxel",
-]
 
-
-def _is_from_sdk(error: Exception) -> bool:
-    """Check if an error originated from SDK code based on stack trace."""
-    tb = error.__traceback__
-    if not tb:
+def _is_path_within(filename: str, root: Path) -> bool:
+    """Return whether a traceback filename resolves inside a trusted package root."""
+    try:
+        Path(filename).resolve().relative_to(root)
+        return True
+    except (OSError, ValueError):
         return False
 
-    # Walk through the traceback
-    while tb:
-        filename = tb.tb_frame.f_code.co_filename
-        if any(pattern in filename for pattern in _SDK_PATTERNS):
+
+def _sdk_relative_filename(filename: str) -> str | None:
+    """Return an SDK-relative frame name, excluding application filesystem paths."""
+    try:
+        relative_path = Path(filename).resolve().relative_to(_SDK_PACKAGE_ROOT)
+    except (OSError, ValueError):
+        return None
+    return (Path(_SDK_PACKAGE_ROOT.name) / relative_path).as_posix()
+
+
+def _is_from_sdk(error: BaseException) -> bool:
+    """Check whether an error has a frame inside this installed SDK package."""
+    tb = error.__traceback__
+    while tb is not None:
+        if _sdk_relative_filename(tb.tb_frame.f_code.co_filename) is not None:
             return True
         tb = tb.tb_next
+    return False
 
+
+def _contains_sdk_exception(error: BaseException) -> bool:
+    """Check an ordinary exception or exception group for an SDK-owned frame."""
+    if _is_from_sdk(error):
+        return True
+    if isinstance(error, _EXCEPTION_GROUP_TYPES):
+        return any(_contains_sdk_exception(child) for child in getattr(error, "exceptions"))
     return False
 
 
@@ -127,15 +172,18 @@ def _generate_event_id() -> str:
     return uuid.uuid4().hex
 
 
-def _parse_stack_trace(exc: Exception) -> list[dict[str, Any]]:
+def _parse_stack_trace(exc: BaseException) -> list[dict[str, Any]]:
     """Parse exception traceback into Sentry-compatible frames."""
     frames: list[dict[str, Any]] = []
     tb = traceback.extract_tb(exc.__traceback__)
 
     for frame in tb:
+        filename = _sdk_relative_filename(frame.filename)
+        if filename is None:
+            continue
         frames.append(
             {
-                "filename": frame.filename,
+                "filename": filename,
                 "function": frame.name or "<anonymous>",
                 "lineno": frame.lineno,
                 "colno": 0,
@@ -145,10 +193,83 @@ def _parse_stack_trace(exc: Exception) -> list[dict[str, Any]]:
     return frames
 
 
-def _error_to_sentry_event(error: Exception) -> dict[str, Any]:
-    """Convert an Exception to a Sentry event payload."""
-    frames = _parse_stack_trace(error)
+def _safe_exception_value(error: BaseException) -> str:
+    """Describe an SDK failure without including exception or response content."""
+    if isinstance(error, _EXCEPTION_GROUP_TYPES):
+        child_count = len(getattr(error, "exceptions"))
+        return f"Unhandled SDK exception group ({child_count} sub-exceptions)"
 
+    details = []
+    status_code = getattr(error, "status_code", None)
+    if status_code is None:
+        status_code = getattr(getattr(error, "response", None), "status_code", None)
+    if type(status_code) is int and 100 <= status_code <= 599:
+        details.append(f"HTTP {status_code}")
+
+    error_code = getattr(error, "error_code", None) or getattr(error, "code", None)
+    if type(error_code) is int:
+        if error_code != status_code:
+            details.append(f"code {error_code}")
+    elif isinstance(error_code, str) and error_code in _SAFE_ERROR_CODES:
+        details.append(f"code {error_code}")
+
+    suffix = f" ({', '.join(details)})" if details else ""
+    return f"Unhandled SDK exception{suffix}"
+
+
+def _exception_to_sentry_value(error: BaseException, mechanism: dict[str, Any]) -> dict[str, Any]:
+    """Convert one exception or exception-group node to a Sentry exception value."""
+    return {
+        "type": type(error).__name__,
+        "value": _safe_exception_value(error),
+        "stacktrace": {"frames": _parse_stack_trace(error)},
+        "mechanism": mechanism,
+    }
+
+
+def _exception_values(
+    error: BaseException, mechanism_type: str = "generic"
+) -> list[dict[str, Any]]:
+    """Serialize an exception tree without sending one event per group leaf."""
+    if not isinstance(error, _EXCEPTION_GROUP_TYPES):
+        return [
+            _exception_to_sentry_value(
+                error,
+                {"type": mechanism_type, "handled": False},
+            )
+        ]
+
+    values: list[dict[str, Any]] = []
+
+    def append_exception(
+        exception: BaseException,
+        parent_id: int | None = None,
+        source: str | None = None,
+    ) -> None:
+        exception_id = len(values)
+        mechanism: dict[str, Any] = {
+            "type": mechanism_type if parent_id is None else "chained",
+            "handled": False,
+            "exception_id": exception_id,
+        }
+        if parent_id is not None:
+            mechanism["parent_id"] = parent_id
+            mechanism["source"] = source
+        if isinstance(exception, _EXCEPTION_GROUP_TYPES):
+            mechanism["is_exception_group"] = True
+
+        values.append(_exception_to_sentry_value(exception, mechanism))
+        if isinstance(exception, _EXCEPTION_GROUP_TYPES):
+            for index, child in enumerate(getattr(exception, "exceptions")):
+                append_exception(child, exception_id, f"exceptions[{index}]")
+
+    append_exception(error)
+    values.reverse()
+    return values
+
+
+def _error_to_sentry_event(error: BaseException, mechanism_type: str = "generic") -> dict[str, Any]:
+    """Convert an exception to a Sentry event payload."""
     return {
         "event_id": _generate_event_id(),
         "timestamp": datetime.now(timezone.utc).timestamp(),
@@ -161,22 +282,14 @@ def _error_to_sentry_event(error: Exception) -> dict[str, Any]:
             "blaxel.version": settings.version,
             "blaxel.commit": settings.commit,
         },
-        "exception": {
-            "values": [
-                {
-                    "type": type(error).__name__,
-                    "value": str(error),
-                    "stacktrace": {"frames": frames},
-                }
-            ]
-        },
+        "exception": {"values": _exception_values(error, mechanism_type)},
     }
 
 
-def _send_to_sentry(event: dict[str, Any]) -> None:
-    """Send an event to Sentry using httpx."""
+def _send_to_sentry(event: dict[str, Any], timeout: float = 2.0) -> bool:
+    """Send an event to Sentry, returning whether delivery succeeded."""
     if not _sentry_config:
-        return
+        return False
 
     public_key = _sentry_config["public_key"]
     host = _sentry_config["host"]
@@ -199,26 +312,28 @@ def _send_to_sentry(event: dict[str, Any]) -> None:
     envelope = f"{envelope_header}\n{item_header}\n{json.dumps(event)}"
 
     try:
-        httpx.post(
+        response = httpx.post(
             envelope_url,
             headers={
                 "Content-Type": "application/x-sentry-envelope",
                 "X-Sentry-Auth": f"Sentry sentry_version=7, sentry_client=blaxel-sdk/{settings.version}, sentry_key={public_key}",
             },
             content=envelope,
-            timeout=5.0,
+            timeout=max(timeout, 0.01),
         )
+        response.raise_for_status()
+        return True
     except Exception:
         # Silently fail - error reporting should never break the SDK
-        pass
+        return False
 
 
 def _has_optional_integration_frame(exc_value) -> bool:
-    """Check whether an exception traceback passed through an integration module."""
+    """Check whether a traceback passed through an installed integration module."""
     tb = getattr(exc_value, "__traceback__", None)
     while tb is not None:
         filename = tb.tb_frame.f_code.co_filename
-        if any(path in filename for path in _OPTIONAL_INTEGRATION_PATHS):
+        if any(_is_path_within(filename, root) for root in _OPTIONAL_INTEGRATION_ROOTS):
             return True
         tb = tb.tb_next
     return False
@@ -299,28 +414,106 @@ def _should_capture_unhandled_exception(exc_type, exc_value) -> bool:
     return not _is_optional_dependency_error(exc_type, exc_value)
 
 
-def _iter_exception_leaves(exc_value):
-    """Yield ordinary exceptions, recursively expanding exception groups when available."""
-    exception_group_type = getattr(builtins, "BaseExceptionGroup", None)
-    if exception_group_type is not None and isinstance(exc_value, exception_group_type):
-        for nested_exception in exc_value.exceptions:
-            yield from _iter_exception_leaves(nested_exception)
-    else:
-        yield exc_value
+def _filter_reportable_exception(exc_value: BaseException) -> BaseException | None:
+    """Keep reportable SDK leaves while preserving an exception group's structure."""
+    if isinstance(exc_value, _EXCEPTION_GROUP_TYPES):
+
+        def is_reportable_leaf(exception: BaseException) -> bool:
+            return not isinstance(
+                exception, _EXCEPTION_GROUP_TYPES
+            ) and _should_capture_unhandled_exception(type(exception), exception)
+
+        return getattr(exc_value, "subgroup")(is_reportable_leaf)
+
+    if _should_capture_unhandled_exception(type(exc_value), exc_value):
+        return exc_value
+    return None
 
 
-def _capture_unhandled_exception(exc_value) -> None:
-    """Capture the first reportable leaf of an unhandled exception or exception group."""
-    for exception in _iter_exception_leaves(exc_value):
-        if _should_capture_unhandled_exception(type(exception), exception):
-            capture_exception(exception)
+def _capture_unhandled_exception(exc_value: BaseException | None, mechanism_type: str) -> None:
+    """Capture one filtered event for an unhandled exception or exception group."""
+    if exc_value is None:
+        return
+    reportable_exception = _filter_reportable_exception(exc_value)
+    if reportable_exception is not None:
+        capture_exception(reportable_exception, mechanism_type)
+
+
+def _capture_unhandled_exception_safely(
+    exc_value: BaseException | None, mechanism_type: str
+) -> None:
+    """Keep telemetry classification failures out of application exception paths."""
+    try:
+        _capture_unhandled_exception(exc_value, mechanism_type)
+    except Exception:
+        pass
+
+
+def _drain_background_capture_queue(capture_queue: Queue[Any]) -> None:
+    """Deliver queued hook events serially outside the failing runtime surface."""
+    while True:
+        item = capture_queue.get()
+        try:
+            if item is _BACKGROUND_CAPTURE_STOP:
+                return
+            exc_value, mechanism_type = item
+            _capture_unhandled_exception_safely(exc_value, mechanism_type)
+        finally:
+            capture_queue.task_done()
+
+
+def _start_background_capture_worker() -> None:
+    """Start the process-wide bounded capture worker during SDK initialization."""
+    global _background_capture_thread
+    with _background_worker_init_lock:
+        if _background_capture_thread is not None and _background_capture_thread.is_alive():
             return
+        try:
+            capture_queue = _background_capture_queue
+            worker = threading.Thread(
+                target=_drain_background_capture_queue,
+                args=(capture_queue,),
+                name="blaxel-sentry-capture",
+                daemon=True,
+            )
+            _background_capture_thread = worker
+            worker.start()
+        except Exception:
+            _background_capture_thread = None
+
+
+def _stop_background_capture_worker(timeout: float = 1.0) -> None:
+    """Stop the delivery worker after pending capture has been flushed."""
+    global _background_capture_thread
+    worker = _background_capture_thread
+    if worker is None or not worker.is_alive():
+        return
+    try:
+        _background_capture_queue.put_nowait(_BACKGROUND_CAPTURE_STOP)
+    except Full:
+        return
+    worker.join(timeout=max(timeout, 0.0))
+    if not worker.is_alive():
+        _background_capture_thread = None
+
+
+def _capture_unhandled_exception_in_background(
+    exc_value: BaseException | None, mechanism_type: str
+) -> None:
+    """Queue asyncio/thread/finalizer failures without blocking their runtime hook."""
+    worker = _background_capture_thread
+    if worker is None or not worker.is_alive():
+        return
+    try:
+        _background_capture_queue.put_nowait((exc_value, mechanism_type))
+    except Full:
+        pass
 
 
 def _blaxel_excepthook(exc_type, exc_value, exc_tb) -> None:
     """Capture an unhandled main-thread SDK exception, then preserve hook chaining."""
     try:
-        _capture_unhandled_exception(exc_value)
+        _capture_unhandled_exception_in_background(exc_value, "excepthook")
     finally:
         if _original_excepthook is not None and _original_excepthook is not _blaxel_excepthook:
             _original_excepthook(exc_type, exc_value, exc_tb)
@@ -329,7 +522,7 @@ def _blaxel_excepthook(exc_type, exc_value, exc_tb) -> None:
 def _blaxel_threading_excepthook(args: Any) -> None:
     """Capture an unhandled worker-thread SDK exception, then preserve hook chaining."""
     try:
-        _capture_unhandled_exception(args.exc_value)
+        _capture_unhandled_exception_in_background(args.exc_value, "threading")
     finally:
         if (
             _original_threading_excepthook is not None
@@ -338,9 +531,36 @@ def _blaxel_threading_excepthook(args: Any) -> None:
             _original_threading_excepthook(args)
 
 
+def _blaxel_unraisablehook(args: Any) -> None:
+    """Capture an SDK exception Python could not otherwise raise."""
+    try:
+        if not sys.is_finalizing():
+            _capture_unhandled_exception_in_background(args.exc_value, "unraisablehook")
+    finally:
+        if (
+            _original_unraisablehook is not None
+            and _original_unraisablehook is not _blaxel_unraisablehook
+        ):
+            _original_unraisablehook(args)
+
+
+def _blaxel_asyncio_call_exception_handler(self: asyncio.BaseEventLoop, context: Any) -> None:
+    """Capture abandoned task/callback failures, then run asyncio's existing handler."""
+    try:
+        _capture_unhandled_exception_in_background(context.get("exception"), "asyncio")
+    finally:
+        if (
+            _original_asyncio_call_exception_handler is not None
+            and _original_asyncio_call_exception_handler
+            is not _blaxel_asyncio_call_exception_handler
+        ):
+            _original_asyncio_call_exception_handler(self, context)
+
+
 def init_sentry() -> None:
     """Initialize the lightweight Sentry client for SDK error tracking."""
     global _handlers_registered, _original_excepthook, _original_threading_excepthook
+    global _original_unraisablehook, _original_asyncio_call_exception_handler
     global _sentry_config, _sentry_initialized
     try:
         dsn = settings.sentry_dsn
@@ -358,50 +578,54 @@ def init_sentry() -> None:
 
         _sentry_initialized = True
 
-        # Register handlers only once
-        if not _handlers_registered:
-            _handlers_registered = True
+        # Register handlers only once, preserving the hooks that were installed
+        # before the first concurrent caller entered initialization.
+        with _handler_registration_lock:
+            if not _handlers_registered:
+                _start_background_capture_worker()
 
-            # Capture only exceptions that escape the process or a worker thread.
-            # A trace hook runs at throw-time and reports exceptions that callers
-            # subsequently handle, which turns expected SDK control flow into noise.
-            _original_excepthook = sys.excepthook
-            _original_threading_excepthook = threading.excepthook
-            sys.excepthook = _blaxel_excepthook
-            threading.excepthook = _blaxel_threading_excepthook
+                # Capture only exceptions that reach a last-chance runtime boundary.
+                # A trace hook runs at throw-time and reports exceptions that callers
+                # subsequently handle, which turns expected SDK control flow into noise.
+                _original_excepthook = sys.excepthook
+                _original_threading_excepthook = threading.excepthook
+                _original_unraisablehook = sys.unraisablehook
+                _original_asyncio_call_exception_handler = (
+                    asyncio.BaseEventLoop.call_exception_handler
+                )
+                sys.excepthook = _blaxel_excepthook
+                threading.excepthook = _blaxel_threading_excepthook
+                sys.unraisablehook = _blaxel_unraisablehook
+                asyncio.BaseEventLoop.call_exception_handler = (
+                    _blaxel_asyncio_call_exception_handler
+                )
+                _handlers_registered = True
 
-            # Register atexit handler to flush pending events
-            atexit.register(flush_sentry)
+                # Register atexit handler to flush pending events and stop the worker.
+                atexit.register(_shutdown_sentry)
 
     except Exception as e:
         logger.debug(f"Error initializing Sentry: {e}")
 
 
-def capture_exception(exception: Exception | None = None) -> None:
+def capture_exception(
+    exception: BaseException | None = None, mechanism_type: str = "generic"
+) -> None:
     """Capture an exception to Sentry.
     Only errors originating from SDK code will be captured.
     """
-    if not _sentry_initialized or not _sentry_config or exception is None:
+    if (
+        not _sentry_initialized
+        or not _sentry_config
+        or exception is None
+        or not _contains_sdk_exception(exception)
+    ):
         return
 
     try:
-        # Generate unique key to prevent duplicate captures
-        exc_key = f"{type(exception).__name__}:{str(exception)}"
-        if exc_key in _captured_exceptions:
-            return
-
-        _captured_exceptions.add(exc_key)
-
-        # Clean up old exception keys to prevent memory leak
-        if len(_captured_exceptions) > 1000:
-            _captured_exceptions.clear()
-
-        # Convert error to Sentry event and queue it
-        event = _error_to_sentry_event(exception)
-        with _flush_lock:
-            _pending_events.append(event)
-
-        # Send immediately (fire and forget)
+        # Delivery is best effort. Runtime hooks already execute this work on the
+        # bounded background worker, so a Sentry outage never blocks the caller.
+        event = _error_to_sentry_event(exception, mechanism_type)
         _send_to_sentry(event)
 
     except Exception:
@@ -410,24 +634,20 @@ def capture_exception(exception: Exception | None = None) -> None:
 
 
 def flush_sentry(timeout: float = 2.0) -> None:
-    """Flush pending Sentry events."""
+    """Wait up to ``timeout`` for the bounded background queue to drain."""
     if not _sentry_initialized:
         return
 
-    with _flush_lock:
-        if not _pending_events:
-            return
+    deadline = time.monotonic() + max(timeout, 0.0)
+    capture_queue = _background_capture_queue
+    while capture_queue.unfinished_tasks and time.monotonic() < deadline:
+        time.sleep(min(0.01, max(deadline - time.monotonic(), 0.0)))
 
-        events_to_send = _pending_events.copy()
-        _pending_events.clear()
 
-    # Send all pending events
-    for event in events_to_send:
-        try:
-            _send_to_sentry(event)
-        except Exception:
-            # Silently fail
-            pass
+def _shutdown_sentry() -> None:
+    """Best-effort process-exit flush for the lightweight telemetry worker."""
+    flush_sentry()
+    _stop_background_capture_worker()
 
 
 def is_sentry_initialized() -> bool:

--- a/src/blaxel/core/common/sentry.py
+++ b/src/blaxel/core/common/sentry.py
@@ -1,4 +1,5 @@
 import atexit
+import builtins
 import json
 import logging
 import sys
@@ -27,6 +28,8 @@ _sentry_config: dict[str, str] | None = None
 _pending_events: list[dict[str, Any]] = []
 _flush_lock = threading.Lock()
 _handlers_registered = False
+_original_excepthook = None
+_original_threading_excepthook = None
 
 # Exceptions that are part of normal control flow and should not be captured
 _IGNORED_EXCEPTIONS = (
@@ -210,20 +213,6 @@ def _send_to_sentry(event: dict[str, Any]) -> None:
         pass
 
 
-def _get_exception_key(exc_type, exc_value, frame) -> str:
-    """Generate a unique key for an exception based on type, message, and origin."""
-    exc_name = exc_type.__name__ if exc_type else "Unknown"
-    exc_msg = str(exc_value) if exc_value else ""
-    tb = getattr(exc_value, "__traceback__", None)
-    if tb:
-        while tb.tb_next:
-            tb = tb.tb_next
-        origin = f"{tb.tb_frame.f_code.co_filename}:{tb.tb_lineno}"
-    else:
-        origin = f"{frame.f_code.co_filename}:{frame.f_lineno}"
-    return f"{exc_name}:{exc_msg}:{origin}"
-
-
 def _has_optional_integration_frame(exc_value) -> bool:
     """Check whether an exception traceback passed through an integration module."""
     tb = getattr(exc_value, "__traceback__", None)
@@ -301,38 +290,58 @@ def _is_optional_dependency_error(exc_type, exc_value, seen: set[int] | None = N
     return False
 
 
-def _trace_blaxel_exceptions(frame, event, arg):
-    """Trace function that captures exceptions from blaxel SDK code."""
-    if event == "exception":
-        exc_type, exc_value, exc_tb = arg
+def _should_capture_unhandled_exception(exc_type, exc_value) -> bool:
+    """Return whether an unhandled exception represents an SDK failure."""
+    if not exc_type or exc_value is None or not _is_from_sdk(exc_value):
+        return False
+    if issubclass(exc_type, _IGNORED_EXCEPTIONS):
+        return False
+    return not _is_optional_dependency_error(exc_type, exc_value)
 
-        # Skip control flow exceptions (not actual errors)
-        if exc_type and issubclass(exc_type, _IGNORED_EXCEPTIONS):
-            return _trace_blaxel_exceptions
 
-        # Skip import errors for optional dependencies (expected when not installed)
-        if _is_optional_dependency_error(exc_type, exc_value):
-            return _trace_blaxel_exceptions
+def _iter_exception_leaves(exc_value):
+    """Yield ordinary exceptions, recursively expanding exception groups when available."""
+    exception_group_type = getattr(builtins, "BaseExceptionGroup", None)
+    if exception_group_type is not None and isinstance(exc_value, exception_group_type):
+        for nested_exception in exc_value.exceptions:
+            yield from _iter_exception_leaves(nested_exception)
+    else:
+        yield exc_value
 
-        filename = frame.f_code.co_filename
 
-        # Only capture if it's from blaxel in site-packages
-        if "site-packages/blaxel" in filename:
-            # Avoid capturing the same exception multiple times using a content-based key
-            exc_key = _get_exception_key(exc_type, exc_value, frame)
-            if exc_key not in _captured_exceptions:
-                _captured_exceptions.add(exc_key)
-                capture_exception(exc_value)
-                # Clean up old exception keys to prevent memory leak
-                if len(_captured_exceptions) > 1000:
-                    _captured_exceptions.clear()
+def _capture_unhandled_exception(exc_value) -> None:
+    """Capture the first reportable leaf of an unhandled exception or exception group."""
+    for exception in _iter_exception_leaves(exc_value):
+        if _should_capture_unhandled_exception(type(exception), exception):
+            capture_exception(exception)
+            return
 
-    return _trace_blaxel_exceptions
+
+def _blaxel_excepthook(exc_type, exc_value, exc_tb) -> None:
+    """Capture an unhandled main-thread SDK exception, then preserve hook chaining."""
+    try:
+        _capture_unhandled_exception(exc_value)
+    finally:
+        if _original_excepthook is not None and _original_excepthook is not _blaxel_excepthook:
+            _original_excepthook(exc_type, exc_value, exc_tb)
+
+
+def _blaxel_threading_excepthook(args: Any) -> None:
+    """Capture an unhandled worker-thread SDK exception, then preserve hook chaining."""
+    try:
+        _capture_unhandled_exception(args.exc_value)
+    finally:
+        if (
+            _original_threading_excepthook is not None
+            and _original_threading_excepthook is not _blaxel_threading_excepthook
+        ):
+            _original_threading_excepthook(args)
 
 
 def init_sentry() -> None:
     """Initialize the lightweight Sentry client for SDK error tracking."""
-    global _sentry_initialized, _sentry_config, _handlers_registered
+    global _handlers_registered, _original_excepthook, _original_threading_excepthook
+    global _sentry_config, _sentry_initialized
     try:
         dsn = settings.sentry_dsn
         if not dsn:
@@ -353,9 +362,13 @@ def init_sentry() -> None:
         if not _handlers_registered:
             _handlers_registered = True
 
-            # Install trace function to automatically capture SDK exceptions
-            sys.settrace(_trace_blaxel_exceptions)
-            threading.settrace(_trace_blaxel_exceptions)
+            # Capture only exceptions that escape the process or a worker thread.
+            # A trace hook runs at throw-time and reports exceptions that callers
+            # subsequently handle, which turns expected SDK control flow into noise.
+            _original_excepthook = sys.excepthook
+            _original_threading_excepthook = threading.excepthook
+            sys.excepthook = _blaxel_excepthook
+            threading.excepthook = _blaxel_threading_excepthook
 
             # Register atexit handler to flush pending events
             atexit.register(flush_sentry)

--- a/src/blaxel/core/common/sentry.py
+++ b/src/blaxel/core/common/sentry.py
@@ -453,6 +453,8 @@ def _drain_background_capture_queue(capture_queue: Queue[Any]) -> None:
     """Deliver queued hook events serially outside the failing runtime surface."""
     while True:
         item = capture_queue.get()
+        exc_value = None
+        mechanism_type = None
         try:
             if item is _BACKGROUND_CAPTURE_STOP:
                 return
@@ -460,6 +462,11 @@ def _drain_background_capture_queue(capture_queue: Queue[Any]) -> None:
             _capture_unhandled_exception_safely(exc_value, mechanism_type)
         finally:
             capture_queue.task_done()
+            # A worker blocked on its next queue read otherwise keeps the last
+            # exception and traceback alive in frame locals indefinitely.
+            item = None
+            exc_value = None
+            mechanism_type = None
 
 
 def _start_background_capture_worker() -> None:

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -1,12 +1,21 @@
-"""Tests for the lightweight Sentry error filter.
+"""Tests for the lightweight Sentry error boundary and import filtering.
 
-The SDK installs a trace function (``sys.settrace``) that forwards exceptions
-originating from ``site-packages/blaxel`` to Sentry. Import errors that happen
-because an optional integration extra is not installed (or because a
-stripped/partial install is missing the integration's modules) are environment
-issues, not SDK defects, and must be filtered out before reaching Sentry.
+The SDK reports unhandled exceptions that originate in ``blaxel`` code. Expected
+optional-integration import failures are filtered even when they are unhandled.
 """
 
+import builtins
+import sys
+import threading
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+import blaxel
+import blaxel.core.common.sentry as sentry
+from blaxel.core.client import Client, errors
+from blaxel.core.client.api.jobs.create_job_execution import _parse_response
 from blaxel.core.common.sentry import (
     _OPTIONAL_INTEGRATION_ENTRYPOINT_MODULES,
     _is_optional_dependency_error,
@@ -20,6 +29,195 @@ def _raise_in_file(filename: str, code: str) -> Exception:
     except Exception as e:  # noqa: BLE001 - we want the raised exception object
         return e
     raise AssertionError("code did not raise")
+
+
+@pytest.fixture
+def installed_sentry_hooks(monkeypatch):
+    """Install hooks with network capture replaced by an in-memory recorder."""
+    captured = []
+    main_hook_calls = []
+    thread_hook_calls = []
+    previous_trace = sys.gettrace()
+    previous_thread_trace = threading.gettrace()
+
+    def main_hook(exc_type, exc_value, exc_tb):
+        main_hook_calls.append((exc_type, exc_value, exc_tb))
+
+    def thread_hook(args):
+        thread_hook_calls.append(args)
+
+    monkeypatch.setattr(blaxel, "__sentry_dsn__", "https://public@example.com/1")
+    monkeypatch.setenv("BL_ENV", "prod")
+    monkeypatch.setattr(sys, "excepthook", main_hook)
+    monkeypatch.setattr(threading, "excepthook", thread_hook)
+    monkeypatch.setattr(sentry.atexit, "register", lambda _callback: None)
+    monkeypatch.setattr(sentry, "capture_exception", captured.append)
+    monkeypatch.setattr(sentry, "_handlers_registered", False)
+    monkeypatch.setattr(sentry, "_sentry_initialized", False)
+    monkeypatch.setattr(sentry, "_sentry_config", None)
+    monkeypatch.setattr(sentry, "_original_excepthook", None)
+    monkeypatch.setattr(sentry, "_original_threading_excepthook", None)
+
+    try:
+        sentry.init_sentry()
+        yield SimpleNamespace(
+            captured=captured,
+            main_hook=main_hook,
+            main_hook_calls=main_hook_calls,
+            thread_hook=thread_hook,
+            thread_hook_calls=thread_hook_calls,
+            previous_trace=previous_trace,
+            previous_thread_trace=previous_thread_trace,
+        )
+    finally:
+        sys.settrace(previous_trace)
+        threading.settrace(previous_thread_trace)
+
+
+class TestUnhandledExceptionHooks:
+    def test_init_replaces_exception_hooks_without_enabling_tracing(self, installed_sentry_hooks):
+        hooks = installed_sentry_hooks
+
+        assert sys.excepthook is sentry._blaxel_excepthook
+        assert threading.excepthook is sentry._blaxel_threading_excepthook
+        assert sentry._original_excepthook is hooks.main_hook
+        assert sentry._original_threading_excepthook is hooks.thread_hook
+        assert sys.gettrace() is hooks.previous_trace
+        assert threading.gettrace() is hooks.previous_thread_trace
+
+    def test_handled_job_404_is_not_captured(self, installed_sentry_hooks):
+        """Regression for SDK-PYTHON-DB: callers may handle a missing job."""
+        namespace = {
+            "Client": Client,
+            "errors": errors,
+            "httpx": httpx,
+            "_parse_response": _parse_response,
+        }
+        exec(
+            compile(
+                """
+try:
+    _parse_response(
+        client=Client(base_url="https://api.blaxel.ai"),
+        response=httpx.Response(
+            404,
+            content=b'{"code":404,"error":"Job not found"}',
+        ),
+    )
+except errors.UnexpectedStatus as exc:
+    handled_status = exc.status_code
+""",
+                "/tmp/site-packages/blaxel/core/jobs/reproduction.py",
+                "exec",
+            ),
+            namespace,
+        )
+
+        assert namespace["handled_status"] == 404
+        assert installed_sentry_hooks.captured == []
+        assert installed_sentry_hooks.main_hook_calls == []
+
+    def test_unhandled_sdk_exception_is_captured_and_chained(self, installed_sentry_hooks):
+        exc = _raise_in_file(
+            "/tmp/site-packages/blaxel/core/broken.py",
+            "raise RuntimeError('sdk failure')",
+        )
+
+        sys.excepthook(type(exc), exc, exc.__traceback__)
+
+        assert installed_sentry_hooks.captured == [exc]
+        assert installed_sentry_hooks.main_hook_calls == [(type(exc), exc, exc.__traceback__)]
+
+    def test_unhandled_thread_exception_is_captured_and_chained(self, installed_sentry_hooks):
+        exc = _raise_in_file(
+            "/tmp/site-packages/blaxel/core/worker.py",
+            "raise RuntimeError('thread failure')",
+        )
+        args = threading.ExceptHookArgs(
+            (type(exc), exc, exc.__traceback__, None),
+        )
+
+        threading.excepthook(args)
+
+        assert installed_sentry_hooks.captured == [exc]
+        assert installed_sentry_hooks.thread_hook_calls == [args]
+
+    def test_unhandled_optional_import_is_filtered_and_chained(self, installed_sentry_hooks):
+        exc = _raise_in_file(
+            "/tmp/site-packages/blaxel/openai/model.py",
+            "raise ModuleNotFoundError(\"No module named 'agents'\", name='agents')",
+        )
+
+        sys.excepthook(type(exc), exc, exc.__traceback__)
+
+        assert installed_sentry_hooks.captured == []
+        assert installed_sentry_hooks.main_hook_calls == [(type(exc), exc, exc.__traceback__)]
+
+    def test_original_hooks_are_chained_when_classification_fails(
+        self, installed_sentry_hooks, monkeypatch
+    ):
+        exc = _raise_in_file(
+            "/tmp/site-packages/blaxel/core/broken.py",
+            "raise RuntimeError('sdk failure')",
+        )
+        args = threading.ExceptHookArgs(
+            (type(exc), exc, exc.__traceback__, None),
+        )
+
+        def fail_classification(_exc_type, _exc_value):
+            raise RuntimeError("classification failed")
+
+        monkeypatch.setattr(sentry, "_should_capture_unhandled_exception", fail_classification)
+
+        with pytest.raises(RuntimeError, match="classification failed"):
+            sys.excepthook(type(exc), exc, exc.__traceback__)
+        with pytest.raises(RuntimeError, match="classification failed"):
+            threading.excepthook(args)
+
+        assert installed_sentry_hooks.main_hook_calls == [(type(exc), exc, exc.__traceback__)]
+        assert installed_sentry_hooks.thread_hook_calls == [args]
+
+    @pytest.mark.skipif(sys.version_info < (3, 11), reason="ExceptionGroup requires Python 3.11")
+    def test_exception_group_captures_first_sdk_failure(self, installed_sentry_hooks):
+        first_sdk_exc = _raise_in_file(
+            "/tmp/site-packages/blaxel/core/broken.py",
+            "raise RuntimeError('first sdk failure')",
+        )
+        second_sdk_exc = _raise_in_file(
+            "/tmp/site-packages/blaxel/core/also_broken.py",
+            "raise RuntimeError('second sdk failure')",
+        )
+        optional_exc = _raise_in_file(
+            "/tmp/site-packages/blaxel/openai/model.py",
+            "raise ModuleNotFoundError(\"No module named 'agents'\", name='agents')",
+        )
+        exception_group_type = getattr(builtins, "ExceptionGroup")
+        group = exception_group_type(
+            "task failures",
+            [optional_exc, first_sdk_exc, second_sdk_exc],
+        )
+
+        sys.excepthook(type(group), group, group.__traceback__)
+
+        assert installed_sentry_hooks.captured == [first_sdk_exc]
+        assert installed_sentry_hooks.main_hook_calls == [(type(group), group, group.__traceback__)]
+
+    @pytest.mark.skipif(sys.version_info < (3, 11), reason="ExceptionGroup requires Python 3.11")
+    def test_optional_only_exception_group_is_filtered_in_thread(self, installed_sentry_hooks):
+        optional_exc = _raise_in_file(
+            "/tmp/site-packages/blaxel/openai/model.py",
+            "raise ModuleNotFoundError(\"No module named 'agents'\", name='agents')",
+        )
+        exception_group_type = getattr(builtins, "ExceptionGroup")
+        group = exception_group_type("task failures", [optional_exc])
+        args = threading.ExceptHookArgs(
+            (type(group), group, group.__traceback__, None),
+        )
+
+        threading.excepthook(args)
+
+        assert installed_sentry_hooks.captured == []
+        assert installed_sentry_hooks.thread_hook_calls == [args]
 
 
 class TestIsOptionalDependencyError:

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -1,13 +1,19 @@
 """Tests for the lightweight Sentry error boundary and import filtering.
 
-The SDK reports unhandled exceptions that originate in ``blaxel`` code. Expected
-optional-integration import failures are filtered even when they are unhandled.
+The SDK reports exceptions only when they reach a last-chance runtime boundary and
+originate in the installed ``blaxel`` package. Expected optional-integration import
+failures remain filtered even when they are unhandled.
 """
 
-import builtins
+import asyncio
+import gc
+import json
 import sys
 import threading
+import time
+from queue import Queue
 from types import SimpleNamespace
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -22,21 +28,55 @@ from blaxel.core.common.sentry import (
 )
 
 
-def _raise_in_file(filename: str, code: str) -> Exception:
+def _raise_in_file(filename: str, code: str, namespace=None) -> BaseException:
     """Execute ``code`` as if it lived in ``filename`` and return the exception."""
     try:
-        exec(compile(code, filename, "exec"), {})
-    except Exception as e:  # noqa: BLE001 - we want the raised exception object
-        return e
+        exec(compile(code, filename, "exec"), namespace or {})
+    except BaseException as error:  # noqa: BLE001 - tests need the raised object
+        return error
     raise AssertionError("code did not raise")
+
+
+def _define_in_file(filename: str, code: str) -> dict:
+    namespace: dict = {}
+    exec(compile(code, filename, "exec"), namespace)
+    return namespace
+
+
+def _sdk_filename(relative_path: str) -> str:
+    return str(sentry._SDK_PACKAGE_ROOT / relative_path)
+
+
+def _raise_in_sdk(relative_path: str, code: str) -> BaseException:
+    return _raise_in_file(_sdk_filename(relative_path), code)
+
+
+def _exception_group_leaves(error: BaseException) -> list[BaseException]:
+    if isinstance(error, sentry._EXCEPTION_GROUP_TYPES):
+        leaves = []
+        for child in getattr(error, "exceptions"):
+            leaves.extend(_exception_group_leaves(child))
+        return leaves
+    return [error]
+
+
+def _wait_for_background_capture() -> None:
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline:
+        if sentry._background_capture_queue.unfinished_tasks == 0:
+            return
+        time.sleep(0.01)
+    raise AssertionError("background capture did not finish")
 
 
 @pytest.fixture
 def installed_sentry_hooks(monkeypatch):
-    """Install hooks with network capture replaced by an in-memory recorder."""
+    """Install all last-chance hooks with in-memory capture and chain recorders."""
     captured = []
     main_hook_calls = []
     thread_hook_calls = []
+    unraisable_hook_calls = []
+    asyncio_hook_calls = []
     previous_trace = sys.gettrace()
     previous_thread_trace = threading.gettrace()
 
@@ -46,17 +86,38 @@ def installed_sentry_hooks(monkeypatch):
     def thread_hook(args):
         thread_hook_calls.append(args)
 
+    def unraisable_hook(args):
+        unraisable_hook_calls.append(args)
+
+    def asyncio_hook(loop, context):
+        asyncio_hook_calls.append((loop, context))
+
+    def capture(exception, mechanism_type="generic"):
+        captured.append((exception, mechanism_type))
+
     monkeypatch.setattr(blaxel, "__sentry_dsn__", "https://public@example.com/1")
     monkeypatch.setenv("BL_ENV", "prod")
     monkeypatch.setattr(sys, "excepthook", main_hook)
     monkeypatch.setattr(threading, "excepthook", thread_hook)
+    monkeypatch.setattr(sys, "unraisablehook", unraisable_hook)
+    monkeypatch.setattr(asyncio.BaseEventLoop, "call_exception_handler", asyncio_hook)
     monkeypatch.setattr(sentry.atexit, "register", lambda _callback: None)
-    monkeypatch.setattr(sentry, "capture_exception", captured.append)
+    monkeypatch.setattr(sentry, "capture_exception", capture)
     monkeypatch.setattr(sentry, "_handlers_registered", False)
     monkeypatch.setattr(sentry, "_sentry_initialized", False)
     monkeypatch.setattr(sentry, "_sentry_config", None)
     monkeypatch.setattr(sentry, "_original_excepthook", None)
     monkeypatch.setattr(sentry, "_original_threading_excepthook", None)
+    monkeypatch.setattr(sentry, "_original_unraisablehook", None)
+    monkeypatch.setattr(sentry, "_original_asyncio_call_exception_handler", None)
+    monkeypatch.setattr(sentry, "_background_worker_init_lock", threading.Lock())
+    monkeypatch.setattr(sentry, "_handler_registration_lock", threading.Lock())
+    monkeypatch.setattr(
+        sentry,
+        "_background_capture_queue",
+        Queue(maxsize=sentry._MAX_CAPTURE_EVENTS),
+    )
+    monkeypatch.setattr(sentry, "_background_capture_thread", None)
 
     try:
         sentry.init_sentry()
@@ -66,24 +127,82 @@ def installed_sentry_hooks(monkeypatch):
             main_hook_calls=main_hook_calls,
             thread_hook=thread_hook,
             thread_hook_calls=thread_hook_calls,
+            unraisable_hook=unraisable_hook,
+            unraisable_hook_calls=unraisable_hook_calls,
+            asyncio_hook=asyncio_hook,
+            asyncio_hook_calls=asyncio_hook_calls,
             previous_trace=previous_trace,
             previous_thread_trace=previous_thread_trace,
         )
     finally:
+        sentry._stop_background_capture_worker()
         sys.settrace(previous_trace)
         threading.settrace(previous_thread_trace)
 
 
 class TestUnhandledExceptionHooks:
-    def test_init_replaces_exception_hooks_without_enabling_tracing(self, installed_sentry_hooks):
+    def test_init_replaces_last_chance_hooks_without_enabling_tracing(self, installed_sentry_hooks):
         hooks = installed_sentry_hooks
 
         assert sys.excepthook is sentry._blaxel_excepthook
         assert threading.excepthook is sentry._blaxel_threading_excepthook
+        assert sys.unraisablehook is sentry._blaxel_unraisablehook
+        assert (
+            asyncio.BaseEventLoop.call_exception_handler
+            is sentry._blaxel_asyncio_call_exception_handler
+        )
         assert sentry._original_excepthook is hooks.main_hook
         assert sentry._original_threading_excepthook is hooks.thread_hook
+        assert sentry._original_unraisablehook is hooks.unraisable_hook
+        assert sentry._original_asyncio_call_exception_handler is hooks.asyncio_hook
         assert sys.gettrace() is hooks.previous_trace
         assert threading.gettrace() is hooks.previous_thread_trace
+
+    def test_repeated_init_does_not_wrap_or_replace_original_hooks(self, installed_sentry_hooks):
+        hooks = installed_sentry_hooks
+
+        sentry.init_sentry()
+
+        assert sentry._original_excepthook is hooks.main_hook
+        assert sentry._original_threading_excepthook is hooks.thread_hook
+        assert sentry._original_unraisablehook is hooks.unraisable_hook
+        assert sentry._original_asyncio_call_exception_handler is hooks.asyncio_hook
+        assert sys.excepthook is sentry._blaxel_excepthook
+        assert threading.excepthook is sentry._blaxel_threading_excepthook
+        assert sys.unraisablehook is sentry._blaxel_unraisablehook
+
+    def test_concurrent_init_preserves_original_hooks(self, installed_sentry_hooks, monkeypatch):
+        hooks = installed_sentry_hooks
+        starts = []
+        counter_lock = threading.Lock()
+
+        def slow_worker_start():
+            with counter_lock:
+                starts.append(True)
+            time.sleep(0.05)
+
+        sys.excepthook = hooks.main_hook
+        threading.excepthook = hooks.thread_hook
+        sys.unraisablehook = hooks.unraisable_hook
+        asyncio.BaseEventLoop.call_exception_handler = hooks.asyncio_hook
+        sentry._handlers_registered = False
+        sentry._original_excepthook = None
+        sentry._original_threading_excepthook = None
+        sentry._original_unraisablehook = None
+        sentry._original_asyncio_call_exception_handler = None
+        monkeypatch.setattr(sentry, "_start_background_capture_worker", slow_worker_start)
+
+        callers = [threading.Thread(target=sentry.init_sentry) for _ in range(4)]
+        for caller in callers:
+            caller.start()
+        for caller in callers:
+            caller.join()
+
+        assert len(starts) == 1
+        assert sentry._original_excepthook is hooks.main_hook
+        assert sentry._original_threading_excepthook is hooks.thread_hook
+        assert sentry._original_unraisablehook is hooks.unraisable_hook
+        assert sentry._original_asyncio_call_exception_handler is hooks.asyncio_hook
 
     def test_handled_job_404_is_not_captured(self, installed_sentry_hooks):
         """Regression for SDK-PYTHON-DB: callers may handle a missing job."""
@@ -107,7 +226,7 @@ try:
 except errors.UnexpectedStatus as exc:
     handled_status = exc.status_code
 """,
-                "/tmp/site-packages/blaxel/core/jobs/reproduction.py",
+                "/tmp/customer/job_reproduction.py",
                 "exec",
             ),
             namespace,
@@ -118,117 +237,428 @@ except errors.UnexpectedStatus as exc:
         assert installed_sentry_hooks.main_hook_calls == []
 
     def test_unhandled_sdk_exception_is_captured_and_chained(self, installed_sentry_hooks):
-        exc = _raise_in_file(
-            "/tmp/site-packages/blaxel/core/broken.py",
-            "raise RuntimeError('sdk failure')",
-        )
+        exc = _raise_in_sdk("core/broken.py", "raise RuntimeError('sdk failure')")
 
         sys.excepthook(type(exc), exc, exc.__traceback__)
+        _wait_for_background_capture()
 
-        assert installed_sentry_hooks.captured == [exc]
+        assert installed_sentry_hooks.captured == [(exc, "excepthook")]
         assert installed_sentry_hooks.main_hook_calls == [(type(exc), exc, exc.__traceback__)]
 
-    def test_unhandled_thread_exception_is_captured_and_chained(self, installed_sentry_hooks):
-        exc = _raise_in_file(
-            "/tmp/site-packages/blaxel/core/worker.py",
-            "raise RuntimeError('thread failure')",
-        )
-        args = threading.ExceptHookArgs(
-            (type(exc), exc, exc.__traceback__, None),
+    def test_actual_worker_thread_failure_is_captured_and_chained(self, installed_sentry_hooks):
+        namespace = _define_in_file(
+            _sdk_filename("core/worker.py"),
+            "def fail():\n    raise RuntimeError('thread failure')",
         )
 
-        threading.excepthook(args)
+        thread = threading.Thread(target=namespace["fail"])
+        thread.start()
+        thread.join()
+        _wait_for_background_capture()
 
-        assert installed_sentry_hooks.captured == [exc]
-        assert installed_sentry_hooks.thread_hook_calls == [args]
+        captured_exception, mechanism = installed_sentry_hooks.captured[0]
+        assert str(captured_exception) == "thread failure"
+        assert mechanism == "threading"
+        assert installed_sentry_hooks.thread_hook_calls[0].exc_value is captured_exception
 
-    def test_unhandled_optional_import_is_filtered_and_chained(self, installed_sentry_hooks):
-        exc = _raise_in_file(
-            "/tmp/site-packages/blaxel/openai/model.py",
-            "raise ModuleNotFoundError(\"No module named 'agents'\", name='agents')",
+    @pytest.mark.asyncio
+    async def test_abandoned_asyncio_task_failure_is_captured_and_chained(
+        self, installed_sentry_hooks
+    ):
+        namespace = _define_in_file(
+            _sdk_filename("core/background.py"),
+            """
+raised = []
+async def fail():
+    error = RuntimeError('async task failure')
+    raised.append(error)
+    raise error
+""",
         )
 
-        sys.excepthook(type(exc), exc, exc.__traceback__)
+        task = asyncio.create_task(namespace["fail"]())
+        await asyncio.sleep(0)
+        assert task.done()
+        expected_exception = namespace["raised"][0]
+        del task
+        gc.collect()
+        await asyncio.sleep(0)
+        _wait_for_background_capture()
 
-        assert installed_sentry_hooks.captured == []
-        assert installed_sentry_hooks.main_hook_calls == [(type(exc), exc, exc.__traceback__)]
+        assert installed_sentry_hooks.captured == [(expected_exception, "asyncio")]
+        assert installed_sentry_hooks.asyncio_hook_calls
+        assert installed_sentry_hooks.asyncio_hook_calls[0][1]["exception"] is expected_exception
 
-    def test_original_hooks_are_chained_when_classification_fails(
+    def test_asyncio_hook_chains_without_waiting_for_delivery(
         self, installed_sentry_hooks, monkeypatch
     ):
-        exc = _raise_in_file(
-            "/tmp/site-packages/blaxel/core/broken.py",
-            "raise RuntimeError('sdk failure')",
+        exc = _raise_in_sdk("core/background.py", "raise RuntimeError('async failure')")
+        started = threading.Event()
+        release = threading.Event()
+        loop = cast(asyncio.BaseEventLoop, asyncio.new_event_loop())
+        context = {"exception": exc}
+
+        def block_capture(_exc_value, _mechanism_type):
+            started.set()
+            release.wait(timeout=1)
+
+        monkeypatch.setattr(sentry, "_capture_unhandled_exception_safely", block_capture)
+        try:
+            asyncio.BaseEventLoop.call_exception_handler(loop, context)
+            assert started.wait(timeout=1)
+            assert installed_sentry_hooks.asyncio_hook_calls == [(loop, context)]
+        finally:
+            release.set()
+            _wait_for_background_capture()
+            loop.close()
+
+    def test_background_capture_queues_a_burst_without_blocking_hooks(
+        self, installed_sentry_hooks, monkeypatch
+    ):
+        exceptions = [
+            _raise_in_sdk("core/background.py", f"raise RuntimeError('failure {index}')")
+            for index in range(3)
+        ]
+        first_started = threading.Event()
+        release_first = threading.Event()
+        captured = []
+
+        def capture(exc_value, mechanism_type):
+            captured.append((exc_value, mechanism_type))
+            if len(captured) == 1:
+                first_started.set()
+                release_first.wait(timeout=1)
+
+        monkeypatch.setattr(sentry, "_capture_unhandled_exception_safely", capture)
+
+        sentry._capture_unhandled_exception_in_background(exceptions[0], "asyncio")
+        assert first_started.wait(timeout=1)
+        sentry._capture_unhandled_exception_in_background(exceptions[1], "asyncio")
+        sentry._capture_unhandled_exception_in_background(exceptions[2], "asyncio")
+        release_first.set()
+        _wait_for_background_capture()
+
+        assert captured == [(exception, "asyncio") for exception in exceptions]
+
+    def test_flush_timeout_does_not_wait_for_in_flight_delivery(
+        self, installed_sentry_hooks, monkeypatch
+    ):
+        exc = _raise_in_sdk("core/slow_delivery.py", "raise RuntimeError('slow')")
+        started = threading.Event()
+        release = threading.Event()
+
+        def slow_capture(_exc, _mechanism):
+            started.set()
+            release.wait(timeout=1)
+
+        monkeypatch.setattr(sentry, "capture_exception", slow_capture)
+        sentry._capture_unhandled_exception_in_background(exc, "asyncio")
+        assert started.wait(timeout=1)
+
+        before = time.monotonic()
+        sentry.flush_sentry(timeout=0.01)
+        elapsed = time.monotonic() - before
+
+        assert elapsed < 0.2
+        release.set()
+        _wait_for_background_capture()
+
+    def test_background_thread_start_failure_is_contained(
+        self, installed_sentry_hooks, monkeypatch
+    ):
+        exc = _raise_in_sdk("core/background.py", "raise RuntimeError('sdk failure')")
+
+        class FailingThread:
+            def __init__(self, **_kwargs):
+                pass
+
+            def is_alive(self):
+                return False
+
+            def start(self):
+                raise RuntimeError("thread unavailable")
+
+        sentry._stop_background_capture_worker()
+        monkeypatch.setattr(
+            sentry,
+            "_background_capture_queue",
+            Queue(maxsize=sentry._MAX_CAPTURE_EVENTS),
         )
-        args = threading.ExceptHookArgs(
-            (type(exc), exc, exc.__traceback__, None),
+        monkeypatch.setattr(sentry, "_background_capture_thread", None)
+        monkeypatch.setattr(sentry.threading, "Thread", FailingThread)
+
+        sentry._start_background_capture_worker()
+        sentry._capture_unhandled_exception_in_background(exc, "asyncio")
+
+        assert sentry._background_capture_queue.empty()
+        assert sentry._background_capture_thread is None
+
+    def test_actual_unraisable_failure_is_captured_and_chained(self, installed_sentry_hooks):
+        namespace = _define_in_file(
+            _sdk_filename("core/finalizer.py"),
+            """
+class BrokenFinalizer:
+    def __del__(self):
+        raise RuntimeError('unraisable sdk failure')
+""",
         )
 
-        def fail_classification(_exc_type, _exc_value):
+        instance = namespace["BrokenFinalizer"]()
+        del instance
+        gc.collect()
+        _wait_for_background_capture()
+
+        captured_exception, mechanism = installed_sentry_hooks.captured[0]
+        assert str(captured_exception) == "unraisable sdk failure"
+        assert mechanism == "unraisablehook"
+        assert installed_sentry_hooks.unraisable_hook_calls[0].exc_value is captured_exception
+
+    def test_unraisable_during_finalization_only_chains(self, installed_sentry_hooks, monkeypatch):
+        exc = _raise_in_sdk("core/finalizer.py", "raise RuntimeError('late finalizer')")
+        args = SimpleNamespace(exc_value=exc)
+        monkeypatch.setattr(sys, "is_finalizing", lambda: True)
+
+        sys.unraisablehook(cast(Any, args))
+
+        assert installed_sentry_hooks.captured == []
+        assert installed_sentry_hooks.unraisable_hook_calls == [args]
+
+    def test_unhandled_optional_import_is_filtered_and_chained(self, installed_sentry_hooks):
+        exc = _raise_in_sdk(
+            "openai/model.py",
+            "raise ModuleNotFoundError(\"No module named 'agents'\", name='agents')",
+        )
+
+        sys.excepthook(type(exc), exc, exc.__traceback__)
+        _wait_for_background_capture()
+
+        assert installed_sentry_hooks.captured == []
+        assert installed_sentry_hooks.main_hook_calls == [(type(exc), exc, exc.__traceback__)]
+
+    def test_similar_application_path_is_not_treated_as_sdk(self, installed_sentry_hooks):
+        exc = _raise_in_file(
+            "/tmp/customer/blaxel/core/broken.py",
+            "raise RuntimeError('application failure')",
+        )
+
+        sys.excepthook(type(exc), exc, exc.__traceback__)
+        _wait_for_background_capture()
+
+        assert installed_sentry_hooks.captured == []
+        assert installed_sentry_hooks.main_hook_calls == [(type(exc), exc, exc.__traceback__)]
+
+    def test_reporting_failures_are_swallowed_and_all_hooks_still_chain(
+        self, installed_sentry_hooks, monkeypatch
+    ):
+        exc = _raise_in_sdk("core/broken.py", "raise RuntimeError('sdk failure')")
+        thread_args = threading.ExceptHookArgs((type(exc), exc, exc.__traceback__, None))
+        unraisable_args = SimpleNamespace(exc_value=exc)
+        asyncio_context = {"message": "Task exception was never retrieved", "exception": exc}
+        loop = cast(asyncio.BaseEventLoop, asyncio.new_event_loop())
+
+        def fail_classification(_exc_value):
             raise RuntimeError("classification failed")
 
-        monkeypatch.setattr(sentry, "_should_capture_unhandled_exception", fail_classification)
+        monkeypatch.setattr(sentry, "_filter_reportable_exception", fail_classification)
 
-        with pytest.raises(RuntimeError, match="classification failed"):
+        try:
             sys.excepthook(type(exc), exc, exc.__traceback__)
-        with pytest.raises(RuntimeError, match="classification failed"):
-            threading.excepthook(args)
+            _wait_for_background_capture()
+            threading.excepthook(thread_args)
+            sys.unraisablehook(cast(Any, unraisable_args))
+            _wait_for_background_capture()
+            asyncio.BaseEventLoop.call_exception_handler(loop, asyncio_context)
+            _wait_for_background_capture()
+        finally:
+            loop.close()
 
+        assert installed_sentry_hooks.captured == []
         assert installed_sentry_hooks.main_hook_calls == [(type(exc), exc, exc.__traceback__)]
-        assert installed_sentry_hooks.thread_hook_calls == [args]
+        assert installed_sentry_hooks.thread_hook_calls == [thread_args]
+        assert installed_sentry_hooks.unraisable_hook_calls == [unraisable_args]
+        assert installed_sentry_hooks.asyncio_hook_calls == [(loop, asyncio_context)]
 
-    @pytest.mark.skipif(sys.version_info < (3, 11), reason="ExceptionGroup requires Python 3.11")
-    def test_exception_group_captures_first_sdk_failure(self, installed_sentry_hooks):
-        first_sdk_exc = _raise_in_file(
-            "/tmp/site-packages/blaxel/core/broken.py",
-            "raise RuntimeError('first sdk failure')",
+    @pytest.mark.skipif(
+        not sentry._EXCEPTION_GROUP_TYPES,
+        reason="Exception groups require Python 3.11 or the exceptiongroup backport",
+    )
+    def test_exception_group_preserves_every_reportable_sdk_leaf(self, installed_sentry_hooks):
+        first_sdk_exc = _raise_in_sdk("core/broken.py", "raise RuntimeError('first sdk failure')")
+        second_sdk_exc = _raise_in_sdk(
+            "core/also_broken.py", "raise RuntimeError('second sdk failure')"
         )
-        second_sdk_exc = _raise_in_file(
-            "/tmp/site-packages/blaxel/core/also_broken.py",
-            "raise RuntimeError('second sdk failure')",
-        )
-        optional_exc = _raise_in_file(
-            "/tmp/site-packages/blaxel/openai/model.py",
+        optional_exc = _raise_in_sdk(
+            "openai/model.py",
             "raise ModuleNotFoundError(\"No module named 'agents'\", name='agents')",
         )
-        exception_group_type = getattr(builtins, "ExceptionGroup")
-        group = exception_group_type(
-            "task failures",
-            [optional_exc, first_sdk_exc, second_sdk_exc],
-        )
+        group_type = sentry._EXCEPTION_GROUP_TYPES[0]
+        nested_group = group_type("nested", [second_sdk_exc])
+        group = group_type("task failures", [optional_exc, first_sdk_exc, nested_group])
 
         sys.excepthook(type(group), group, group.__traceback__)
+        _wait_for_background_capture()
 
-        assert installed_sentry_hooks.captured == [first_sdk_exc]
+        assert len(installed_sentry_hooks.captured) == 1
+        captured_group, mechanism = installed_sentry_hooks.captured[0]
+        assert mechanism == "excepthook"
+        assert isinstance(captured_group, sentry._EXCEPTION_GROUP_TYPES)
+        assert getattr(captured_group, "message") == "task failures"
+        assert _exception_group_leaves(captured_group) == [first_sdk_exc, second_sdk_exc]
         assert installed_sentry_hooks.main_hook_calls == [(type(group), group, group.__traceback__)]
 
-    @pytest.mark.skipif(sys.version_info < (3, 11), reason="ExceptionGroup requires Python 3.11")
+        values = sentry._exception_values(captured_group, mechanism)
+        assert [value["mechanism"]["exception_id"] for value in values] == [3, 2, 1, 0]
+        assert values[-1]["value"] == "Unhandled SDK exception group (2 sub-exceptions)"
+        assert values[-1]["mechanism"] == {
+            "type": "excepthook",
+            "handled": False,
+            "exception_id": 0,
+            "is_exception_group": True,
+        }
+        assert all(value["mechanism"]["handled"] is False for value in values)
+
+    @pytest.mark.skipif(
+        not sentry._EXCEPTION_GROUP_TYPES,
+        reason="Exception groups require Python 3.11 or the exceptiongroup backport",
+    )
     def test_optional_only_exception_group_is_filtered_in_thread(self, installed_sentry_hooks):
-        optional_exc = _raise_in_file(
-            "/tmp/site-packages/blaxel/openai/model.py",
+        optional_exc = _raise_in_sdk(
+            "openai/model.py",
             "raise ModuleNotFoundError(\"No module named 'agents'\", name='agents')",
         )
-        exception_group_type = getattr(builtins, "ExceptionGroup")
-        group = exception_group_type("task failures", [optional_exc])
-        args = threading.ExceptHookArgs(
-            (type(group), group, group.__traceback__, None),
-        )
+        group_type = sentry._EXCEPTION_GROUP_TYPES[0]
+        group = group_type("task failures", [optional_exc])
+        args = threading.ExceptHookArgs((type(group), group, group.__traceback__, None))
 
         threading.excepthook(args)
 
         assert installed_sentry_hooks.captured == []
         assert installed_sentry_hooks.thread_hook_calls == [args]
+
+
+class TestSentryDelivery:
+    def test_successful_delivery_is_not_duplicated_by_flush(self, monkeypatch):
+        exc = _raise_in_sdk("core/delivery.py", "raise RuntimeError('delivery failure')")
+        sent_events = []
+        monkeypatch.setattr(sentry, "_sentry_initialized", True)
+        monkeypatch.setattr(sentry, "_sentry_config", {"public_key": "key"})
+
+        def send(event):
+            sent_events.append(event)
+            return True
+
+        monkeypatch.setattr(sentry, "_send_to_sentry", send)
+
+        sentry.capture_exception(exc, "excepthook")
+        sentry.flush_sentry()
+
+        assert len(sent_events) == 1
+
+    def test_failed_delivery_is_best_effort_and_not_retried_during_flush(self, monkeypatch):
+        exc = _raise_in_sdk("core/delivery.py", "raise RuntimeError('sentry unavailable')")
+        sent_events = []
+
+        def send(event):
+            sent_events.append(event)
+            return False
+
+        monkeypatch.setattr(sentry, "_sentry_initialized", True)
+        monkeypatch.setattr(sentry, "_sentry_config", {"public_key": "key"})
+        monkeypatch.setattr(sentry, "_send_to_sentry", send)
+
+        sentry.capture_exception(exc, "excepthook")
+        sentry.flush_sentry()
+
+        assert len(sent_events) == 1
+
+    def test_distinct_occurrences_with_the_same_message_are_both_delivered(self, monkeypatch):
+        first = _raise_in_sdk("core/repeated.py", "raise RuntimeError('same failure')")
+        second = _raise_in_sdk("core/repeated.py", "raise RuntimeError('same failure')")
+        sent_events = []
+
+        def send(event):
+            sent_events.append(event)
+            return True
+
+        monkeypatch.setattr(sentry, "_sentry_initialized", True)
+        monkeypatch.setattr(sentry, "_sentry_config", {"public_key": "key"})
+        monkeypatch.setattr(sentry, "_send_to_sentry", send)
+
+        sentry.capture_exception(first, "excepthook")
+        sentry.capture_exception(second, "excepthook")
+
+        assert len(sent_events) == 2
+
+
+class TestSentryPayloadPrivacy:
+    def test_public_capture_rejects_application_exception(self, monkeypatch):
+        exc = _raise_in_file(
+            "/tmp/customer/blaxel/core/application.py",
+            "raise RuntimeError('private application failure')",
+        )
+        sent_events = []
+        monkeypatch.setattr(sentry, "_sentry_initialized", True)
+        monkeypatch.setattr(sentry, "_sentry_config", {"public_key": "key"})
+        monkeypatch.setattr(sentry, "_send_to_sentry", sent_events.append)
+
+        sentry.capture_exception(exc)
+
+        assert sent_events == []
+
+    def test_event_contains_only_package_relative_sdk_frames(self):
+        namespace = _define_in_file(
+            _sdk_filename("core/private_failure.py"),
+            "def fail():\n    raise RuntimeError('sdk failure')",
+        )
+        exc = _raise_in_file(
+            "/tmp/customer/private/application.py",
+            "fail()",
+            {"fail": namespace["fail"]},
+        )
+
+        event = sentry._error_to_sentry_event(exc, "excepthook")
+        frames = event["exception"]["values"][0]["stacktrace"]["frames"]
+
+        assert frames
+        assert all(frame["filename"].startswith("blaxel/") for frame in frames)
+        assert all(not frame["filename"].startswith("/") for frame in frames)
+        assert all("customer" not in frame["filename"] for frame in frames)
+        exception_value = event["exception"]["values"][0]
+        assert exception_value["value"] == "Unhandled SDK exception"
+        assert "sdk failure" not in json.dumps(event)
+        assert exception_value["mechanism"] == {
+            "type": "excepthook",
+            "handled": False,
+        }
+
+    def test_response_content_is_not_serialized(self):
+        exc = _raise_in_file(
+            "/tmp/customer/request.py",
+            """
+_parse_response(
+    client=Client(base_url="https://api.blaxel.ai"),
+    response=httpx.Response(
+        404,
+        content=b'{"error":"token=top-secret-customer-value"}',
+    ),
+)
+""",
+            {"Client": Client, "httpx": httpx, "_parse_response": _parse_response},
+        )
+
+        setattr(exc, "code", "CUSTOMER_SECRET")
+        event = sentry._error_to_sentry_event(exc, "excepthook")
+        serialized_event = json.dumps(event)
+
+        assert "top-secret-customer-value" not in serialized_event
+        assert "CUSTOMER_SECRET" not in serialized_event
+        assert event["exception"]["values"][0]["value"] == ("Unhandled SDK exception (HTTP 404)")
 
 
 class TestIsOptionalDependencyError:
     """Cover the import-error classification used to suppress Sentry noise."""
 
     def test_missing_integration_submodule_is_optional(self):
-        """The exact production symptom: a stripped install missing model.py.
-
-        ``from .model import *`` in ``blaxel/openai/__init__.py`` raises
-        ``ModuleNotFoundError: No module named 'blaxel.openai.model'``.
-        """
         exc = ModuleNotFoundError(
             "No module named 'blaxel.openai.model'", name="blaxel.openai.model"
         )
@@ -241,32 +671,36 @@ class TestIsOptionalDependencyError:
         assert _is_optional_dependency_error(type(exc), exc) is True
 
     def test_each_optional_integration_package_is_covered(self):
-        for pkg in _OPTIONAL_INTEGRATION_ENTRYPOINT_MODULES:
-            exc = ModuleNotFoundError(f"No module named '{pkg}'", name=pkg)
-            assert _is_optional_dependency_error(type(exc), exc) is True, pkg
+        for package in _OPTIONAL_INTEGRATION_ENTRYPOINT_MODULES:
+            exc = ModuleNotFoundError(f"No module named '{package}'", name=package)
+            assert _is_optional_dependency_error(type(exc), exc) is True, package
 
     def test_each_optional_integration_entrypoint_module_is_covered(self):
-        for pkg, entrypoints in _OPTIONAL_INTEGRATION_ENTRYPOINT_MODULES.items():
+        for package, entrypoints in _OPTIONAL_INTEGRATION_ENTRYPOINT_MODULES.items():
             for entrypoint in entrypoints:
-                missing = f"{pkg}.{entrypoint}"
+                missing = f"{package}.{entrypoint}"
                 exc = ModuleNotFoundError(f"No module named '{missing}'", name=missing)
                 assert _is_optional_dependency_error(type(exc), exc) is True, missing
 
     def test_opentelemetry_dependency_is_optional(self):
-        """Existing behavior: opentelemetry import errors are still suppressed."""
         exc = ModuleNotFoundError("No module named 'opentelemetry'", name="opentelemetry")
         assert _is_optional_dependency_error(type(exc), exc) is True
 
     def test_missing_third_party_dep_while_loading_integration_is_optional(self):
-        """A missing extra dep (e.g. ``agents`` for blaxel[openai]) is expected."""
-        exc = _raise_in_file(
-            "/usr/lib/python3.12/site-packages/blaxel/openai/model.py",
+        exc = _raise_in_sdk(
+            "openai/model.py",
             "raise ModuleNotFoundError(\"No module named 'agents'\", name='agents')",
         )
         assert _is_optional_dependency_error(type(exc), exc) is True
 
+    def test_similar_application_path_does_not_count_as_optional_integration(self):
+        exc = _raise_in_file(
+            "/tmp/customer/blaxel/openai/model.py",
+            "raise ModuleNotFoundError(\"No module named 'agents'\", name='agents')",
+        )
+        assert _is_optional_dependency_error(type(exc), exc) is False
+
     def test_missing_nested_blaxel_module_inside_integration_is_not_optional(self):
-        """Internal integration packaging/import bugs must still reach Sentry."""
         exc = ModuleNotFoundError(
             "No module named 'blaxel.pydantic.custom.gemni'",
             name="blaxel.pydantic.custom.gemni",
@@ -274,7 +708,6 @@ class TestIsOptionalDependencyError:
         assert _is_optional_dependency_error(ModuleNotFoundError, exc) is False
 
     def test_wrapped_integration_import_guard_error_is_optional(self):
-        """The friendly optional-extra guard from blaxel.openai stays quiet."""
         cause = ModuleNotFoundError(
             "No module named 'blaxel.openai.model'",
             name="blaxel.openai.model",
@@ -288,16 +721,13 @@ class TestIsOptionalDependencyError:
         assert _is_optional_dependency_error(type(exc), exc) is True
 
     def test_missing_third_party_dep_outside_integration_is_not_optional(self):
-        """A third-party import failure outside any optional integration (e.g. a
-        genuine missing core dependency) must still be reported."""
-        exc = _raise_in_file(
-            "/usr/lib/python3.12/site-packages/blaxel/core/common/settings.py",
+        exc = _raise_in_sdk(
+            "core/common/settings.py",
             "raise ModuleNotFoundError(\"No module named 'httpx'\", name='httpx')",
         )
         assert _is_optional_dependency_error(type(exc), exc) is False
 
     def test_core_module_import_error_is_not_optional(self):
-        """A genuine SDK bug failing on a ``blaxel.*`` core module is captured."""
         exc = ModuleNotFoundError(
             "No module named 'blaxel.core.missing'", name="blaxel.core.missing"
         )

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -11,6 +11,7 @@ import json
 import sys
 import threading
 import time
+import weakref
 from queue import Queue
 from types import SimpleNamespace
 from typing import Any, cast
@@ -339,6 +340,40 @@ async def fail():
         _wait_for_background_capture()
 
         assert captured == [(exception, "asyncio") for exception in exceptions]
+
+    def test_background_worker_releases_delivered_exception(self, monkeypatch):
+        class Payload:
+            pass
+
+        payload = Payload()
+        payload_ref = weakref.ref(payload)
+        exc = _raise_in_sdk("core/background.py", "raise RuntimeError('failure')")
+        setattr(exc, "payload", payload)
+        capture_queue = Queue()
+        monkeypatch.setattr(
+            sentry,
+            "_capture_unhandled_exception_safely",
+            lambda _exc, _mechanism: None,
+        )
+        worker = threading.Thread(
+            target=sentry._drain_background_capture_queue,
+            args=(capture_queue,),
+            daemon=True,
+        )
+        worker.start()
+
+        try:
+            capture_queue.put((exc, "asyncio"))
+            capture_queue.join()
+            del exc
+            del payload
+            gc.collect()
+
+            assert payload_ref() is None
+        finally:
+            capture_queue.put(sentry._BACKGROUND_CAPTURE_STOP)
+            capture_queue.join()
+            worker.join(timeout=1)
 
     def test_flush_timeout_does_not_wait_for_in_flight_delivery(
         self, installed_sentry_hooks, monkeypatch


### PR DESCRIPTION
## Summary

- replace global first-chance tracing with last-chance main-thread, worker-thread, asyncio, and unraisable exception hooks while chaining pre-existing handlers
- attribute SDK ownership from the resolved installed package root, not path substrings, and send only sanitized exception metadata plus SDK-relative frames
- preserve every reportable `ExceptionGroup` leaf in one structured event on Python 3.10+, with no unbounded request fan-out
- deliver hook events through a bounded, non-blocking background queue with an explicit best-effort flush deadline

This fixes the reporting boundary rather than special-casing `404` or `UnexpectedStatus`: caller-handled SDK exceptions are no longer reported as SDK defects, while genuinely unhandled SDK failures remain visible. It refreshes the architectural direction from #164 on current `main`.

## Before / after

| Behavior | Current SDK | This change |
| --- | --- | --- |
| Caller-handled job `404` | 1 capture | 0 captures |
| Six absent optional integrations | 0 captures | 0 captures |
| Genuine unhandled SDK failure | 1 capture | 1 sanitized capture |
| Abandoned asyncio task / unraisable SDK failure | not covered | 1 sanitized capture |
| Global Python tracing | installed | not installed |

The recurring deleted-job request tracked in ENG-3990 remains an operational configuration issue; this change prevents a handled response from being misclassified as an SDK defect.

## Verification

- `ruff check .`
- changed-file `ruff format --check`
- changed-file Pyright targeting Python 3.10
- 372 unit tests on the exact #195-stacked ref
- wheel and sdist build
- fresh-wheel behavioral smoke on the current stacked ref; standalone wheel smokes also passed on Python 3.10, 3.12, and 3.14

Depends on #195 only for the repository-wide framework CI repair; against that base, this PR remains the three-file Sentry change.

Primary: [ENG-4038](https://linear.app/blaxel/issue/ENG-4038). Related producer cleanup: [ENG-3990](https://linear.app/blaxel/issue/ENG-3990), [ENG-3989](https://linear.app/blaxel/issue/ENG-3989).

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds explicit clearing of frame-local references (`item`, `exc_value`, `mechanism_type`) in `_drain_background_capture_queue` after `task_done()`, preventing the background worker from keeping the last delivered exception alive indefinitely while blocked on the next `queue.get()`. Includes a `weakref`-based test verifying the GC behavior.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3cadbb747201d54d5dc535d8ff1c76ccad51658c.</sup>
<!-- /MENDRAL_SUMMARY -->

