### PR TITLE
fix(jobs): exit non-zero when a job task raises (ENG-4261)

### DIFF
--- a/src/blaxel/core/jobs/__init__.py
+++ b/src/blaxel/core/jobs/__init__.py
@@ -70,6 +70,7 @@ class BlJobWrapper:
                 func(**parsed_args)
         except Exception as error:
             logger.error(f"Job execution failed: {error}")
+            raise SystemExit(1) from error
 
 
 logger = getLogger(__name__)

--- a/tests/core/test_jobs.py
+++ b/tests/core/test_jobs.py
@@ -76,3 +76,31 @@ async def test_bl_job_representation():
     # Test string representation
     assert str(job) == "Job test-job"
     assert repr(job) == "Job test-job"
+
+
+def test_bl_start_job_success_returns_normally(monkeypatch):
+    """A task that completes must not raise."""
+    from blaxel.core.jobs import bl_start_job
+
+    monkeypatch.setattr("sys.argv", ["job"])
+    monkeypatch.delenv("BL_EXECUTION_DATA_URL", raising=False)
+
+    calls = []
+    bl_start_job.start(lambda **kwargs: calls.append(kwargs))
+    assert calls == [{}]
+
+
+def test_bl_start_job_failure_exits_nonzero(monkeypatch):
+    """A task that raises must exit the job process with a non-zero code (ENG-4261)."""
+    from blaxel.core.jobs import bl_start_job
+
+    monkeypatch.setattr("sys.argv", ["job"])
+    monkeypatch.delenv("BL_EXECUTION_DATA_URL", raising=False)
+
+    def boom(**kwargs):
+        raise RuntimeError("task failed")
+
+    with pytest.raises(SystemExit) as excinfo:
+        bl_start_job.start(boom)
+    assert excinfo.value.code == 1
+    assert isinstance(excinfo.value.__cause__, RuntimeError)


### PR DESCRIPTION
Fixes ENG-4261

## What

`BlJobWrapper.start()` caught every task exception, logged it, and returned normally — so the job process exited 0 and the execution plane recorded **`succeeded` for failed tasks**. Observed live on 2026-07-28 (workspace `calibrator`, job `agents-api-cookbook-job`): the task raised, the log showed `Job execution failed: …`, and the execution status API returned `"status": "succeeded"` with `stats.success: 1`.

The except block now re-raises as `SystemExit(1)` (with the original exception chained), so a failed task produces a non-zero process exit and the execution reflects the failure.

## Tests

- `test_bl_start_job_failure_exits_nonzero`: a raising task exits with code 1 and chains the original error.
- `test_bl_start_job_success_returns_normally`: guard for the success path.
- `uv run pytest tests/core/test_jobs.py` (7 passed) and `ruff check` clean.

## Platform verification plan

After merge I will deploy a deliberately failing job installing `blaxel` from this commit and confirm the execution status API reports `failed` (will attach evidence to ENG-4261).

## Note

TypeScript SDK should be checked for the same swallow pattern; ENG-4261 carries that as a follow-up item.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a bug where job task exceptions were swallowed (logged but not propagated), causing the process to exit 0 and the execution plane to report success. Now re-raises as `SystemExit(1)` with the original exception chained.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a5b0081bdb8b8b6a975ff1d042b59eb406d4765f.</sup>
<!-- /MENDRAL_SUMMARY -->