### PR TITLE
ci: test minimum and latest framework versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,6 +69,53 @@ jobs:
           source .venv/bin/activate
           make test
 
+  framework-compatibility:
+    name: Compatibility (${{ matrix.target.framework }}, ${{ matrix.version }}, Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    env:
+      BL_API_KEY: fake_api_key
+      BL_WORKSPACE: fake_workspace
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.14"]
+        version: [minimum, latest]
+        target:
+          - framework: openai
+            package: openai-agents
+            minimum: "0.0.19"
+            test: tests/compatibility/test_openai_adapter.py
+          - framework: googleadk
+            package: google-adk
+            # 1.5.0 is the first non-yanked release allowed by >=1.4.0.
+            minimum: "1.5.0"
+            test: tests/compatibility/test_googleadk_adapter.py
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install ${{ matrix.version }} dependencies
+        run: |
+          uv venv
+          source .venv/bin/activate
+          packages=(-e ".[${{ matrix.target.framework }}]" pytest pytest-asyncio)
+          if [[ "${{ matrix.version }}" == "minimum" ]]; then
+            packages+=("${{ matrix.target.package }}==${{ matrix.target.minimum }}")
+          fi
+          uv pip install "${packages[@]}"
+          uv pip check
+          python -c "from importlib.metadata import version; print('${{ matrix.target.package }}=' + version('${{ matrix.target.package }}'))"
+
+      - name: Test ${{ matrix.target.framework }} adapter
+        run: |
+          source .venv/bin/activate
+          pytest -q ${{ matrix.target.test }}
+
   integration-test:
     name: Integration Tests (Core)
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Install uv"
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,7 +92,7 @@ jobs:
             test: tests/compatibility/test_googleadk_adapter.py
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Install uv"
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0

--- a/tests/compatibility/test_googleadk_adapter.py
+++ b/tests/compatibility/test_googleadk_adapter.py
@@ -1,0 +1,69 @@
+import inspect
+
+import pytest
+
+pytest.importorskip("google.adk", reason="google-adk is not installed")
+
+from google.adk.agents import Agent  # noqa: E402
+from google.adk.runners import Runner  # noqa: E402
+from google.adk.sessions import InMemorySessionService  # noqa: E402
+
+from blaxel.core.tools.types import Tool  # noqa: E402
+from blaxel.googleadk.model import get_google_adk_model  # noqa: E402
+from blaxel.googleadk.tools import GoogleADKTool  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_googleadk_adapter_constructs_runner_and_invokes_tool():
+    expected_tool_context = object()
+
+    async def add(a: int, b: int, tool_context=None) -> dict[str, int]:
+        assert tool_context is expected_tool_context
+        return {"sum": a + b}
+
+    tool = Tool(
+        name="add",
+        description="Add two numbers",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer"},
+                "b": {"type": "integer"},
+            },
+            "required": ["a", "b"],
+            "additionalProperties": False,
+        },
+        coroutine=add,
+    )
+
+    wrapped_tool = GoogleADKTool(tool)
+    declaration = wrapped_tool._get_declaration()
+    assert declaration is not None
+    assert declaration.name == "add"
+    assert await wrapped_tool.run_async(
+        args={"a": 2, "b": 3}, tool_context=expected_tool_context
+    ) == {"sum": 5}
+
+    model = await get_google_adk_model(
+        "https://example.invalid", "openai", "compatibility-test"
+    )
+    agent = Agent(
+        name="compatibility_test",
+        instruction="Do not run.",
+        model=model,
+        tools=[wrapped_tool],
+    )
+    session_service = InMemorySessionService()
+    session_result = session_service.create_session(
+        app_name="compatibility-test",
+        user_id="compatibility-user",
+    )
+    session = await session_result if inspect.isawaitable(session_result) else session_result
+    runner = Runner(
+        agent=agent,
+        app_name="compatibility-test",
+        session_service=session_service,
+    )
+
+    assert session is not None
+    assert runner is not None

--- a/tests/compatibility/test_openai_adapter.py
+++ b/tests/compatibility/test_openai_adapter.py
@@ -1,0 +1,54 @@
+import pytest
+
+pytest.importorskip("agents", reason="openai-agents is not installed")
+
+from agents import Agent, OpenAIChatCompletionsModel  # noqa: E402
+from openai import AsyncOpenAI  # noqa: E402
+
+from blaxel.core.tools.types import Tool  # noqa: E402
+from blaxel.openai.model import DynamicHeadersHTTPClient  # noqa: E402
+from blaxel.openai.tools import get_openai_tool  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_openai_adapter_constructs_agent_and_invokes_tool():
+    async def add(a: int, b: int) -> dict[str, int]:
+        return {"sum": a + b}
+
+    tool = Tool(
+        name="add",
+        description="Add two numbers",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer"},
+                "b": {"type": "integer"},
+            },
+            "required": ["a", "b"],
+            "additionalProperties": False,
+        },
+        coroutine=add,
+    )
+
+    wrapped_tool = get_openai_tool(tool)
+    assert await wrapped_tool.on_invoke_tool(None, '{"a": 2, "b": 3}') == {"sum": 5}
+
+    http_client = DynamicHeadersHTTPClient(base_url="https://example.invalid")
+    try:
+        model = OpenAIChatCompletionsModel(
+            model="compatibility-test",
+            openai_client=AsyncOpenAI(
+                base_url="https://example.invalid/v1",
+                api_key="not-a-secret",
+                http_client=http_client,
+            ),
+        )
+        agent = Agent(
+            name="compatibility-test",
+            instructions="Do not run.",
+            model=model,
+            tools=[wrapped_tool],
+        )
+        assert agent is not None
+    finally:
+        await http_client.aclose()


### PR DESCRIPTION
Fixes ENG-4308

## Summary

- add offline compatibility tests for the OpenAI Agents and Google ADK adapters
- run each adapter against its effective minimum and latest dependency version
- cover Python 3.10 and 3.14, while existing live framework tests cover Python 3.12
- keep the current dependency floors instead of forcing breaking framework upgrades

## Why

Fresh installs already resolve current framework releases because these extras use open-ended `>=` constraints. Raising the floors in #203 and #204 would only reject previously supported environments. The existing minimum versions and current releases both pass the adapter contract, so CI coverage is safer than forcing upgrades.

Google ADK 1.5.0 is the first non-yanked release available under the existing `google-adk>=1.4.0` constraint.

## Verification

- all 8 minimum/latest compatibility combinations passed locally
- Python 3.10 and 3.14 passed for both frameworks
- 427 unit tests passed; 2 optional-dependency tests skipped in the base environment
- Ruff passed
- actionlint passed
- wheel and source distribution builds passed

Supersedes the dependency-floor approach in #203 and #204.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `framework-compatibility` CI job testing OpenAI Agents and Google ADK adapters against minimum and latest dependency versions on Python 3.10 and 3.14, with two new offline compatibility test files.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3d7901b1341f67d43a8e75d75d821d7b547216e3.</sup>
<!-- /MENDRAL_SUMMARY -->