### PR TITLE
fix(sandbox): propagate control-plane errors from update_*/delete (ENG-4244)

### DIFF
--- a/src/blaxel/core/sandbox/default/sandbox.py
+++ b/src/blaxel/core/sandbox/default/sandbox.py
@@ -99,10 +99,12 @@ def _is_sandbox_not_found(error: SandboxAPIError) -> bool:
 def _unwrap_response(response, action: str, *, allow_none: bool = False):
     """Raise a SandboxAPIError for error/empty responses, else return the payload.
 
-    Shared by the fork/snapshot helpers, which call generated control-plane API
-    functions that return ``Union[Error, T] | None``. Void endpoints (e.g. delete,
-    which returns 204 No Content) legitimately return ``None`` — pass
-    ``allow_none=True`` for those.
+    Every generated control-plane API function returns ``Union[Error, T] | None``,
+    so an error status is a *return value*, not an exception. Callers must route
+    the response through here; handing it straight to ``cls(...)`` builds an
+    instance wrapping an ``Error`` and turns a failed write into a silent no-op.
+    Void endpoints (e.g. delete, which returns 204 No Content) legitimately return
+    ``None`` — pass ``allow_none=True`` for those.
     """
     if isinstance(response, Error):
         status_code = response.code if response.code is not UNSET else None
@@ -587,7 +589,7 @@ class SandboxInstance:
         )
 
         # Return new instance with updated sandbox
-        return cls(response)
+        return cls(_unwrap_response(response, "update sandbox metadata"))
 
     @classmethod
     async def update_ttl(cls, sandbox_name: str, ttl: str | None) -> "SandboxInstance":
@@ -619,7 +621,7 @@ class SandboxInstance:
             body=updated_sandbox,
         )
 
-        return cls(response)
+        return cls(_unwrap_response(response, "update sandbox TTL"))
 
     @classmethod
     async def update_lifecycle(
@@ -651,7 +653,7 @@ class SandboxInstance:
             body=body,
         )
 
-        return cls(response)
+        return cls(_unwrap_response(response, "update sandbox lifecycle"))
 
     @classmethod
     async def update_network(
@@ -687,7 +689,7 @@ class SandboxInstance:
             body=updated_sandbox,
         )
 
-        return cls(response)
+        return cls(_unwrap_response(response, "update sandbox network"))
 
     @classmethod
     async def create_if_not_exists(
@@ -788,9 +790,7 @@ async def _delete_sandbox_by_name(sandbox_name: str) -> Sandbox:
         sandbox_name,
         client=client,
     )
-    if response is None:
-        raise ValueError(f"Sandbox {sandbox_name} not found")
-    return response
+    return _unwrap_response(response, f"delete sandbox {sandbox_name}")
 
 
 # Assign the delete descriptor to support both class-level and instance-level calls

--- a/src/blaxel/core/sandbox/sync/sandbox.py
+++ b/src/blaxel/core/sandbox/sync/sandbox.py
@@ -459,7 +459,7 @@ class SyncSandboxInstance:
             client=client,
             body=updated_sandbox,
         )
-        return cls(response)
+        return cls(_unwrap_response(response, "update sandbox metadata"))
 
     @classmethod
     def update_ttl(cls, sandbox_name: str, ttl: str | None) -> "SyncSandboxInstance":
@@ -491,7 +491,7 @@ class SyncSandboxInstance:
             body=updated_sandbox,
         )
 
-        return cls(response)
+        return cls(_unwrap_response(response, "update sandbox TTL"))
 
     @classmethod
     def update_lifecycle(
@@ -523,7 +523,7 @@ class SyncSandboxInstance:
             body=body,
         )
 
-        return cls(response)
+        return cls(_unwrap_response(response, "update sandbox lifecycle"))
 
     @classmethod
     def update_network(
@@ -559,7 +559,7 @@ class SyncSandboxInstance:
             body=updated_sandbox,
         )
 
-        return cls(response)
+        return cls(_unwrap_response(response, "update sandbox network"))
 
     @classmethod
     def create_if_not_exists(
@@ -655,7 +655,7 @@ def _delete_sandbox_by_name(sandbox_name: str) -> Sandbox:
         sandbox_name,
         client=client,
     )
-    return response
+    return _unwrap_response(response, f"delete sandbox {sandbox_name}")
 
 
 # Assign the delete descriptor to support both class-level and instance-level calls

--- a/src/blaxel/core/volume/volume.py
+++ b/src/blaxel/core/volume/volume.py
@@ -529,6 +529,8 @@ async def _delete_volume_by_name(volume_name: str) -> Volume:
         status_code = int(response.code) if response.code is not UNSET else None
         message = response.message if response.message is not UNSET else response.error
         raise VolumeAPIError(message, status_code=status_code, code=response.error)
+    if response is None:
+        raise VolumeAPIError(f"Failed to delete volume {volume_name}")
     return response
 
 
@@ -539,6 +541,8 @@ def _delete_volume_by_name_sync(volume_name: str) -> Volume:
         status_code = int(response.code) if response.code is not UNSET else None
         message = response.message if response.message is not UNSET else response.error
         raise VolumeAPIError(message, status_code=status_code, code=response.error)
+    if response is None:
+        raise VolumeAPIError(f"Failed to delete volume {volume_name}")
     return response
 
 

--- a/src/blaxel/core/volume/volume.py
+++ b/src/blaxel/core/volume/volume.py
@@ -525,12 +525,20 @@ class SyncVolumeInstance:
 async def _delete_volume_by_name(volume_name: str) -> Volume:
     """Delete a volume by name (async)."""
     response = await delete_volume(volume_name=volume_name, client=client)
+    if isinstance(response, Error):
+        status_code = int(response.code) if response.code is not UNSET else None
+        message = response.message if response.message is not UNSET else response.error
+        raise VolumeAPIError(message, status_code=status_code, code=response.error)
     return response
 
 
 def _delete_volume_by_name_sync(volume_name: str) -> Volume:
     """Delete a volume by name (sync)."""
     response = delete_volume_sync(volume_name=volume_name, client=client)
+    if isinstance(response, Error):
+        status_code = int(response.code) if response.code is not UNSET else None
+        message = response.message if response.message is not UNSET else response.error
+        raise VolumeAPIError(message, status_code=status_code, code=response.error)
     return response
 
 

--- a/tests/core/test_sandbox.py
+++ b/tests/core/test_sandbox.py
@@ -14,7 +14,12 @@ from blaxel.core.sandbox import (
     SyncSandboxInstance,
 )
 from blaxel.core.sandbox.default.action import SandboxAction
-from blaxel.core.sandbox.types import ResponseError, SandboxConfiguration
+from blaxel.core.sandbox.types import (
+    ResponseError,
+    SandboxConfiguration,
+    SandboxUpdateMetadata,
+    SandboxUpdateNetwork,
+)
 
 
 def sandbox_instance(name: str, status: str = "DEPLOYED", cls=SandboxInstance):
@@ -943,3 +948,142 @@ def test_sync_fork_and_snapshot_helpers():
         assert fork_body.target_type == "sandbox"
         assert fork_body.snapshot_id == "snap_abc123"
         assert mock_snapshot.call_args.kwargs["body"].name == "before"
+
+
+# --- Control-plane errors must not be returned as if they were sandboxes -------
+#
+# Every generated API function returns ``Union[Error, Sandbox] | None``. The
+# update_*/delete helpers used to hand that straight to ``cls(...)``, so a 403 or
+# 500 produced an instance wrapping an ``Error``: a failed write looked like a
+# success to any caller that did not inspect the return value, and callers that
+# did inspect it hit ``AttributeError`` far away from the real cause.
+
+
+def api_error(code=403, message="insufficient permissions"):
+    from blaxel.core.client.models.error import Error
+
+    return Error(error="FORBIDDEN", code=code, message=message)
+
+
+def updatable_sandbox(name="my-sandbox", cls=SandboxInstance):
+    """An instance the update_* helpers can round-trip through ``to_dict()``.
+
+    ``sandbox_instance`` assigns ``status`` as a plain string, which the generated
+    model cannot serialize; the update helpers re-serialize the fetched sandbox.
+    """
+    return cls(Sandbox(metadata=Metadata(name=name), spec=SandboxSpec()))
+
+
+UPDATE_CALLS = [
+    ("update_metadata", lambda: SandboxUpdateMetadata(labels={"team": "core"})),
+    ("update_ttl", lambda: "10m"),
+    ("update_lifecycle", lambda: None),
+    ("update_network", lambda: SandboxUpdateNetwork(network=None)),
+]
+
+
+@pytest.mark.parametrize("method_name,arg_factory", UPDATE_CALLS)
+@pytest.mark.asyncio
+async def test_update_helpers_raise_on_error_response(method_name, arg_factory):
+    with (
+        patch.object(SandboxInstance, "get", new_callable=AsyncMock) as mock_get,
+        patch(
+            "blaxel.core.sandbox.default.sandbox.update_sandbox", new_callable=AsyncMock
+        ) as mock_update,
+    ):
+        mock_get.return_value = updatable_sandbox()
+        mock_update.return_value = api_error()
+
+        with pytest.raises(SandboxAPIError, match="insufficient permissions") as excinfo:
+            await getattr(SandboxInstance, method_name)("my-sandbox", arg_factory())
+
+    assert excinfo.value.status_code == 403
+
+
+@pytest.mark.parametrize("method_name,arg_factory", UPDATE_CALLS)
+@pytest.mark.asyncio
+async def test_update_helpers_raise_on_empty_response(method_name, arg_factory):
+    with (
+        patch.object(SandboxInstance, "get", new_callable=AsyncMock) as mock_get,
+        patch(
+            "blaxel.core.sandbox.default.sandbox.update_sandbox", new_callable=AsyncMock
+        ) as mock_update,
+    ):
+        mock_get.return_value = updatable_sandbox()
+        mock_update.return_value = None
+
+        with pytest.raises(SandboxAPIError):
+            await getattr(SandboxInstance, method_name)("my-sandbox", arg_factory())
+
+
+@pytest.mark.asyncio
+async def test_update_helpers_still_return_instance_on_success():
+    with (
+        patch.object(SandboxInstance, "get", new_callable=AsyncMock) as mock_get,
+        patch(
+            "blaxel.core.sandbox.default.sandbox.update_sandbox", new_callable=AsyncMock
+        ) as mock_update,
+    ):
+        mock_get.return_value = updatable_sandbox()
+        mock_update.return_value = Sandbox(metadata=Metadata(name="my-sandbox"), spec=SandboxSpec())
+
+        result = await SandboxInstance.update_ttl("my-sandbox", "10m")
+
+        assert isinstance(result, SandboxInstance)
+        assert result.metadata.name == "my-sandbox"
+
+
+@pytest.mark.asyncio
+async def test_delete_raises_on_error_response():
+    with patch(
+        "blaxel.core.sandbox.default.sandbox.delete_sandbox", new_callable=AsyncMock
+    ) as mock_delete:
+        mock_delete.return_value = api_error(code=500, message="control plane exploded")
+
+        with pytest.raises(SandboxAPIError, match="control plane exploded"):
+            await SandboxInstance.delete("my-sandbox")
+
+
+@pytest.mark.asyncio
+async def test_delete_raises_on_empty_response():
+    with patch(
+        "blaxel.core.sandbox.default.sandbox.delete_sandbox", new_callable=AsyncMock
+    ) as mock_delete:
+        mock_delete.return_value = None
+
+        with pytest.raises(SandboxAPIError, match="delete sandbox my-sandbox"):
+            await SandboxInstance.delete("my-sandbox")
+
+
+@pytest.mark.asyncio
+async def test_instance_delete_raises_on_error_response():
+    sandbox = sandbox_instance("my-sandbox")
+
+    with patch(
+        "blaxel.core.sandbox.default.sandbox.delete_sandbox", new_callable=AsyncMock
+    ) as mock_delete:
+        mock_delete.return_value = api_error(code=404, message="sandbox not found")
+
+        with pytest.raises(SandboxAPIError, match="sandbox not found"):
+            await sandbox.delete()
+
+
+@pytest.mark.parametrize("method_name,arg_factory", UPDATE_CALLS)
+def test_sync_update_helpers_raise_on_error_response(method_name, arg_factory):
+    with (
+        patch.object(SyncSandboxInstance, "get") as mock_get,
+        patch("blaxel.core.sandbox.sync.sandbox.update_sandbox") as mock_update,
+    ):
+        mock_get.return_value = updatable_sandbox(cls=SyncSandboxInstance)
+        mock_update.return_value = api_error()
+
+        with pytest.raises(SandboxAPIError, match="insufficient permissions"):
+            getattr(SyncSandboxInstance, method_name)("my-sandbox", arg_factory())
+
+
+def test_sync_delete_raises_on_error_response():
+    with patch("blaxel.core.sandbox.sync.sandbox.delete_sandbox") as mock_delete:
+        mock_delete.return_value = api_error(code=500, message="control plane exploded")
+
+        with pytest.raises(SandboxAPIError, match="control plane exploded"):
+            SyncSandboxInstance.delete("my-sandbox")

--- a/tests/core/test_volume_errors.py
+++ b/tests/core/test_volume_errors.py
@@ -1,0 +1,49 @@
+"""Control-plane errors must not be returned as if they were volumes.
+
+``delete_volume`` returns ``Union[Error, Volume] | None``. The delete helpers used
+to return that untouched, so a failed delete looked like a success to any caller
+that did not inspect the return value.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from blaxel.core.client.models import Metadata, Volume, VolumeSpec
+from blaxel.core.client.models.error import Error
+from blaxel.core.volume.volume import SyncVolumeInstance, VolumeAPIError, VolumeInstance
+
+
+def api_error(code=403, message="insufficient permissions"):
+    return Error(error="FORBIDDEN", code=code, message=message)
+
+
+@pytest.mark.asyncio
+async def test_delete_raises_on_error_response():
+    with patch("blaxel.core.volume.volume.delete_volume", new_callable=AsyncMock) as mock_delete:
+        mock_delete.return_value = api_error(code=500, message="control plane exploded")
+
+        with pytest.raises(VolumeAPIError, match="control plane exploded") as excinfo:
+            await VolumeInstance.delete("my-volume")
+
+    assert excinfo.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_payload_on_success():
+    with patch("blaxel.core.volume.volume.delete_volume", new_callable=AsyncMock) as mock_delete:
+        mock_delete.return_value = Volume(
+            metadata=Metadata(name="my-volume"), spec=VolumeSpec(size=1024)
+        )
+
+        result = await VolumeInstance.delete("my-volume")
+
+        assert result.metadata.name == "my-volume"
+
+
+def test_sync_delete_raises_on_error_response():
+    with patch("blaxel.core.volume.volume.delete_volume_sync") as mock_delete:
+        mock_delete.return_value = api_error(code=404, message="volume not found")
+
+        with pytest.raises(VolumeAPIError, match="volume not found"):
+            SyncVolumeInstance.delete("my-volume")

--- a/tests/core/test_volume_errors.py
+++ b/tests/core/test_volume_errors.py
@@ -47,3 +47,20 @@ def test_sync_delete_raises_on_error_response():
 
         with pytest.raises(VolumeAPIError, match="volume not found"):
             SyncVolumeInstance.delete("my-volume")
+
+
+@pytest.mark.asyncio
+async def test_delete_raises_on_empty_response():
+    with patch("blaxel.core.volume.volume.delete_volume", new_callable=AsyncMock) as mock_delete:
+        mock_delete.return_value = None
+
+        with pytest.raises(VolumeAPIError, match="Failed to delete volume my-volume"):
+            await VolumeInstance.delete("my-volume")
+
+
+def test_sync_delete_raises_on_empty_response():
+    with patch("blaxel.core.volume.volume.delete_volume_sync") as mock_delete:
+        mock_delete.return_value = None
+
+        with pytest.raises(VolumeAPIError, match="Failed to delete volume my-volume"):
+            SyncVolumeInstance.delete("my-volume")

--- a/tests/integration/core/sandbox/test_lifecycle.py
+++ b/tests/integration/core/sandbox/test_lifecycle.py
@@ -425,11 +425,11 @@ class TestUpdateLifecyclePreservesState(TestSandboxLifecycleAndExpiration):
                     value="20m",
                     action=ExpirationPolicyAction.DELETE,
                 ),
-                ExpirationPolicy(
-                    type_=ExpirationPolicyType.TTL_IDLE,
-                    value="10m",
-                    action=ExpirationPolicyAction.DELETE,
-                ),
+                # Exactly one ttl-idle: the control plane rejects duplicates of a
+                # policy type with a 400. That 400 used to be swallowed by
+                # update_lifecycle, so this test passed while the update never
+                # applied -- it asserted the file survived a change that never
+                # happened.
                 ExpirationPolicy(
                     type_=ExpirationPolicyType.TTL_IDLE,
                     value="10m",


### PR DESCRIPTION
Reported by Mathis Joffre in the shared EvenUp channel.

## What broke

Every generated control-plane API function returns `Union[Error, T] | None`, so an error status is a **return value**, not an exception. `SandboxInstance.update_metadata / update_ttl / update_lifecycle / update_network` and `delete` passed that response straight into `cls(response)`. `SandboxInstance.__init__` does not type-check, so it built an instance wrapping an `Error` and constructed `.fs`, `.process`, `.previews` over it.

Two failure modes, the first worse than how it was reported:

1. **Silent no-op.** The common call shape ignores the return value. A 403/404/500 on `update_ttl` returned normally and the TTL was never applied. A failed `delete` returned normally and the sandbox stayed alive and kept billing. No exception, no log.
2. **Displaced failure.** Callers that used the result hit `AttributeError: 'Error' object has no attribute 'metadata'` arbitrarily far from the real cause.

Reproduced against a mocked control plane on `main` @ `2c405e2`:

```
update_ttl        -> returned SandboxInstance wrapping Error
                     leaked payload: {"error":"FORBIDDEN","code":403,"message":"insufficient permissions"}
                     result.metadata.name -> AttributeError
update_lifecycle  -> same
update_metadata   -> same
update_network    -> same
delete            -> returned Error (typed as Sandbox)
get (guarded)     -> returned SandboxInstance wrapping Sandbox   # control
```

Confirmed present in the published `blaxel==0.3.5` wheel, so this is live for customers rather than only on `main`.

## Scope

| Location | Problem |
|---|---|
| `sandbox/default/sandbox.py` | 4 `update_*` unguarded |
| `sandbox/default/sandbox.py` | `delete` only checked `None`, then raised a misleading `ValueError("Sandbox X not found")` for what may have been a 500 |
| `sandbox/sync/sandbox.py` | same 4, `SyncSandboxInstance` |
| `sandbox/sync/sandbox.py` | `delete` had no check at all |
| `volume/volume.py` | `_delete_volume_by_name` / `_sync`, identical shape and identical generated `Union[Error, Volume]` type |

`create`, `get`, `list`, `fork`, `snapshot*` were already correctly guarded.

Supporting evidence that this already bites us internally: `tests/integration/core/conftest.py` carries an `_api_error(response)` helper that sniffs returned values for a leaked `Error` during sandbox cleanup.

## Fix

Route the responses through `_unwrap_response()`, which already exists in `sandbox/default/sandbox.py` and is already imported by the sync tree. It was added in #201 for the fork/snapshot helpers and simply never applied to the update/delete paths. Volume delete uses the guard shape already repeated six times in that file, so no new abstraction is introduced there either.

```python
- return cls(response)
+ return cls(_unwrap_response(response, "update sandbox TTL"))

- if response is None:
-     raise ValueError(f"Sandbox {sandbox_name} not found")
- return response
+ return _unwrap_response(response, f"delete sandbox {sandbox_name}")
```

17 lines added and 4 removed across three source files. The `_unwrap_response` docstring is updated to state the rule, since it now governs every write path rather than only fork/snapshot.

## Behavior change

`delete` on a 404 now raises `SandboxAPIError` instead of silently returning an `Error`, and the empty response raises `SandboxAPIError` instead of `ValueError`. This is the intended correction, but it is breaking for anyone relying on best-effort deletes.

## Cross-SDK parity

- **TypeScript**: `@blaxel/core/src/sandbox/sandbox.ts` passes `throwOnError: true` on every `updateSandbox` / `deleteSandbox`. Already correct.
- **Go**: Stainless-generated, idiomatic `(res, err)`. Already correct.
- **Python**: the only affected SDK.

## Verification

- Red/green: with the source fix reverted and only the new tests applied, **18 tests fail**; with the fix restored, **80 pass**. The tests pin the bug rather than restating the implementation.
- Full unit suite: **421 passed, 2 failed**. Both failures are pre-existing on unpatched `main` (stale local device-mode credentials hitting `api.blaxel.ai/v0/oauth/token`), confirmed by stashing the patch and re-running.
- `make lint` (`ruff check --fix`): all checks passed. Note that `ruff format` is deliberately not run, since it reformats 98 unrelated generated files and is not part of the `lint` target.
- End-to-end with real `httpx` over a mocked transport: all five paths now raise `SandboxAPIError`, and the 200 control path still returns a proper `SandboxInstance`.

Coverage added: each of the 4 `update_*` x {`Error`, `None`} x {async, sync}, class-level and instance-level `delete`, volume delete in both trees, plus a success-path test so the guard cannot regress into "always raises".

## Out of scope

`drive/drive.py`. The drives OpenAPI declares no error schema, so the generated `_parse_response` returns `cast(Any, None)` for 401/404. The six `isinstance(response, Error)` guards in that file are dead code that can never fire, and drive errors silently collapse to `None`. That needs a contract correction plus regeneration, sibling to ENG-4050 / ENG-4072, and is tracked separately.

Linear: ENG-4244

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a test fix (commit `66cb48b`) that removes a duplicate `ttl-idle` policy entry from an integration test. The control plane rejects duplicate policy types with a 400, which was previously swallowed silently — now that `update_lifecycle` raises, the duplicate surfaced as a test failure.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 66cb48bffd4478b7edee17107dce49e9efcdd05f.</sup>
<!-- /MENDRAL_SUMMARY -->