### PR TITLE
fix(deps): cap mcp below 2.0.0 (ENG-4250)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,10 @@ dependencies = [
   "websockets<16.0.0",
   "attrs>=21.3.0",
   "httpx>=0.27.0",
-  "mcp>=1.9.4",
+  # mcp 2.0.0 removed mcp.server.fastmcp, which core/mcp/server.py subclasses.
+  # Cap until that surface is migrated; an unbounded range let a major bump
+  # break every fresh install (CI resolves outside uv.lock via `uv pip install`).
+  "mcp>=1.9.4,<2.0.0",
   "dockerfile-parse>=2.0.0",
 ]
 


### PR DESCRIPTION
## What broke

`mcp 2.0.0` was published today at 13:45 UTC and removed the `mcp.server.fastmcp` module. `src/blaxel/core/mcp/server.py` subclasses it:

```python
from mcp.server.fastmcp import FastMCP as FastMCPBase
```

`pyproject.toml` declared `mcp>=1.9.4` with no upper bound, and the workflow's first step runs `uv pip install -e .`, which resolves fresh and ignores `uv.lock`. Every fresh install now fails at import:

```
File "src/blaxel/core/mcp/server.py", line 13, in <module>
    from mcp.server.fastmcp import FastMCP as FastMCPBase
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

This kills `Test package installation (base)` **before any test executes**, so `Unit Tests` fails across 3.10-3.14. It is repo-wide, not branch-specific: every open PR and the next push to `main`. Last green `main` run was 2026-07-24, before the release.

Published wheel contents:

| version | files under `mcp/server/fastmcp` |
|---|---|
| `1.20.0` | 19 |
| `2.0.0` | **0** |

Upstream split FastMCP out into the standalone `fastmcp` package (currently 3.4.5).

## Blast radius is one import

Every `mcp` import in our source was audited. Only FastMCP is gone:

| our import | status in 2.0.0 |
|---|---|
| `mcp.ClientSession` | survives |
| `mcp.client.streamable_http` | survives |
| `mcp.shared.message.SessionMessage` | survives |
| `mcp.types` | survives |
| `mcp.server.fastmcp.FastMCP` | **removed** |

Total dependency: one import and one subclass overriding `run()`, in a 148-line file.

## Fix

```diff
-  "mcp>=1.9.4",
+  "mcp>=1.9.4,<2.0.0",
```

A major bump is entitled to break; the unbounded `>=` was the actual defect. This matches the existing `websockets<16.0.0` precedent in the same dependency list. `uv lock` produces no change, since the lockfile already resolved inside 1.x, so the diff is one file.

## Verification

- Reproduced the exact CI failure locally on clean `main` @ `2c405e2` using the workflow's own commands (`uv venv`, `uv pip install -e .`, `import blaxel.core`): `ModuleNotFoundError`.
- With the cap, the same commands resolve `mcp 1.29.0` and emit the workflow's own success lines for both `Test package installation (base)` and `(with extras)`.
- Unit suite: 401 passed, 2 failed, both pre-existing on unpatched `main` (stale local device-mode credentials hitting `api.blaxel.ai/v0/oauth/token`).
- `uv lock`: no change.

## Deliberately not in this PR

Migrating off the removed FastMCP surface. It is small, but it needs an owner decision about the MCP server surface, and an outage stop-gap is the wrong place for it.

Also observed while auditing: 9 of 11 core dependencies are unbounded (`pydantic`, `pyjwt`, `python-dateutil`, `pyyaml`, `requests`, `tomli`, `attrs`, `httpx`, `dockerfile-parse`). The same failure mode is available to any of them, but a reflexive mass-cap is a policy decision rather than a fix for this outage.

## Unblocks

ENG-4244 / #206, whose only red checks are this failure.

Linear: ENG-4250

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Caps the `mcp` dependency at `<2.0.0` to prevent CI failures caused by `mcp 2.0.0` removing the `mcp.server.fastmcp` module that this SDK subclasses.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 899177d52bdf78cbe9cf3c13c54e6680c9f89a84.</sup>
<!-- /MENDRAL_SUMMARY -->