### PR TITLE
fix(sandbox): replace bare except with except Exception

### DIFF
--- a/src/blaxel/core/sandbox/default/filesystem.py
+++ b/src/blaxel/core/sandbox/default/filesystem.py
@@ -462,7 +462,7 @@ class SandboxFileSystem(SandboxAction):
 
                                         content = await self.read(file_path)
                                         file_event.content = content
-                                    except:
+                                    except Exception:
                                         file_event.content = None
 
                                 await callback(file_event)

--- a/src/blaxel/core/sandbox/default/process.py
+++ b/src/blaxel/core/sandbox/default/process.py
@@ -407,7 +407,7 @@ class SandboxProcess(SandboxAction):
             try:
                 data = await self.get(identifier)
                 status = data.status or "running"
-            except:
+            except Exception:
                 break
 
             if (asyncio.get_running_loop().time() * 1000) - start_time > max_wait:


### PR DESCRIPTION
Fixes ENG-4605

## Summary

Two bare `except:` clauses in the async sandbox path catch `KeyboardInterrupt` and `SystemExit`, preventing users from cleanly interrupting long-running operations. The sync counterpart (`SyncSandboxProcess.wait()`) already uses `except Exception:` — this aligns the async side.

## Changes

- **`sandbox/default/process.py`** — `wait()` polling loop: `except:` → `except Exception:`
- **`sandbox/default/filesystem.py`** — `watch()` content-read fallback: `except:` → `except Exception:`

## Why

Bare `except:` is a [well-documented Python anti-pattern](https://docs.python.org/3/howto/logging.html#exceptions) that swallows `KeyboardInterrupt` (Ctrl+C), `SystemExit` (graceful shutdown), and `GeneratorExit`. In a polling loop like `wait()`, this means a user pressing Ctrl+C during a long process wait silently continues polling instead of exiting. The filesystem watcher has the same issue when reading file content fails for a non-exception reason.

## Validation

- Verified the sync `SyncSandboxProcess.wait()` already uses `except Exception:` (line 351)
- Both changes are mechanical single-line fixes with no behavioral change for normal `Exception` subclasses

Made with [Cursor](https://cursor.com)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces two bare `except:` clauses with `except Exception:` in the async sandbox code paths (process polling loop and filesystem watcher), aligning them with the sync counterpart that already uses `except Exception:`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b611d0663d926ba979cd470576dfb815d42fa1fe.</sup>
<!-- /MENDRAL_SUMMARY -->