### PR TITLE
Add Trustabl security scanning to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you've built a Python SDK for interacting with the Blaxel platform, which seems like a really innovative approach to secure sandbox management. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing. 

1. [MEDIUM] Project uses default OpenAI tracing
   What it means: The project uses the OpenAI Agents SDK with default tracing enabled.

2. [MEDIUM] LlmAgent has no description
   File: tests/integration/googleadk/test_tools.py
   What it means: Google ADK routes delegation between agents using the `description=` field on each LlmAgent.

3. [MEDIUM] Agent has no safety_settings
   File: tests/integration/googleadk/test_tools.py
   What it means: Google ADK agents use Gemini models whose configurable content filters default to OFF when safety_settings is not provided.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new GitHub Actions workflow that runs the Trustabl static analyzer for AI agent reliability on pushes to main and all PRs, uploading SARIF results to GitHub's Security tab.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a8cf516cd9c92af9f470372cfcfe8a83d05af325.</sup>
<!-- /MENDRAL_SUMMARY -->