### PR TITLE
fix: restore framework integration compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ llamaindex = [
 pydantic = ["pydantic-ai>=1.0.8"]
 
 # Google ADK module
-googleadk = ["google-adk>=1.4.0", "litellm>=1.63.11"]
+googleadk = ["google-adk>=1.4.0", "litellm>=1.63.11", "orjson>=3.11.6,<4.0"]
 
 # Development dependencies
 dev = ["ruff", "pyright", "pytest", "uv"]

--- a/src/blaxel/pydantic/tools.py
+++ b/src/blaxel/pydantic/tools.py
@@ -73,6 +73,7 @@ def get_pydantic_tool(tool: Tool) -> PydanticTool:
         description=tool.description,
         prepare=prepare_tool,
         takes_ctx=False,
+        strict=False,
     )
 
 

--- a/tests/core/test_integration_cleanup.py
+++ b/tests/core/test_integration_cleanup.py
@@ -1,0 +1,60 @@
+"""Regression tests for the Core integration cleanup safeguards."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from blaxel.core.client.models.get_workspace_features_response_200 import (
+    GetWorkspaceFeaturesResponse200,
+)
+from tests.integration.core.conftest import (
+    _TEST_RESOURCE_LABELS,
+    _is_test_resource,
+    _resource_labels,
+)
+from tests.integration.core.sandbox import test_volumes
+
+
+def test_lite_volume_without_labels_is_not_treated_as_a_test_resource():
+    listed_volume = SimpleNamespace(metadata=SimpleNamespace(name="volume-from-list"))
+
+    assert _resource_labels(listed_volume) == {}
+    assert _is_test_resource(listed_volume) is False
+
+
+def test_cleanup_requires_all_exact_test_labels():
+    exact_match = SimpleNamespace(
+        metadata=SimpleNamespace(
+            labels={
+                **_TEST_RESOURCE_LABELS,
+                "extra": "allowed",
+            }
+        )
+    )
+    partial_labels = _TEST_RESOURCE_LABELS.copy()
+    partial_labels.pop("created-by")
+    partial_match = SimpleNamespace(metadata=SimpleNamespace(labels=partial_labels))
+
+    assert _is_test_resource(exact_match) is True
+    assert _is_test_resource(partial_match) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("features", "expected"),
+    [
+        ({}, False),
+        ({"generation_mk31": True}, True),
+    ],
+)
+async def test_workspace_feature_detection_uses_the_live_feature_map(
+    monkeypatch, features, expected
+):
+    response = GetWorkspaceFeaturesResponse200.from_dict({"features": features})
+
+    async def get_features(*, client):
+        return response
+
+    monkeypatch.setattr(test_volumes, "get_workspace_features", get_features)
+
+    assert await test_volumes._workspace_feature_enabled("generation_mk31") is expected

--- a/tests/core/test_pydantic_tools.py
+++ b/tests/core/test_pydantic_tools.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from blaxel.core.tools.types import Tool
 from blaxel.pydantic import tools as pydantic_tools
 
 
@@ -11,6 +12,38 @@ class _DummyBlTools:
 
     def get_tools(self):
         return []
+
+
+@pytest.mark.asyncio
+async def test_pydantic_tools_mark_external_schemas_as_non_strict():
+    async def invoke(**_kwargs):
+        return None
+
+    tool = Tool(
+        name="codegenParallelApply",
+        description="Apply code edits in parallel",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "editRegions": {
+                    "type": ["null", "array"],
+                    "items": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "additionalProperties": False,
+                    },
+                }
+            },
+        },
+        coroutine=invoke,
+    )
+
+    converted = pydantic_tools.get_pydantic_tool(tool)
+    assert converted.prepare is not None
+    prepared = await converted.prepare(None, converted.tool_def)
+
+    assert prepared is not None
+    assert prepared.strict is False
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_pydantic_tools.py
+++ b/tests/core/test_pydantic_tools.py
@@ -1,6 +1,10 @@
 """Tests for the Pydantic AI tools wrapper."""
 
+import inspect
+from typing import cast
+
 import pytest
+from pydantic_ai import RunContext
 
 from blaxel.core.tools.types import Tool
 from blaxel.pydantic import tools as pydantic_tools
@@ -40,7 +44,10 @@ async def test_pydantic_tools_mark_external_schemas_as_non_strict():
 
     converted = pydantic_tools.get_pydantic_tool(tool)
     assert converted.prepare is not None
-    prepared = await converted.prepare(None, converted.tool_def)
+    context = cast(RunContext[object], object())
+    prepared = converted.prepare(context, converted.tool_def)
+    if inspect.isawaitable(prepared):
+        prepared = await prepared
 
     assert prepared is not None
     assert prepared.strict is False

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -13,10 +13,25 @@ env = os.environ.get("BL_ENV", "prod")
 default_region = "eu-dub-1" if env == "dev" else "us-pdx-1"
 default_image = "blaxel/base-image:latest"
 
-# Default labels to identify test sandboxes in the UI
+# Default labels identify both the test owner and this specific test job. The
+# run label prevents one CI job's cleanup from deleting another job's resources
+# when they share a workspace.
+_test_run_id = (
+    "-".join(
+        part
+        for part in (
+            os.environ.get("GITHUB_RUN_ID"),
+            os.environ.get("GITHUB_JOB"),
+            os.environ.get("GITHUB_RUN_ATTEMPT"),
+        )
+        if part
+    )
+    or f"local-{os.getpid()}"
+)
 default_labels = {
     "env": "integration-test",
     "created-by": "pytest",
+    "test-run": _test_run_id,
 }
 
 

--- a/tests/integration/core/conftest.py
+++ b/tests/integration/core/conftest.py
@@ -2,68 +2,170 @@
 
 import asyncio
 
+import pytest
+
+from tests.helpers import default_labels
+
+_TEST_RESOURCE_LABELS = default_labels.copy()
+
+
+def _resource_labels(resource) -> dict[str, str]:
+    """Return resource labels without assuming every list projection includes them."""
+    metadata = getattr(resource, "metadata", None)
+    labels = getattr(metadata, "labels", None)
+    if isinstance(labels, dict):
+        return labels
+    return getattr(labels, "additional_properties", {}) or {}
+
+
+def _is_test_resource(resource) -> bool:
+    labels = _resource_labels(resource)
+    return all(labels.get(key) == value for key, value in _TEST_RESOURCE_LABELS.items())
+
+
+def _api_error(response) -> str | None:
+    """Describe generated API error responses while accepting successful models."""
+    from blaxel.core.client.models.error import Error
+
+    if not isinstance(response, Error):
+        return None
+    return f"{response.code}: {response.error}"
+
 
 def pytest_sessionfinish(session, exitstatus):
     """Clean up all test sandboxes after the test session ends.
 
     With pytest-xdist, this only runs on the master node after all workers finish.
     """
-    # Skip cleanup on worker nodes (pytest-xdist)
-    # Workers have workerinput attribute, master doesn't
+    # Skip cleanup on worker nodes (pytest-xdist). Workers have workerinput;
+    # the master process does not.
     if hasattr(session.config, "workerinput"):
         return
 
+    from blaxel.core.client.api.volumes.list_volumes import asyncio as list_volumes
     from blaxel.core.client.client import client
+    from blaxel.core.client.pagination import get_page_data, get_page_meta, normalize_cursor
     from blaxel.core.sandbox import SandboxInstance
     from blaxel.core.volume import VolumeInstance
+    from tests.helpers import wait_for_sandbox_deletion, wait_for_volume_deletion
 
-    async def cleanup_test_resources():
-        """Delete all sandboxes and volumes with test labels."""
-        # Reset client for cleanup
+    async def list_volume_candidates():
+        """List newly written test-volume candidates with server-side search."""
+        cursor = None
+        candidates = []
+        while True:
+            response = await list_volumes(
+                client=client,
+                cursor=normalize_cursor(cursor),
+                limit=50,
+                q=_TEST_RESOURCE_LABELS["env"],
+            )
+            response_error = _api_error(response)
+            if response_error:
+                raise RuntimeError(response_error)
+            if response is None:
+                raise RuntimeError("volume list returned no response")
+
+            candidates.extend(VolumeInstance(volume) for volume in get_page_data(response))
+            meta = get_page_meta(response)
+            if not bool(getattr(meta, "has_more", False)):
+                return candidates
+
+            next_cursor = getattr(meta, "next_cursor", None)
+            if not isinstance(next_cursor, str) or not next_cursor:
+                raise RuntimeError("volume list said it has more results without a next cursor")
+            cursor = next_cursor
+
+    async def cleanup_test_resources() -> list[str]:
+        """Delete resources with the exact integration-test labels."""
+        # Reset the shared client so cleanup gets an event-loop-local client.
         client._async_client = None
 
         print("\n🧹 Cleaning up test resources...")
+        deleted_sandboxes = 0
+        deleted_volumes = 0
+        cleanup_errors: list[str] = []
 
-        # Clean up sandboxes with test labels
+        # Collect every matching sandbox before deleting so cursor pagination is
+        # not mutated underneath the scan.
         try:
-            sandboxes = await SandboxInstance.list()
-            for sb in sandboxes:
-                labels = sb.metadata.labels
-                # Labels are stored in additional_properties of MetadataLabels object
-                if labels is not None:
-                    props = getattr(labels, "additional_properties", {}) or {}
-                    if props.get("env") == "integration-test":
-                        try:
-                            await sb.delete()
-                        except Exception:
-                            pass
-        except Exception as e:
-            print(f"  Error listing sandboxes: {e}")
+            sandbox_page = await SandboxInstance.list()
+            sandboxes = [
+                sandbox
+                async for sandbox in sandbox_page.auto_paging_iter()
+                if _is_test_resource(sandbox)
+            ]
+        except Exception as error:
+            cleanup_errors.append(f"listing sandboxes: {error}")
+            sandboxes = []
 
-        # Clean up volumes with test labels
+        for sandbox in sandboxes:
+            name = sandbox.metadata.name
+            try:
+                delete_error = _api_error(await sandbox.delete())
+                if delete_error:
+                    cleanup_errors.append(f"deleting sandbox {name}: {delete_error}")
+                    continue
+                if not await wait_for_sandbox_deletion(name):
+                    cleanup_errors.append(f"deleting sandbox {name}: timed out")
+                    continue
+                deleted_sandboxes += 1
+            except Exception as error:
+                cleanup_errors.append(f"deleting sandbox {name}: {error}")
+
+        # Volume list responses intentionally use LiteVolumeMetadata, which has
+        # no labels. Search narrows the scan to newly written rows whose haystack
+        # contains the test label, then GET provides labels for an exact match.
+        # Collect every page before deleting so pagination is not mutated.
         try:
-            volumes = await VolumeInstance.list()
-            for vol in volumes:
-                labels = vol.metadata.labels if hasattr(vol, "metadata") and vol.metadata else None
-                # Labels are stored in additional_properties of MetadataLabels object
-                if labels is not None:
-                    props = getattr(labels, "additional_properties", {}) or {}
-                    if props.get("env") == "integration-test":
-                        try:
-                            await vol.delete()  # type: ignore[attr-defined]
-                        except Exception:
-                            pass
-        except Exception as e:
-            print(f"  Error listing volumes: {e}")
+            listed_volumes = await list_volume_candidates()
+        except Exception as error:
+            cleanup_errors.append(f"listing volumes: {error}")
+            listed_volumes = []
 
-        # Close the client
-        if client._async_client is not None:
-            client._async_client = None
+        volumes = []
+        for listed_volume in listed_volumes:
+            name = listed_volume.name
+            if not isinstance(name, str) or not name:
+                cleanup_errors.append("inspecting volume: list response omitted its name")
+                continue
+            try:
+                volume = await VolumeInstance.get(name)
+            except Exception as error:
+                cleanup_errors.append(f"inspecting volume {name}: {error}")
+                continue
+            if _is_test_resource(volume):
+                volumes.append(volume)
 
-        print("✅ Cleanup complete!")
+        for volume in volumes:
+            name = volume.name
+            try:
+                delete_error = _api_error(await volume.delete())
+                if delete_error:
+                    cleanup_errors.append(f"deleting volume {name}: {delete_error}")
+                    continue
+                if not await wait_for_volume_deletion(name):
+                    cleanup_errors.append(f"deleting volume {name}: timed out")
+                    continue
+                deleted_volumes += 1
+            except Exception as error:
+                cleanup_errors.append(f"deleting volume {name}: {error}")
 
-    # Run cleanup in a new event loop
+        # Discard the loop-bound client after cleanup.
+        client._async_client = None
+
+        print(f"  Deleted {deleted_sandboxes} sandbox(es) and {deleted_volumes} volume(s).")
+        return cleanup_errors
+
     try:
-        asyncio.run(cleanup_test_resources())
-    except Exception as e:
-        print(f"⚠️ Cleanup error: {e}")
+        cleanup_errors = asyncio.run(cleanup_test_resources())
+    except Exception as error:
+        cleanup_errors = [f"cleanup crashed: {error}"]
+
+    if cleanup_errors:
+        for error in cleanup_errors:
+            print(f"  Cleanup error: {error}")
+        print("❌ Cleanup incomplete.")
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+    else:
+        print("✅ Cleanup complete!")

--- a/tests/integration/core/sandbox/test_volumes.py
+++ b/tests/integration/core/sandbox/test_volumes.py
@@ -1,9 +1,16 @@
 import asyncio
+import os
 import time
 
 import pytest
 import pytest_asyncio
 
+from blaxel.core.client.api.workspaces.get_workspace_features import (
+    asyncio as get_workspace_features,
+)
+from blaxel.core.client.client import client
+from blaxel.core.client.models.error import Error
+from blaxel.core.client.types import Unset
 from blaxel.core.sandbox import SandboxInstance
 from blaxel.core.volume import VolumeInstance
 from tests.helpers import (
@@ -15,6 +22,25 @@ from tests.helpers import (
     wait_for_volume_deletion,
 )
 
+_MK31_FEATURE = "generation_mk31"
+_REQUIRE_MK31_ENV = "BL_REQUIRE_GENERATION_MK31"
+
+
+async def _workspace_feature_enabled(feature: str) -> bool:
+    response = await get_workspace_features(client=client)
+    if response is None:
+        pytest.fail(f"Could not determine whether workspace feature {feature!r} is enabled")
+    if isinstance(response, Error):
+        pytest.fail(
+            f"Could not determine whether workspace feature {feature!r} is enabled: "
+            f"{response.code}: {response.error}"
+        )
+
+    features = response.features
+    if isinstance(features, Unset) or features is None:
+        return False
+    return features.additional_properties.get(feature) is True
+
 
 class TestVolumeOperations:
     """Base class for volume tests with cleanup tracking."""
@@ -23,7 +49,8 @@ class TestVolumeOperations:
     created_volumes: list[str] = []
 
     @pytest_asyncio.fixture(autouse=True, scope="class", loop_scope="class")
-    async def cleanup(self, request):
+    @classmethod
+    async def cleanup(cls, request):
         """Clean up all resources after each test class."""
         # Reset lists for this class
         request.cls.created_sandboxes = []
@@ -32,31 +59,39 @@ class TestVolumeOperations:
         yield
 
         # Clean up sandboxes first (they depend on volumes)
-        await asyncio.gather(
-            *[self._safe_delete_sandbox(name) for name in request.cls.created_sandboxes],
+        cleanup_results = await asyncio.gather(
+            *[cls._safe_delete_sandbox(name) for name in request.cls.created_sandboxes],
             return_exceptions=True,
         )
 
         # Then clean up volumes
-        await asyncio.gather(
-            *[self._safe_delete_volume(name) for name in request.cls.created_volumes],
-            return_exceptions=True,
+        cleanup_results.extend(
+            await asyncio.gather(
+                *[cls._safe_delete_volume(name) for name in request.cls.created_volumes],
+                return_exceptions=True,
+            )
         )
 
-    async def _safe_delete_sandbox(self, name: str) -> None:
-        """Safely delete a sandbox, ignoring errors."""
-        try:
-            await SandboxInstance.delete(name)
-            await wait_for_sandbox_deletion(name)
-        except Exception:
-            pass
+        cleanup_errors = [result for result in cleanup_results if isinstance(result, BaseException)]
+        if cleanup_errors:
+            pytest.fail(
+                "Tracked resource cleanup failed:\n"
+                + "\n".join(f"- {type(error).__name__}: {error}" for error in cleanup_errors)
+            )
 
-    async def _safe_delete_volume(self, name: str) -> None:
-        """Safely delete a volume, ignoring errors."""
-        try:
-            await VolumeInstance.delete(name)
-        except Exception:
-            pass
+    @staticmethod
+    async def _safe_delete_sandbox(name: str) -> None:
+        """Delete a tracked sandbox and verify that deletion completes."""
+        await SandboxInstance.delete(name)
+        if not await wait_for_sandbox_deletion(name):
+            raise AssertionError(f"Timed out deleting sandbox {name}")
+
+    @staticmethod
+    async def _safe_delete_volume(name: str) -> None:
+        """Delete a tracked volume and verify that deletion completes."""
+        await VolumeInstance.delete(name)
+        if not await wait_for_volume_deletion(name):
+            raise AssertionError(f"Timed out deleting volume {name}")
 
 
 @pytest.mark.asyncio(loop_scope="class")
@@ -214,6 +249,15 @@ class TestEphemeralVolumes(TestVolumeOperations):
 
     async def test_creates_sandbox_with_ephemeral_volume(self):
         """An ephemeral volume mounts as scratch space without a Volume resource."""
+        if not await _workspace_feature_enabled(_MK31_FEATURE):
+            message = (
+                "ephemeral volumes require the generation_mk31 workspace feature; "
+                f"set {_REQUIRE_MK31_ENV}=1 in the MK3.1 lane to make absence a failure"
+            )
+            if os.environ.get(_REQUIRE_MK31_ENV) == "1":
+                pytest.fail(message)
+            pytest.skip(message)
+
         sandbox_name = unique_name("ephemeral-sandbox")
 
         sandbox = await SandboxInstance.create(
@@ -236,12 +280,13 @@ class TestEphemeralVolumes(TestVolumeOperations):
         self.created_sandboxes.append(sandbox_name)
 
         # Verify the scratch disk is mounted and writable.
-        await sandbox.process.exec(
+        write_result = await sandbox.process.exec(
             {
                 "command": "echo 'ephemeral' > /scratch/test.txt",
                 "wait_for_completion": True,
             }
         )
+        assert write_result.exit_code == 0, write_result.logs
 
         result = await sandbox.process.exec(
             {
@@ -285,6 +330,7 @@ class TestVolumeResize(TestVolumeOperations):
                 "labels": default_labels,
             }
         )
+        self.created_sandboxes.append(sandbox1_name)
 
         # Write ~400MB of data to the volume
         await sandbox1.process.exec(
@@ -321,7 +367,8 @@ class TestVolumeResize(TestVolumeOperations):
 
         # Delete first sandbox
         await SandboxInstance.delete(sandbox1_name)
-        await wait_for_sandbox_deletion(sandbox1_name)
+        assert await wait_for_sandbox_deletion(sandbox1_name)
+        self.created_sandboxes.remove(sandbox1_name)
 
         # Resize volume to 1GB
         updated_volume = await VolumeInstance.update(volume_name, {"size": 1024})
@@ -467,6 +514,7 @@ class TestVolumePersistence(TestVolumeOperations):
                 "labels": default_labels,
             }
         )
+        self.created_sandboxes.append(sandbox1_name)
 
         await sandbox1.process.exec(
             {
@@ -477,7 +525,8 @@ class TestVolumePersistence(TestVolumeOperations):
 
         # Delete first sandbox and wait for full deletion
         await SandboxInstance.delete(sandbox1_name)
-        await wait_for_sandbox_deletion(sandbox1_name)
+        assert await wait_for_sandbox_deletion(sandbox1_name)
+        self.created_sandboxes.remove(sandbox1_name)
 
         # Second sandbox - read data
         sandbox2_name = unique_name("persist-2")


### PR DESCRIPTION
## Summary

Restore the deterministic framework integration lanes and make the shared Core gate report the workspace's real capabilities:

- mark externally supplied Pydantic MCP tool schemas as non-strict, preventing Pydantic AI from incorrectly inferring OpenAI strict mode after the adapter's non-strict schema cleanup
- include LiteLLM 1.92's newly required `orjson` runtime dependency in the `googleadk` extra without pulling the unrelated `litellm[proxy]` stack
- run the ephemeral-volume test only when the workspace advertises `generation_mk31`; the dedicated MK3.1 lane can set `BL_REQUIRE_GENERATION_MK31=1` so an absent capability fails instead of becoming a permanent skip
- assert the scratch-volume write succeeded before reading it
- make resource cleanup exact-run scoped, pagination-safe, and failure-reporting; volume labels are resolved through GET because list responses intentionally return `LiteVolumeMetadata` without labels

These are owning-layer compatibility and test-truth fixes. No SDK production errors are hidden, no retries are broadened, and no product behavior is weakened. The framework fixes are grouped because both are required to restore the same integration matrix and otherwise block each other's PR.

## Verification

- 351 unit tests passed on exact head `c3f13ad`
- repository Ruff lint passed; changed-file Ruff format passed
- `make build` injected the exact full head SHA in an isolated clean worktree
- exact-head wheel and sdist built successfully
- fresh exact-head wheel with `googleadk` installed `orjson` and imported `blaxel.googleadk`, LiteLLM, and orjson
- Pydantic live integration: 3 passed
- Google ADK live integration: 4 passed
- `pydantic-ai==1.0.8` on Python 3.10: focused tests passed
- live `calibrator` MK3.0 check: ephemeral-volume test skipped before resource creation
- strict MK3.1-mode check: the same absent capability failed loudly with `BL_REQUIRE_GENERATION_MK31=1`
- disposable persistent-volume check passed and deleted its exact resource; post-check found zero pytest-labeled volumes

Tracks [ENG-3523](https://linear.app/blaxel/issue/ENG-3523) and [ENG-3998](https://linear.app/blaxel/issue/ENG-3998).

This PR is the shared CI prerequisite for #194 and #199. Their implementation diffs remain separate when based on this branch.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds test infrastructure hardening: run-scoped resource labels to prevent cross-job cleanup interference, paginated volume cleanup with error reporting, MK3.1 feature-gated ephemeral volume tests, and deterministic unit tests for the cleanup safeguards.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c3f13ad7d83af5dc01370586e6b02cfd9140c604.</sup>
<!-- /MENDRAL_SUMMARY -->
