### PR TITLE
fix(client): type undocumented 409 and 429 responses (ENG-4050)

### DIFF
--- a/src/blaxel/core/client/api/agents/create_agent.py
+++ b/src/blaxel/core/client/api/agents/create_agent.py
@@ -59,7 +59,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Agent,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/agents/delete_agent.py
+++ b/src/blaxel/core/client/api/agents/delete_agent.py
@@ -43,7 +43,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Agent,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/agents/get_agent.py
+++ b/src/blaxel/core/client/api/agents/get_agent.py
@@ -52,7 +52,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Agent,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/agents/list_agent_revisions.py
+++ b/src/blaxel/core/client/api/agents/list_agent_revisions.py
@@ -31,7 +31,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Revisi
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/agents/list_agents.py
+++ b/src/blaxel/core/client/api/agents/list_agents.py
@@ -69,7 +69,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[AgentL
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/agents/update_agent.py
+++ b/src/blaxel/core/client/api/agents/update_agent.py
@@ -60,7 +60,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Agent,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/applications/create_application.py
+++ b/src/blaxel/core/client/api/applications/create_application.py
@@ -61,7 +61,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/applications/delete_application.py
+++ b/src/blaxel/core/client/api/applications/delete_application.py
@@ -45,7 +45,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/applications/get_application.py
+++ b/src/blaxel/core/client/api/applications/get_application.py
@@ -45,7 +45,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/applications/list_application_revisions.py
+++ b/src/blaxel/core/client/api/applications/list_application_revisions.py
@@ -31,7 +31,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Revisi
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/applications/list_applications.py
+++ b/src/blaxel/core/client/api/applications/list_applications.py
@@ -71,7 +71,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/applications/update_application.py
+++ b/src/blaxel/core/client/api/applications/update_application.py
@@ -62,7 +62,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/create_sandbox.py
+++ b/src/blaxel/core/client/api/compute/create_sandbox.py
@@ -69,7 +69,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/create_sandbox_preview.py
+++ b/src/blaxel/core/client/api/compute/create_sandbox_preview.py
@@ -47,7 +47,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Preview | No
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/create_sandbox_preview_token.py
+++ b/src/blaxel/core/client/api/compute/create_sandbox_preview_token.py
@@ -40,7 +40,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> PreviewToken
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/create_sandbox_schedule.py
+++ b/src/blaxel/core/client/api/compute/create_sandbox_schedule.py
@@ -39,7 +39,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> SandboxSched
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/delete_sandbox.py
+++ b/src/blaxel/core/client/api/compute/delete_sandbox.py
@@ -43,7 +43,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/delete_sandbox_preview.py
+++ b/src/blaxel/core/client/api/compute/delete_sandbox_preview.py
@@ -27,7 +27,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Preview | No
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/delete_sandbox_preview_token.py
+++ b/src/blaxel/core/client/api/compute/delete_sandbox_preview_token.py
@@ -30,7 +30,7 @@ def _parse_response(
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/delete_sandbox_schedule.py
+++ b/src/blaxel/core/client/api/compute/delete_sandbox_schedule.py
@@ -27,7 +27,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> SandboxSched
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/get_sandbox.py
+++ b/src/blaxel/core/client/api/compute/get_sandbox.py
@@ -52,7 +52,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/get_sandbox_by_external_id.py
+++ b/src/blaxel/core/client/api/compute/get_sandbox_by_external_id.py
@@ -43,7 +43,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/get_sandbox_preview.py
+++ b/src/blaxel/core/client/api/compute/get_sandbox_preview.py
@@ -27,7 +27,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Preview | No
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/get_sandbox_schedule.py
+++ b/src/blaxel/core/client/api/compute/get_sandbox_schedule.py
@@ -27,7 +27,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> SandboxSched
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/list_sandbox_preview_tokens.py
+++ b/src/blaxel/core/client/api/compute/list_sandbox_preview_tokens.py
@@ -32,7 +32,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Previe
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/list_sandbox_previews.py
+++ b/src/blaxel/core/client/api/compute/list_sandbox_previews.py
@@ -31,7 +31,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Previe
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/list_sandbox_schedule_executions.py
+++ b/src/blaxel/core/client/api/compute/list_sandbox_schedule_executions.py
@@ -51,7 +51,7 @@ def _parse_response(
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/list_sandbox_schedules.py
+++ b/src/blaxel/core/client/api/compute/list_sandbox_schedules.py
@@ -57,7 +57,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> SandboxSched
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/list_sandboxes.py
+++ b/src/blaxel/core/client/api/compute/list_sandboxes.py
@@ -77,7 +77,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/update_sandbox.py
+++ b/src/blaxel/core/client/api/compute/update_sandbox.py
@@ -60,7 +60,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/update_sandbox_preview.py
+++ b/src/blaxel/core/client/api/compute/update_sandbox_preview.py
@@ -40,7 +40,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Preview | No
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/compute/update_sandbox_schedule.py
+++ b/src/blaxel/core/client/api/compute/update_sandbox_schedule.py
@@ -40,7 +40,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> SandboxSched
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/configurations/get_configuration.py
+++ b/src/blaxel/core/client/api/configurations/get_configuration.py
@@ -24,7 +24,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Configuratio
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/customdomains/create_application_custom_domain.py
+++ b/src/blaxel/core/client/api/customdomains/create_application_custom_domain.py
@@ -39,7 +39,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> CustomDomain
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/customdomains/create_custom_domain.py
+++ b/src/blaxel/core/client/api/customdomains/create_custom_domain.py
@@ -38,7 +38,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> CustomDomain
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/customdomains/delete_custom_domain.py
+++ b/src/blaxel/core/client/api/customdomains/delete_custom_domain.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> CustomDomain
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/customdomains/get_custom_domain.py
+++ b/src/blaxel/core/client/api/customdomains/get_custom_domain.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> CustomDomain
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/customdomains/list_custom_domains.py
+++ b/src/blaxel/core/client/api/customdomains/list_custom_domains.py
@@ -29,7 +29,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Custom
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/customdomains/update_custom_domain.py
+++ b/src/blaxel/core/client/api/customdomains/update_custom_domain.py
@@ -39,7 +39,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> CustomDomain
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/customdomains/verify_custom_domain.py
+++ b/src/blaxel/core/client/api/customdomains/verify_custom_domain.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> CustomDomain
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/default/get_template.py
+++ b/src/blaxel/core/client/api/default/get_template.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Template | N
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/drives/create_drive.py
+++ b/src/blaxel/core/client/api/drives/create_drive.py
@@ -41,7 +41,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, D
         response_401 = cast(Any, None)
         return response_401
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/drives/create_drive_access_token.py
+++ b/src/blaxel/core/client/api/drives/create_drive_access_token.py
@@ -37,7 +37,7 @@ def _parse_response(
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/drives/delete_drive.py
+++ b/src/blaxel/core/client/api/drives/delete_drive.py
@@ -34,7 +34,7 @@ def _parse_response(
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/drives/get_drive.py
+++ b/src/blaxel/core/client/api/drives/get_drive.py
@@ -32,7 +32,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, D
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/drives/get_drive_jwks.py
+++ b/src/blaxel/core/client/api/drives/get_drive_jwks.py
@@ -24,7 +24,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> GetDriveJWKS
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/drives/list_drives.py
+++ b/src/blaxel/core/client/api/drives/list_drives.py
@@ -59,7 +59,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, D
         response_401 = cast(Any, None)
         return response_401
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/drives/update_drive.py
+++ b/src/blaxel/core/client/api/drives/update_drive.py
@@ -45,7 +45,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, D
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/feature_flags/test_feature_flag.py
+++ b/src/blaxel/core/client/api/feature_flags/test_feature_flag.py
@@ -50,7 +50,7 @@ def _parse_response(
 
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/functions/create_function.py
+++ b/src/blaxel/core/client/api/functions/create_function.py
@@ -59,7 +59,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/functions/delete_function.py
+++ b/src/blaxel/core/client/api/functions/delete_function.py
@@ -43,7 +43,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/functions/get_function.py
+++ b/src/blaxel/core/client/api/functions/get_function.py
@@ -52,7 +52,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/functions/list_function_revisions.py
+++ b/src/blaxel/core/client/api/functions/list_function_revisions.py
@@ -31,7 +31,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Revisi
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/functions/list_functions.py
+++ b/src/blaxel/core/client/api/functions/list_functions.py
@@ -71,7 +71,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/functions/update_function.py
+++ b/src/blaxel/core/client/api/functions/update_function.py
@@ -60,7 +60,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/images/accept_image_share.py
+++ b/src/blaxel/core/client/api/images/accept_image_share.py
@@ -47,7 +47,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, I
         response_410 = cast(Any, None)
         return response_410
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/images/cleanup_images.py
+++ b/src/blaxel/core/client/api/images/cleanup_images.py
@@ -24,7 +24,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> CleanupImage
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/images/create_image.py
+++ b/src/blaxel/core/client/api/images/create_image.py
@@ -44,7 +44,7 @@ def _parse_response(
         response_400 = cast(Any, None)
         return response_400
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/images/decline_image_share.py
+++ b/src/blaxel/core/client/api/images/decline_image_share.py
@@ -27,7 +27,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Any | None:
     if response.status_code == 404:
         return None
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/images/delete_image.py
+++ b/src/blaxel/core/client/api/images/delete_image.py
@@ -33,7 +33,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, I
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/images/delete_image_tag.py
+++ b/src/blaxel/core/client/api/images/delete_image_tag.py
@@ -34,7 +34,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, I
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/images/get_image.py
+++ b/src/blaxel/core/client/api/images/get_image.py
@@ -27,7 +27,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Image | None
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/images/list_image_shares.py
+++ b/src/blaxel/core/client/api/images/list_image_shares.py
@@ -37,7 +37,7 @@ def _parse_response(
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/images/list_images.py
+++ b/src/blaxel/core/client/api/images/list_images.py
@@ -29,7 +29,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Image"
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/images/list_pending_image_shares.py
+++ b/src/blaxel/core/client/api/images/list_pending_image_shares.py
@@ -46,7 +46,7 @@ def _parse_response(
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/images/share_image.py
+++ b/src/blaxel/core/client/api/images/share_image.py
@@ -57,7 +57,7 @@ def _parse_response(
         response_409 = cast(Any, None)
         return response_409
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/images/unshare_image.py
+++ b/src/blaxel/core/client/api/images/unshare_image.py
@@ -31,7 +31,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, I
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/integrations/create_integration_connection.py
+++ b/src/blaxel/core/client/api/integrations/create_integration_connection.py
@@ -61,7 +61,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/integrations/delete_integration_connection.py
+++ b/src/blaxel/core/client/api/integrations/delete_integration_connection.py
@@ -49,7 +49,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/integrations/get_integration.py
+++ b/src/blaxel/core/client/api/integrations/get_integration.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Integration 
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/integrations/get_integration_connection.py
+++ b/src/blaxel/core/client/api/integrations/get_integration_connection.py
@@ -45,7 +45,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/integrations/get_integration_connection_model.py
+++ b/src/blaxel/core/client/api/integrations/get_integration_connection_model.py
@@ -24,7 +24,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Any | None:
     if response.status_code == 200:
         return None
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/integrations/get_integration_connection_model_endpoint_configurations.py
+++ b/src/blaxel/core/client/api/integrations/get_integration_connection_model_endpoint_configurations.py
@@ -23,7 +23,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Any | None:
     if response.status_code == 200:
         return None
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/integrations/list_integration_connection_models.py
+++ b/src/blaxel/core/client/api/integrations/list_integration_connection_models.py
@@ -23,7 +23,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Any | None:
     if response.status_code == 200:
         return None
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/integrations/list_integration_connections.py
+++ b/src/blaxel/core/client/api/integrations/list_integration_connections.py
@@ -44,7 +44,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/integrations/update_integration_connection.py
+++ b/src/blaxel/core/client/api/integrations/update_integration_connection.py
@@ -62,7 +62,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/jobs/create_job.py
+++ b/src/blaxel/core/client/api/jobs/create_job.py
@@ -38,7 +38,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Job | None:
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/jobs/create_job_execution.py
+++ b/src/blaxel/core/client/api/jobs/create_job_execution.py
@@ -48,7 +48,7 @@ def _parse_response(
         response_500 = cast(Any, None)
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/jobs/delete_job.py
+++ b/src/blaxel/core/client/api/jobs/delete_job.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Job | None:
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/jobs/delete_job_execution.py
+++ b/src/blaxel/core/client/api/jobs/delete_job_execution.py
@@ -36,7 +36,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, J
         response_500 = cast(Any, None)
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/jobs/get_job.py
+++ b/src/blaxel/core/client/api/jobs/get_job.py
@@ -35,7 +35,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Job | None:
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/jobs/get_job_execution.py
+++ b/src/blaxel/core/client/api/jobs/get_job_execution.py
@@ -36,7 +36,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, J
         response_500 = cast(Any, None)
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/jobs/list_job_execution_tasks.py
+++ b/src/blaxel/core/client/api/jobs/list_job_execution_tasks.py
@@ -61,7 +61,7 @@ def _parse_response(
         response_500 = cast(Any, None)
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/jobs/list_job_executions.py
+++ b/src/blaxel/core/client/api/jobs/list_job_executions.py
@@ -60,7 +60,7 @@ def _parse_response(
         response_500 = cast(Any, None)
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/jobs/list_job_revisions.py
+++ b/src/blaxel/core/client/api/jobs/list_job_revisions.py
@@ -31,7 +31,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Revisi
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/jobs/list_jobs.py
+++ b/src/blaxel/core/client/api/jobs/list_jobs.py
@@ -56,7 +56,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> JobList | No
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/jobs/update_job.py
+++ b/src/blaxel/core/client/api/jobs/update_job.py
@@ -39,7 +39,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Job | None:
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/locations/list_locations.py
+++ b/src/blaxel/core/client/api/locations/list_locations.py
@@ -29,7 +29,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Locati
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/mcphub/list_mcp_hub_definitions.py
+++ b/src/blaxel/core/client/api/mcphub/list_mcp_hub_definitions.py
@@ -29,7 +29,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["MCPDef
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/models/create_model.py
+++ b/src/blaxel/core/client/api/models/create_model.py
@@ -59,7 +59,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/models/delete_model.py
+++ b/src/blaxel/core/client/api/models/delete_model.py
@@ -43,7 +43,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/models/get_model.py
+++ b/src/blaxel/core/client/api/models/get_model.py
@@ -43,7 +43,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/models/list_model_revisions.py
+++ b/src/blaxel/core/client/api/models/list_model_revisions.py
@@ -31,7 +31,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Revisi
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/models/list_models.py
+++ b/src/blaxel/core/client/api/models/list_models.py
@@ -69,7 +69,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/models/update_model.py
+++ b/src/blaxel/core/client/api/models/update_model.py
@@ -60,7 +60,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/policies/create_policy.py
+++ b/src/blaxel/core/client/api/policies/create_policy.py
@@ -38,7 +38,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Policy | Non
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/policies/delete_policy.py
+++ b/src/blaxel/core/client/api/policies/delete_policy.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Policy | Non
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/policies/get_policy.py
+++ b/src/blaxel/core/client/api/policies/get_policy.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Policy | Non
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/policies/get_policy_usages.py
+++ b/src/blaxel/core/client/api/policies/get_policy_usages.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> PolicyUsages
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/policies/list_policies.py
+++ b/src/blaxel/core/client/api/policies/list_policies.py
@@ -56,7 +56,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> PolicyList |
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/policies/update_policy.py
+++ b/src/blaxel/core/client/api/policies/update_policy.py
@@ -39,7 +39,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Policy | Non
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/public_ipslist/list_public_ips.py
+++ b/src/blaxel/core/client/api/public_ipslist/list_public_ips.py
@@ -34,7 +34,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> PublicIps | 
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/sandboxhub/list_sandbox_hub_definitions.py
+++ b/src/blaxel/core/client/api/sandboxhub/list_sandbox_hub_definitions.py
@@ -31,7 +31,7 @@ def _parse_response(
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/service_accounts/create_api_key_for_service_account.py
+++ b/src/blaxel/core/client/api/service_accounts/create_api_key_for_service_account.py
@@ -40,7 +40,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> ApiKey | Non
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/service_accounts/create_workspace_service_account.py
+++ b/src/blaxel/core/client/api/service_accounts/create_workspace_service_account.py
@@ -43,7 +43,7 @@ def _parse_response(
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/service_accounts/delete_api_key_for_service_account.py
+++ b/src/blaxel/core/client/api/service_accounts/delete_api_key_for_service_account.py
@@ -24,7 +24,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Any | None:
     if response.status_code == 200:
         return None
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/service_accounts/delete_workspace_service_account.py
+++ b/src/blaxel/core/client/api/service_accounts/delete_workspace_service_account.py
@@ -30,7 +30,7 @@ def _parse_response(
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/service_accounts/get_workspace_service_accounts.py
+++ b/src/blaxel/core/client/api/service_accounts/get_workspace_service_accounts.py
@@ -35,7 +35,7 @@ def _parse_response(
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/service_accounts/list_api_keys_for_service_account.py
+++ b/src/blaxel/core/client/api/service_accounts/list_api_keys_for_service_account.py
@@ -31,7 +31,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["ApiKey
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/service_accounts/update_workspace_service_account.py
+++ b/src/blaxel/core/client/api/service_accounts/update_workspace_service_account.py
@@ -44,7 +44,7 @@ def _parse_response(
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/templates/list_templates.py
+++ b/src/blaxel/core/client/api/templates/list_templates.py
@@ -29,7 +29,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Templa
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/volume_templates/create_volume_template.py
+++ b/src/blaxel/core/client/api/volume_templates/create_volume_template.py
@@ -49,7 +49,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> VolumeTempla
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/volume_templates/delete_volume_template.py
+++ b/src/blaxel/core/client/api/volume_templates/delete_volume_template.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> VolumeTempla
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/volume_templates/delete_volume_template_version.py
+++ b/src/blaxel/core/client/api/volume_templates/delete_volume_template_version.py
@@ -37,7 +37,7 @@ def _parse_response(
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/volume_templates/get_volume_template.py
+++ b/src/blaxel/core/client/api/volume_templates/get_volume_template.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> VolumeTempla
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/volume_templates/list_volume_templates.py
+++ b/src/blaxel/core/client/api/volume_templates/list_volume_templates.py
@@ -29,7 +29,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Volume
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/volume_templates/update_volume_template.py
+++ b/src/blaxel/core/client/api/volume_templates/update_volume_template.py
@@ -50,7 +50,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> VolumeTempla
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/volumes/create_volume.py
+++ b/src/blaxel/core/client/api/volumes/create_volume.py
@@ -59,7 +59,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/volumes/delete_volume.py
+++ b/src/blaxel/core/client/api/volumes/delete_volume.py
@@ -47,7 +47,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/volumes/get_volume.py
+++ b/src/blaxel/core/client/api/volumes/get_volume.py
@@ -43,7 +43,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/volumes/list_volumes.py
+++ b/src/blaxel/core/client/api/volumes/list_volumes.py
@@ -69,7 +69,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/volumes/update_volume.py
+++ b/src/blaxel/core/client/api/volumes/update_volume.py
@@ -39,7 +39,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Volume | Non
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/create_egress_gateway.py
+++ b/src/blaxel/core/client/api/vpcs/create_egress_gateway.py
@@ -39,7 +39,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> EgressGatewa
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/create_egress_ip.py
+++ b/src/blaxel/core/client/api/vpcs/create_egress_ip.py
@@ -40,7 +40,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> EgressIP | N
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/create_vpc.py
+++ b/src/blaxel/core/client/api/vpcs/create_vpc.py
@@ -38,7 +38,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> VPC | None:
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/delete_egress_gateway.py
+++ b/src/blaxel/core/client/api/vpcs/delete_egress_gateway.py
@@ -27,7 +27,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> EgressGatewa
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/delete_egress_ip.py
+++ b/src/blaxel/core/client/api/vpcs/delete_egress_ip.py
@@ -28,7 +28,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> EgressIP | N
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/delete_vpc.py
+++ b/src/blaxel/core/client/api/vpcs/delete_vpc.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> VPC | None:
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/get_egress_gateway.py
+++ b/src/blaxel/core/client/api/vpcs/get_egress_gateway.py
@@ -27,7 +27,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> EgressGatewa
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/get_egress_gateway_usage.py
+++ b/src/blaxel/core/client/api/vpcs/get_egress_gateway_usage.py
@@ -24,7 +24,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> EgressGatewa
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/get_egress_ip.py
+++ b/src/blaxel/core/client/api/vpcs/get_egress_ip.py
@@ -28,7 +28,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> EgressIP | N
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/get_vpc.py
+++ b/src/blaxel/core/client/api/vpcs/get_vpc.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> VPC | None:
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/list_all_egress_gateways.py
+++ b/src/blaxel/core/client/api/vpcs/list_all_egress_gateways.py
@@ -29,7 +29,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Egress
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/list_all_egress_i_ps.py
+++ b/src/blaxel/core/client/api/vpcs/list_all_egress_i_ps.py
@@ -29,7 +29,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Egress
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/list_egress_gateways.py
+++ b/src/blaxel/core/client/api/vpcs/list_egress_gateways.py
@@ -31,7 +31,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Egress
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/list_egress_i_ps.py
+++ b/src/blaxel/core/client/api/vpcs/list_egress_i_ps.py
@@ -32,7 +32,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Egress
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/vpcs/list_vp_cs.py
+++ b/src/blaxel/core/client/api/vpcs/list_vp_cs.py
@@ -29,7 +29,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["VPC"] 
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/accept_workspace_invitation.py
+++ b/src/blaxel/core/client/api/workspaces/accept_workspace_invitation.py
@@ -31,7 +31,7 @@ def _parse_response(
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/check_workspace_availability.py
+++ b/src/blaxel/core/client/api/workspaces/check_workspace_availability.py
@@ -61,7 +61,7 @@ def _parse_response(
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/create_workspace.py
+++ b/src/blaxel/core/client/api/workspaces/create_workspace.py
@@ -59,7 +59,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/decline_workspace_invitation.py
+++ b/src/blaxel/core/client/api/workspaces/decline_workspace_invitation.py
@@ -26,7 +26,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> PendingInvit
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/delete_workspace.py
+++ b/src/blaxel/core/client/api/workspaces/delete_workspace.py
@@ -43,7 +43,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/get_workspace.py
+++ b/src/blaxel/core/client/api/workspaces/get_workspace.py
@@ -52,7 +52,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/get_workspace_features.py
+++ b/src/blaxel/core/client/api/workspaces/get_workspace_features.py
@@ -39,7 +39,7 @@ def _parse_response(
 
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/invite_workspace_user.py
+++ b/src/blaxel/core/client/api/workspaces/invite_workspace_user.py
@@ -47,7 +47,7 @@ def _parse_response(
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/leave_workspace.py
+++ b/src/blaxel/core/client/api/workspaces/leave_workspace.py
@@ -29,7 +29,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, W
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/list_workspace_users.py
+++ b/src/blaxel/core/client/api/workspaces/list_workspace_users.py
@@ -29,7 +29,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Worksp
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/list_workspaces.py
+++ b/src/blaxel/core/client/api/workspaces/list_workspaces.py
@@ -40,7 +40,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/remove_workspace_user.py
+++ b/src/blaxel/core/client/api/workspaces/remove_workspace_user.py
@@ -25,7 +25,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Any | None:
     if response.status_code == 404:
         return None
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/update_workspace.py
+++ b/src/blaxel/core/client/api/workspaces/update_workspace.py
@@ -60,7 +60,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Error,
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/api/workspaces/update_workspace_user_role.py
+++ b/src/blaxel/core/client/api/workspaces/update_workspace_user_role.py
@@ -48,7 +48,7 @@ def _parse_response(
         response_404 = cast(Any, None)
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/client/errors.py
+++ b/src/blaxel/core/client/errors.py
@@ -1,16 +1,159 @@
-"""Contains shared errors types that can be raised from API functions"""
+"""Contains shared error types that can be raised from API functions."""
+
+import json
+import re
+from datetime import timezone
+from email.utils import format_datetime, parsedate_to_datetime
+from http import HTTPStatus
+from typing import Any, Mapping
+
+_MAX_JSON_INSPECTION_BYTES = 64 * 1024
+_STABLE_CODE_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]{1,127}$")
+
+
+def _json_body(content: bytes) -> dict[str, Any] | None:
+    if not content or len(content) > _MAX_JSON_INSPECTION_BYTES:
+        return None
+    try:
+        value = json.loads(content)
+    except (UnicodeDecodeError, ValueError, RecursionError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _safe_body_preview(content: bytes) -> str:
+    if not content:
+        return "<empty body>"
+    return f"<response body: {len(content)} bytes>"
+
+
+def _safe_retry_after_value(value: Any) -> str | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and 0 <= value <= 9_999_999_999:
+        return str(value)
+    if not isinstance(value, str):
+        return None
+
+    value = value.strip()
+    if re.fullmatch(r"[0-9]{1,10}", value):
+        return value
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if retry_at is None or retry_at.tzinfo is None:
+        return None
+    return format_datetime(retry_at.astimezone(timezone.utc), usegmt=True)
+
+
+def _extract_error_metadata(
+    content: bytes,
+) -> tuple[str | None, bool | None, str | None]:
+    parsed = _json_body(content)
+    if parsed is None:
+        return None, None, None
+
+    nested_error = parsed.get("error")
+    sources = [nested_error, parsed] if isinstance(nested_error, dict) else [parsed]
+
+    error_code: str | None = None
+    retryable: bool | None = None
+    retry_after: str | None = None
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        if error_code is None:
+            for key in ("code", "error_code", "type"):
+                candidate = source.get(key)
+                if isinstance(candidate, str) and _STABLE_CODE_PATTERN.fullmatch(candidate):
+                    error_code = candidate
+                    break
+        candidate_retryable = source.get("retryable")
+        if retryable is None and isinstance(candidate_retryable, bool):
+            retryable = candidate_retryable
+        if retry_after is None:
+            for key in ("retry_after", "retryAfter", "retry_after_seconds"):
+                retry_after = _safe_retry_after_value(source.get(key))
+                if retry_after is not None:
+                    break
+
+    return error_code, retryable, retry_after
+
+
+def _retry_after_header(headers: Mapping[str, str] | None) -> str | None:
+    if headers is None:
+        return None
+    for key, value in headers.items():
+        if isinstance(key, str) and key.lower() == "retry-after":
+            return _safe_retry_after_value(value)
+    return None
 
 
 class UnexpectedStatus(Exception):
-    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+    """Raised when an API returns a status absent from its OpenAPI contract."""
 
     def __init__(self, status_code: int, content: bytes):
         self.status_code = status_code
         self.content = content
+        self.body_preview = _safe_body_preview(content)
 
-        super().__init__(
-            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        super().__init__(f"Unexpected HTTP status {status_code}")
+
+
+class APIStatusError(UnexpectedStatus):
+    """Base class for typed HTTP status errors not modeled by an endpoint."""
+
+    def __init__(
+        self,
+        status_code: int,
+        content: bytes,
+        headers: Mapping[str, str] | None = None,
+    ):
+        self.error_code, self.retryable, body_retry_after = _extract_error_metadata(content)
+        self.retry_after = _retry_after_header(headers) or body_retry_after
+        self.retry_after_seconds = (
+            int(self.retry_after)
+            if self.retry_after is not None and self.retry_after.isdigit()
+            else None
         )
+        if self.retryable is None and self.retry_after is not None:
+            self.retryable = True
+
+        super().__init__(status_code, content)
+
+        try:
+            status_name = HTTPStatus(status_code).phrase
+        except ValueError:
+            status_name = "HTTP error"
+        Exception.__init__(self, f"HTTP {status_code} {status_name}")
 
 
-__all__ = ["UnexpectedStatus"]
+class ConflictError(APIStatusError):
+    """Raised for an undocumented HTTP 409 conflict response."""
+
+
+class RateLimitError(APIStatusError):
+    """Raised for an undocumented HTTP 429 rate-limit response."""
+
+
+def from_response(
+    status_code: int,
+    content: bytes,
+    headers: Mapping[str, str] | None = None,
+) -> UnexpectedStatus:
+    """Build the most specific safe error for an undocumented response."""
+    if status_code == HTTPStatus.CONFLICT:
+        return ConflictError(status_code, content, headers)
+    if status_code == HTTPStatus.TOO_MANY_REQUESTS:
+        return RateLimitError(status_code, content, headers)
+    return UnexpectedStatus(status_code, content)
+
+
+__all__ = [
+    "APIStatusError",
+    "ConflictError",
+    "RateLimitError",
+    "UnexpectedStatus",
+    "from_response",
+]

--- a/src/blaxel/core/sandbox/client/api/codegen/get_codegen_reranking_path.py
+++ b/src/blaxel/core/sandbox/client/api/codegen/get_codegen_reranking_path.py
@@ -59,7 +59,7 @@ def _parse_response(
 
         return response_503
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/drive/delete_drives_mount_mount_path.py
+++ b/src/blaxel/core/sandbox/client/api/drive/delete_drives_mount_mount_path.py
@@ -37,7 +37,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/drive/get_drives_mount.py
+++ b/src/blaxel/core/sandbox/client/api/drive/get_drives_mount.py
@@ -31,7 +31,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/drive/post_drives_mount.py
+++ b/src/blaxel/core/sandbox/client/api/drive/post_drives_mount.py
@@ -50,7 +50,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/fastapply/put_codegen_fastapply_path.py
+++ b/src/blaxel/core/sandbox/client/api/fastapply/put_codegen_fastapply_path.py
@@ -55,7 +55,7 @@ def _parse_response(
 
         return response_503
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/delete_filesystem_multipart_upload_id_abort.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/delete_filesystem_multipart_upload_id_abort.py
@@ -41,7 +41,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/delete_filesystem_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/delete_filesystem_path.py
@@ -50,7 +50,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/delete_filesystem_tree_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/delete_filesystem_tree_path.py
@@ -50,7 +50,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_content_search_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_content_search_path.py
@@ -62,7 +62,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_find_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_find_path.py
@@ -62,7 +62,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_multipart.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_multipart.py
@@ -31,7 +31,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_multipart_upload_id_parts.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_multipart_upload_id_parts.py
@@ -41,7 +41,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_path.py
@@ -76,7 +76,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_search_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_search_path.py
@@ -59,7 +59,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_tree_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_filesystem_tree_path.py
@@ -67,7 +67,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/get_watch_filesystem_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/get_watch_filesystem_path.py
@@ -44,7 +44,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/post_filesystem_multipart_initiate_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/post_filesystem_multipart_initiate_path.py
@@ -51,7 +51,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/post_filesystem_multipart_upload_id_complete.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/post_filesystem_multipart_upload_id_complete.py
@@ -55,7 +55,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/put_filesystem_multipart_upload_id_part.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/put_filesystem_multipart_upload_id_part.py
@@ -61,7 +61,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/put_filesystem_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/put_filesystem_path.py
@@ -55,7 +55,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/filesystem/put_filesystem_tree_path.py
+++ b/src/blaxel/core/sandbox/client/api/filesystem/put_filesystem_tree_path.py
@@ -81,7 +81,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/network/delete_network_process_pid_monitor.py
+++ b/src/blaxel/core/sandbox/client/api/network/delete_network_process_pid_monitor.py
@@ -43,7 +43,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/network/delete_network_tunnel.py
+++ b/src/blaxel/core/sandbox/client/api/network/delete_network_tunnel.py
@@ -35,7 +35,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/network/get_network_process_pid_ports.py
+++ b/src/blaxel/core/sandbox/client/api/network/get_network_process_pid_ports.py
@@ -43,7 +43,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/network/post_network_process_pid_monitor.py
+++ b/src/blaxel/core/sandbox/client/api/network/post_network_process_pid_monitor.py
@@ -57,7 +57,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/network/put_network_tunnel_config.py
+++ b/src/blaxel/core/sandbox/client/api/network/put_network_tunnel_config.py
@@ -54,7 +54,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/process/delete_process_identifier.py
+++ b/src/blaxel/core/sandbox/client/api/process/delete_process_identifier.py
@@ -41,7 +41,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/process/delete_process_identifier_kill.py
+++ b/src/blaxel/core/sandbox/client/api/process/delete_process_identifier_kill.py
@@ -41,7 +41,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/process/get_process.py
+++ b/src/blaxel/core/sandbox/client/api/process/get_process.py
@@ -29,7 +29,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> list["Proces
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/process/get_process_identifier.py
+++ b/src/blaxel/core/sandbox/client/api/process/get_process_identifier.py
@@ -33,7 +33,7 @@ def _parse_response(
 
         return response_404
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/process/get_process_identifier_logs.py
+++ b/src/blaxel/core/sandbox/client/api/process/get_process_identifier_logs.py
@@ -41,7 +41,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/process/get_process_identifier_logs_stream.py
+++ b/src/blaxel/core/sandbox/client/api/process/get_process_identifier_logs_stream.py
@@ -39,7 +39,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/process/post_process.py
+++ b/src/blaxel/core/sandbox/client/api/process/post_process.py
@@ -54,7 +54,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/system/get_health.py
+++ b/src/blaxel/core/sandbox/client/api/system/get_health.py
@@ -24,7 +24,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> HealthRespon
 
         return response_200
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/api/system/post_upgrade.py
+++ b/src/blaxel/core/sandbox/client/api/system/post_upgrade.py
@@ -46,7 +46,7 @@ def _parse_response(
 
         return response_500
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/src/blaxel/core/sandbox/client/errors.py
+++ b/src/blaxel/core/sandbox/client/errors.py
@@ -1,16 +1,159 @@
-"""Contains shared errors types that can be raised from API functions"""
+"""Contains shared error types that can be raised from API functions."""
+
+import json
+import re
+from datetime import timezone
+from email.utils import format_datetime, parsedate_to_datetime
+from http import HTTPStatus
+from typing import Any, Mapping
+
+_MAX_JSON_INSPECTION_BYTES = 64 * 1024
+_STABLE_CODE_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]{1,127}$")
+
+
+def _json_body(content: bytes) -> dict[str, Any] | None:
+    if not content or len(content) > _MAX_JSON_INSPECTION_BYTES:
+        return None
+    try:
+        value = json.loads(content)
+    except (UnicodeDecodeError, ValueError, RecursionError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _safe_body_preview(content: bytes) -> str:
+    if not content:
+        return "<empty body>"
+    return f"<response body: {len(content)} bytes>"
+
+
+def _safe_retry_after_value(value: Any) -> str | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and 0 <= value <= 9_999_999_999:
+        return str(value)
+    if not isinstance(value, str):
+        return None
+
+    value = value.strip()
+    if re.fullmatch(r"[0-9]{1,10}", value):
+        return value
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if retry_at is None or retry_at.tzinfo is None:
+        return None
+    return format_datetime(retry_at.astimezone(timezone.utc), usegmt=True)
+
+
+def _extract_error_metadata(
+    content: bytes,
+) -> tuple[str | None, bool | None, str | None]:
+    parsed = _json_body(content)
+    if parsed is None:
+        return None, None, None
+
+    nested_error = parsed.get("error")
+    sources = [nested_error, parsed] if isinstance(nested_error, dict) else [parsed]
+
+    error_code: str | None = None
+    retryable: bool | None = None
+    retry_after: str | None = None
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        if error_code is None:
+            for key in ("code", "error_code", "type"):
+                candidate = source.get(key)
+                if isinstance(candidate, str) and _STABLE_CODE_PATTERN.fullmatch(candidate):
+                    error_code = candidate
+                    break
+        candidate_retryable = source.get("retryable")
+        if retryable is None and isinstance(candidate_retryable, bool):
+            retryable = candidate_retryable
+        if retry_after is None:
+            for key in ("retry_after", "retryAfter", "retry_after_seconds"):
+                retry_after = _safe_retry_after_value(source.get(key))
+                if retry_after is not None:
+                    break
+
+    return error_code, retryable, retry_after
+
+
+def _retry_after_header(headers: Mapping[str, str] | None) -> str | None:
+    if headers is None:
+        return None
+    for key, value in headers.items():
+        if isinstance(key, str) and key.lower() == "retry-after":
+            return _safe_retry_after_value(value)
+    return None
 
 
 class UnexpectedStatus(Exception):
-    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+    """Raised when an API returns a status absent from its OpenAPI contract."""
 
     def __init__(self, status_code: int, content: bytes):
         self.status_code = status_code
         self.content = content
+        self.body_preview = _safe_body_preview(content)
 
-        super().__init__(
-            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        super().__init__(f"Unexpected HTTP status {status_code}")
+
+
+class APIStatusError(UnexpectedStatus):
+    """Base class for typed HTTP status errors not modeled by an endpoint."""
+
+    def __init__(
+        self,
+        status_code: int,
+        content: bytes,
+        headers: Mapping[str, str] | None = None,
+    ):
+        self.error_code, self.retryable, body_retry_after = _extract_error_metadata(content)
+        self.retry_after = _retry_after_header(headers) or body_retry_after
+        self.retry_after_seconds = (
+            int(self.retry_after)
+            if self.retry_after is not None and self.retry_after.isdigit()
+            else None
         )
+        if self.retryable is None and self.retry_after is not None:
+            self.retryable = True
+
+        super().__init__(status_code, content)
+
+        try:
+            status_name = HTTPStatus(status_code).phrase
+        except ValueError:
+            status_name = "HTTP error"
+        Exception.__init__(self, f"HTTP {status_code} {status_name}")
 
 
-__all__ = ["UnexpectedStatus"]
+class ConflictError(APIStatusError):
+    """Raised for an undocumented HTTP 409 conflict response."""
+
+
+class RateLimitError(APIStatusError):
+    """Raised for an undocumented HTTP 429 rate-limit response."""
+
+
+def from_response(
+    status_code: int,
+    content: bytes,
+    headers: Mapping[str, str] | None = None,
+) -> UnexpectedStatus:
+    """Build the most specific safe error for an undocumented response."""
+    if status_code == HTTPStatus.CONFLICT:
+        return ConflictError(status_code, content, headers)
+    if status_code == HTTPStatus.TOO_MANY_REQUESTS:
+        return RateLimitError(status_code, content, headers)
+    return UnexpectedStatus(status_code, content)
+
+
+__all__ = [
+    "APIStatusError",
+    "ConflictError",
+    "RateLimitError",
+    "UnexpectedStatus",
+    "from_response",
+]

--- a/templates/endpoint_module.py.jinja
+++ b/templates/endpoint_module.py.jinja
@@ -85,7 +85,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> {{ return_st
         {% endif %}
     {% endfor %}
     if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
+        raise errors.from_response(response.status_code, response.content, response.headers)
     else:
         return None
 

--- a/templates/errors.py.jinja
+++ b/templates/errors.py.jinja
@@ -1,14 +1,159 @@
-""" Contains shared errors types that can be raised from API functions """
+"""Contains shared error types that can be raised from API functions."""
+
+import json
+import re
+from datetime import timezone
+from email.utils import format_datetime, parsedate_to_datetime
+from http import HTTPStatus
+from typing import Any, Mapping
+
+_MAX_JSON_INSPECTION_BYTES = 64 * 1024
+_STABLE_CODE_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]{1,127}$")
+
+
+def _json_body(content: bytes) -> dict[str, Any] | None:
+    if not content or len(content) > _MAX_JSON_INSPECTION_BYTES:
+        return None
+    try:
+        value = json.loads(content)
+    except (UnicodeDecodeError, ValueError, RecursionError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _safe_body_preview(content: bytes) -> str:
+    if not content:
+        return "<empty body>"
+    return f"<response body: {len(content)} bytes>"
+
+
+def _safe_retry_after_value(value: Any) -> str | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and 0 <= value <= 9_999_999_999:
+        return str(value)
+    if not isinstance(value, str):
+        return None
+
+    value = value.strip()
+    if re.fullmatch(r"[0-9]{1,10}", value):
+        return value
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if retry_at is None or retry_at.tzinfo is None:
+        return None
+    return format_datetime(retry_at.astimezone(timezone.utc), usegmt=True)
+
+
+def _extract_error_metadata(
+    content: bytes,
+) -> tuple[str | None, bool | None, str | None]:
+    parsed = _json_body(content)
+    if parsed is None:
+        return None, None, None
+
+    nested_error = parsed.get("error")
+    sources = [nested_error, parsed] if isinstance(nested_error, dict) else [parsed]
+
+    error_code: str | None = None
+    retryable: bool | None = None
+    retry_after: str | None = None
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        if error_code is None:
+            for key in ("code", "error_code", "type"):
+                candidate = source.get(key)
+                if isinstance(candidate, str) and _STABLE_CODE_PATTERN.fullmatch(candidate):
+                    error_code = candidate
+                    break
+        candidate_retryable = source.get("retryable")
+        if retryable is None and isinstance(candidate_retryable, bool):
+            retryable = candidate_retryable
+        if retry_after is None:
+            for key in ("retry_after", "retryAfter", "retry_after_seconds"):
+                retry_after = _safe_retry_after_value(source.get(key))
+                if retry_after is not None:
+                    break
+
+    return error_code, retryable, retry_after
+
+
+def _retry_after_header(headers: Mapping[str, str] | None) -> str | None:
+    if headers is None:
+        return None
+    for key, value in headers.items():
+        if isinstance(key, str) and key.lower() == "retry-after":
+            return _safe_retry_after_value(value)
+    return None
+
 
 class UnexpectedStatus(Exception):
-    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+    """Raised when an API returns a status absent from its OpenAPI contract."""
 
     def __init__(self, status_code: int, content: bytes):
         self.status_code = status_code
         self.content = content
+        self.body_preview = _safe_body_preview(content)
 
-        super().__init__(
-            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        super().__init__(f"Unexpected HTTP status {status_code}")
+
+
+class APIStatusError(UnexpectedStatus):
+    """Base class for typed HTTP status errors not modeled by an endpoint."""
+
+    def __init__(
+        self,
+        status_code: int,
+        content: bytes,
+        headers: Mapping[str, str] | None = None,
+    ):
+        self.error_code, self.retryable, body_retry_after = _extract_error_metadata(content)
+        self.retry_after = _retry_after_header(headers) or body_retry_after
+        self.retry_after_seconds = (
+            int(self.retry_after)
+            if self.retry_after is not None and self.retry_after.isdigit()
+            else None
         )
+        if self.retryable is None and self.retry_after is not None:
+            self.retryable = True
 
-__all__ = ["UnexpectedStatus"]
+        super().__init__(status_code, content)
+
+        try:
+            status_name = HTTPStatus(status_code).phrase
+        except ValueError:
+            status_name = "HTTP error"
+        Exception.__init__(self, f"HTTP {status_code} {status_name}")
+
+
+class ConflictError(APIStatusError):
+    """Raised for an undocumented HTTP 409 conflict response."""
+
+
+class RateLimitError(APIStatusError):
+    """Raised for an undocumented HTTP 429 rate-limit response."""
+
+
+def from_response(
+    status_code: int,
+    content: bytes,
+    headers: Mapping[str, str] | None = None,
+) -> UnexpectedStatus:
+    """Build the most specific safe error for an undocumented response."""
+    if status_code == HTTPStatus.CONFLICT:
+        return ConflictError(status_code, content, headers)
+    if status_code == HTTPStatus.TOO_MANY_REQUESTS:
+        return RateLimitError(status_code, content, headers)
+    return UnexpectedStatus(status_code, content)
+
+
+__all__ = [
+    "APIStatusError",
+    "ConflictError",
+    "RateLimitError",
+    "UnexpectedStatus",
+    "from_response",
+]

--- a/tests/core/test_generated_status_errors.py
+++ b/tests/core/test_generated_status_errors.py
@@ -1,0 +1,233 @@
+import httpx
+import pytest
+
+from blaxel.core.client import errors
+from blaxel.core.client.api.drives import create_drive
+from blaxel.core.client.api.volumes import create_volume
+from blaxel.core.client.client import Client
+from blaxel.core.client.models.drive import Drive
+from blaxel.core.client.models.volume import Volume
+from blaxel.core.sandbox.client import errors as sandbox_errors
+from blaxel.core.sandbox.client.api.drive import get_drives_mount
+from blaxel.core.sandbox.client.client import Client as SandboxClient
+
+
+def _drive() -> Drive:
+    return Drive(metadata={"name": "test-drive"}, spec={})  # type: ignore[arg-type]
+
+
+def _volume() -> Volume:
+    return Volume(metadata={"name": "test-volume"}, spec={"size": 1024})  # type: ignore[arg-type]
+
+
+def _response(
+    status_code: int,
+    *,
+    content: bytes,
+    headers: dict[str, str] | None = None,
+    path: str = "/drives",
+) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        content=content,
+        headers=headers,
+        request=httpx.Request("POST", f"https://api.blaxel.test{path}"),
+    )
+
+
+def test_drive_create_sync_raises_typed_conflict_without_raw_body() -> None:
+    sensitive_body = (
+        b'{"error":"Resource already exists: customer-drive-123",'
+        b'"code":409,"message":"token=private-token /Users/alice/project"}'
+    )
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return _response(409, content=sensitive_body)
+
+    http_client = httpx.Client(
+        base_url="https://api.blaxel.test",
+        transport=httpx.MockTransport(handler),
+    )
+    client = Client(base_url="https://api.blaxel.test").set_httpx_client(http_client)
+
+    with pytest.raises(errors.ConflictError) as exc_info:
+        create_drive.sync(client=client, body=_drive())
+
+    exc = exc_info.value
+    assert isinstance(exc, errors.UnexpectedStatus)
+    assert exc.status_code == 409
+    assert exc.error_code is None
+    assert exc.content == sensitive_body
+    assert exc.body_preview.startswith("<response body:")
+    assert str(exc) == "HTTP 409 Conflict"
+    assert "customer-drive-123" not in str(exc)
+    assert "private-token" not in str(exc)
+    assert "/Users/alice" not in str(exc)
+
+
+@pytest.mark.asyncio
+async def test_volume_create_async_raises_typed_rate_limit_with_retry_after() -> None:
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return _response(
+            429,
+            content=b"quota backend unavailable for customer@example.com",
+            headers={"Content-Type": "text/plain", "Retry-After": "7"},
+            path="/volumes",
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = Client(
+        base_url="https://api.blaxel.test",
+        httpx_args={"transport": transport},
+    )
+
+    with pytest.raises(errors.RateLimitError) as exc_info:
+        await create_volume.asyncio(client=client, body=_volume())
+
+    exc = exc_info.value
+    assert isinstance(exc, errors.UnexpectedStatus)
+    assert exc.status_code == 429
+    assert exc.retry_after == "7"
+    assert exc.retry_after_seconds == 7
+    assert exc.retryable is True
+    assert exc.error_code is None
+    assert exc.body_preview.startswith("<response body:")
+    assert str(exc) == "HTTP 429 Too Many Requests"
+    assert "customer@example.com" not in str(exc)
+    await client.get_async_httpx_client().aclose()
+
+
+def test_typed_rate_limit_preserves_stable_error_metadata() -> None:
+    error = errors.from_response(
+        429,
+        (
+            b'{"error":{"code":"USAGE_LIMIT_EXCEEDED",'
+            b'"message":"workspace private-workspace exhausted quota",'
+            b'"retryable":false,"authorization":"Bearer private",'
+            b'"retry_after_seconds":19}}'
+        ),
+    )
+
+    assert isinstance(error, errors.RateLimitError)
+    assert error.error_code == "USAGE_LIMIT_EXCEEDED"
+    assert error.retryable is False
+    assert error.retry_after == "19"
+    assert error.retry_after_seconds == 19
+    assert str(error) == "HTTP 429 Too Many Requests"
+    assert error.error_code not in str(error)
+    assert "private-workspace" not in str(error)
+    assert "Bearer private" not in str(error)
+
+
+def test_body_derived_code_is_metadata_only_not_exception_text() -> None:
+    error = errors.from_response(
+        409,
+        b'{"error":{"code":"PRIVATE_WORKSPACE_SECRET","retryable":false}}',
+    )
+
+    assert isinstance(error, errors.ConflictError)
+    assert error.error_code == "PRIVATE_WORKSPACE_SECRET"
+    assert str(error) == "HTTP 409 Conflict"
+    assert "PRIVATE_WORKSPACE_SECRET" not in str(error)
+
+
+@pytest.mark.parametrize("status_code", [409, 429])
+def test_typed_status_returns_none_when_raising_is_disabled(status_code: int) -> None:
+    client = Client(
+        base_url="https://api.blaxel.test",
+        raise_on_unexpected_status=False,
+    )
+    response = _response(status_code, content=b"not json")
+
+    assert create_drive._parse_response(client=client, response=response) is None
+
+
+def test_unknown_status_retains_unexpected_status_type() -> None:
+    client = Client(base_url="https://api.blaxel.test")
+    response = _response(418, content=b"private teapot response")
+
+    with pytest.raises(errors.UnexpectedStatus) as exc_info:
+        create_drive._parse_response(client=client, response=response)
+
+    assert type(exc_info.value) is errors.UnexpectedStatus
+    assert str(exc_info.value) == "Unexpected HTTP status 418"
+    assert "private teapot response" not in str(exc_info.value)
+
+
+def test_invalid_retry_after_is_not_retained() -> None:
+    error = errors.from_response(
+        429,
+        b"rate limited",
+        {"Retry-After": "private-header-value"},
+    )
+
+    assert isinstance(error, errors.RateLimitError)
+    assert error.retry_after is None
+
+    boolean_retry_after = errors.from_response(429, b'{"retry_after":true}')
+    assert isinstance(boolean_retry_after, errors.RateLimitError)
+    assert boolean_retry_after.retry_after is None
+
+
+def test_http_date_retry_after_is_preserved_without_becoming_seconds() -> None:
+    retry_at = "Wed, 21 Oct 2037 07:28:00 GMT"
+
+    error = errors.from_response(429, b"rate limited", {"rEtRy-AfTeR": retry_at})
+
+    assert isinstance(error, errors.RateLimitError)
+    assert error.retry_after == retry_at
+    assert error.retry_after_seconds is None
+
+
+def test_http_date_retry_after_drops_comments_and_normalizes_timezone() -> None:
+    error = errors.from_response(
+        429,
+        b"rate limited",
+        {"Retry-After": "Wed, 21 Oct 2037 00:28:00 -0700 (private@example.com)"},
+    )
+
+    assert isinstance(error, errors.RateLimitError)
+    assert error.retry_after == "Wed, 21 Oct 2037 07:28:00 GMT"
+    assert error.retry_after_seconds is None
+    assert "private@example.com" not in error.retry_after
+
+
+def test_body_summary_never_exposes_user_controlled_json_keys() -> None:
+    error = errors.from_response(
+        418,
+        b'{"customer@example.com":{"private-token":"private-value"}}',
+    )
+
+    assert type(error) is errors.UnexpectedStatus
+    assert error.body_preview.startswith("<response body:")
+    assert str(error) == "Unexpected HTTP status 418"
+    assert "customer@example.com" not in str(error)
+    assert "private-token" not in str(error)
+    assert "private-value" not in str(error)
+
+
+def test_malformed_metadata_cannot_mask_rate_limit_error() -> None:
+    oversized_integer = b'{"retry_after":' + (b"9" * 5_000) + b"}"
+
+    error = errors.from_response(429, oversized_integer)
+
+    assert isinstance(error, errors.RateLimitError)
+    assert error.retry_after is None
+    assert "999999" not in str(error)
+
+
+def test_sandbox_generated_client_uses_the_same_typed_safe_errors() -> None:
+    response = _response(
+        409,
+        content=b'{"error":"private mount path /mnt/customer"}',
+        path="/drives/mount",
+    )
+
+    with pytest.raises(sandbox_errors.ConflictError) as exc_info:
+        get_drives_mount._parse_response(
+            client=SandboxClient(base_url="https://api.blaxel.test"),
+            response=response,
+        )
+
+    assert isinstance(exc_info.value, sandbox_errors.UnexpectedStatus)
+    assert "/mnt/customer" not in str(exc_info.value)


### PR DESCRIPTION
## What broke

The generated Python clients only recognize statuses declared in OpenAPI. Controlplane can return `409` while creating a drive and `429` while creating a volume, but those responses are missing from the current contract. Every undocumented response therefore fell through to the generator's generic `UnexpectedStatus`, whose printable message included the raw server body. That erased useful status semantics and made customer-controlled response text available to error reporting.

This is the SDK half of ENG-4050. ENG-4072 tracks correcting the controlplane/OpenAPI contract itself.

## Fix

- generate every unexpected response through one shared `from_response(...)` factory
- type `409` as `ConflictError` and `429` as `RateLimitError` across both generated client trees
- retain raw `content` on the exception for compatibility while keeping `str(error)` fixed and safe
- expose only bounded, validated metadata (`error_code`, `retryable`, sanitized `Retry-After`) as attributes
- keep all other undocumented statuses as `UnexpectedStatus`
- update the generator templates, then regenerate both controlplane and sandbox clients so future generation preserves the behavior

This PR does not add retries. In particular, it does not replay writes; safe mutation retry policy remains gated on ENG-4051 and the gateway pre-dispatch contract in ENG-4071.

## Verification

- exact current-main merged head `f4076af`: `make lint`, `git diff --check`, and `make test` (390 passed)
- fresh GitHub matrix on the same head: Python 3.10–3.14, Core and all framework integrations, CodeQL, Cursor, and Mendral passed; Core passed on rerun after one unrelated Agent Drive empty-read flake
- scoped Pyright for the changed runtime and tests — 0 errors, 0 warnings
- an isolated release-shaped build injected the exact full commit, and `uv build` produced both wheel and source distribution
- clean wheel consumer and clean source-distribution consumer each exercised:
  - sync generated drive create returning `409`
  - async generated volume create returning `429` with `Retry-After`
  - the sibling sandbox-generated client returning `409`
- adversarial cases prove server body, JSON keys, paths, email-like data, malformed metadata, and body-derived error codes never enter the printable exception
- generator audit: 186/186 generated endpoint modules use `errors.from_response`, zero retain the former direct raise, and both generated error modules exactly match the template

## Scope

The shared template is the narrowest durable boundary because both official generated client trees had the same fallback. Known declared success and error responses are unchanged, `raise_on_unexpected_status=False` remains unchanged, and callers can still inspect the original response bytes through `content`.

#195 and #194 are merged. This branch was refreshed onto current `main` at `f4076af`; the PR diff remains only the generated status-error change.

Linear: ENG-4050

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces the raw-body-leaking `UnexpectedStatus` exception with a `from_response` factory that maps undocumented 409 responses to `ConflictError` and 429 to `RateLimitError`. These typed exceptions expose validated metadata (error_code, retryable, sanitized retry-after) as attributes while keeping `str(error)` fixed and free of user-controlled content. All 186+ generated endpoint modules are updated to call the new factory, and a comprehensive test suite validates the security and correctness properties.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3a35f80f51b238f4cb96bdbb9aca8d6f548dee0c.</sup>
<!-- /MENDRAL_SUMMARY -->


