### PR TITLE
fix(sandbox): retry safe pre-dispatch failures (ENG-2972)

### DIFF
--- a/src/blaxel/core/sandbox/client/client.py
+++ b/src/blaxel/core/sandbox/client/client.py
@@ -5,6 +5,28 @@ from typing import Any, Union
 import httpx
 from attrs import define, evolve, field
 
+from ..transient_retry import (
+    is_replayable_request,
+    retry_safe_request,
+    retry_safe_request_async,
+)
+
+
+class SandboxHTTPClient(httpx.Client):
+    def request(self, *args: Any, **kwargs: Any) -> httpx.Response:
+        request = super().request
+        if not is_replayable_request(kwargs):
+            return request(*args, **kwargs)
+        return retry_safe_request(lambda: request(*args, **kwargs))
+
+
+class AsyncSandboxHTTPClient(httpx.AsyncClient):
+    async def request(self, *args: Any, **kwargs: Any) -> httpx.Response:
+        request = super().request
+        if not is_replayable_request(kwargs):
+            return await request(*args, **kwargs)
+        return await retry_safe_request_async(lambda: request(*args, **kwargs))
+
 
 @define
 class Client:
@@ -109,7 +131,7 @@ class Client:
     def get_httpx_client(self) -> httpx.Client:
         """Get the underlying httpx.Client, constructing a new one if not previously set"""
         if self._client is None:
-            self._client = httpx.Client(
+            self._client = SandboxHTTPClient(
                 base_url=self._base_url,
                 cookies=self._cookies,
                 headers=self._headers,
@@ -150,7 +172,7 @@ class Client:
             self._async_client_loop = None
 
         if self._async_client is None:
-            self._async_client = httpx.AsyncClient(
+            self._async_client = AsyncSandboxHTTPClient(
                 base_url=self._base_url,
                 cookies=self._cookies,
                 headers=self._headers,

--- a/src/blaxel/core/sandbox/client/errors.py
+++ b/src/blaxel/core/sandbox/client/errors.py
@@ -147,7 +147,7 @@ def from_response(
         return ConflictError(status_code, content, headers)
     if status_code == HTTPStatus.TOO_MANY_REQUESTS:
         return RateLimitError(status_code, content, headers)
-    return UnexpectedStatus(status_code, content)
+    return APIStatusError(status_code, content, headers)
 
 
 __all__ = [

--- a/src/blaxel/core/sandbox/default/action.py
+++ b/src/blaxel/core/sandbox/default/action.py
@@ -2,6 +2,7 @@ import httpx
 
 from ...common.internal import get_forced_url, get_global_unique_hash
 from ...common.settings import settings
+from ..client.client import AsyncSandboxHTTPClient
 from ..types import ResponseError, SandboxConfiguration
 
 
@@ -57,7 +58,7 @@ class SandboxAction:
         """Get persistent HTTP client for this sandbox instance."""
         if self._client is None:
             base_url = self.sandbox_config.force_url or self.url
-            self._client = httpx.AsyncClient(
+            self._client = AsyncSandboxHTTPClient(
                 base_url=base_url,
                 headers=self.sandbox_config.headers
                 if self.sandbox_config.force_url

--- a/src/blaxel/core/sandbox/default/filesystem.py
+++ b/src/blaxel/core/sandbox/default/filesystem.py
@@ -10,7 +10,11 @@ import httpx
 
 from ...common.settings import settings
 from ..client.models import Directory, FileRequest, SuccessResponse
-from ..transient_retry import retry_on_transient_reset_async
+from ..transient_retry import (
+    retry_on_transient_reset_async,
+    retry_safe_request_async,
+    retry_safe_stream_async,
+)
 from ..types import (
     AsyncWatchHandle,
     CopyResponse,
@@ -99,16 +103,23 @@ class SandboxFileSystem(SandboxAction):
         headers = {**settings.headers, **self.sandbox_config.headers}
 
         async def put_once() -> SuccessResponse:
-            files = {
-                "file": (
-                    "binary-file.bin",
-                    io.BytesIO(content),
-                    "application/octet-stream",
-                ),
-            }
-            data = {"permissions": "0644", "path": path}
-            client = self.get_client()
-            response = await client.put(url, files=files, data=data, headers=headers)
+            async def request_once() -> httpx.Response:
+                files = {
+                    "file": (
+                        "binary-file.bin",
+                        io.BytesIO(content),
+                        "application/octet-stream",
+                    ),
+                }
+                data = {"permissions": "0644", "path": path}
+                return await self.get_client().put(
+                    url,
+                    files=files,
+                    data=data,
+                    headers=headers,
+                )
+
+            response = await retry_safe_request_async(request_once)
             try:
                 content_bytes = await response.aread()
                 if not response.is_success:
@@ -417,8 +428,8 @@ class SandboxFileSystem(SandboxAction):
             url = f"{self.url}/watch/filesystem/{path}"
             headers = {**settings.headers, **self.sandbox_config.headers}
             async with httpx.AsyncClient() as client_instance:
-                async with client_instance.stream(
-                    "GET", url, params=params, headers=headers
+                async with retry_safe_stream_async(
+                    lambda: client_instance.stream("GET", url, params=params, headers=headers)
                 ) as response:
                     if not response.is_success:
                         raise Exception(f"Failed to start watching: {response.status_code}")
@@ -515,9 +526,16 @@ class SandboxFileSystem(SandboxAction):
         params = {"partNumber": part_number}
 
         async def put_once() -> Dict[str, Any]:
-            files = {"file": ("part", io.BytesIO(data), "application/octet-stream")}
-            client = self.get_client()
-            response = await client.put(url, files=files, params=params, headers=headers)
+            async def request_once() -> httpx.Response:
+                files = {"file": ("part", io.BytesIO(data), "application/octet-stream")}
+                return await self.get_client().put(
+                    url,
+                    files=files,
+                    params=params,
+                    headers=headers,
+                )
+
+            response = await retry_safe_request_async(request_once)
             try:
                 self.handle_response_error(response)
                 result = json.loads(await response.aread())

--- a/src/blaxel/core/sandbox/default/filesystem.py
+++ b/src/blaxel/core/sandbox/default/filesystem.py
@@ -19,6 +19,7 @@ from ..transient_retry import (
 from ..types import (
     AsyncWatchHandle,
     CopyResponse,
+    ResponseError,
     SandboxConfiguration,
     SandboxFilesystemFile,
     WatchEvent,
@@ -123,9 +124,7 @@ class SandboxFileSystem(SandboxAction):
             response = await retry_safe_request_async(request_once)
             try:
                 content_bytes = await response.aread()
-                if not response.is_success:
-                    error_text = content_bytes.decode("utf-8", errors="ignore")
-                    raise Exception(f"Failed to write binary: {response.status_code} {error_text}")
+                self.handle_response_error(response)
                 result = SuccessResponse.from_dict(json.loads(content_bytes))
                 assert result is not None
                 return result
@@ -433,7 +432,8 @@ class SandboxFileSystem(SandboxAction):
                     lambda: client_instance.stream("GET", url, params=params, headers=headers)
                 ) as response:
                     if not response.is_success:
-                        raise Exception(f"Failed to start watching: {response.status_code}")
+                        await response.aread()
+                        raise ResponseError(response)
                     buffer = ""
                     async for chunk in response.aiter_text():
                         if closed:

--- a/src/blaxel/core/sandbox/default/filesystem.py
+++ b/src/blaxel/core/sandbox/default/filesystem.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Dict, List, Union
 import httpx
 
 from ...common.settings import settings
+from ..client.client import AsyncSandboxHTTPClient
 from ..client.models import Directory, FileRequest, SuccessResponse
 from ..transient_retry import (
     retry_on_transient_reset_async,
@@ -427,7 +428,7 @@ class SandboxFileSystem(SandboxAction):
 
             url = f"{self.url}/watch/filesystem/{path}"
             headers = {**settings.headers, **self.sandbox_config.headers}
-            async with httpx.AsyncClient() as client_instance:
+            async with AsyncSandboxHTTPClient() as client_instance:
                 async with retry_safe_stream_async(
                     lambda: client_instance.stream("GET", url, params=params, headers=headers)
                 ) as response:

--- a/src/blaxel/core/sandbox/default/interpreter.py
+++ b/src/blaxel/core/sandbox/default/interpreter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import logging
 from typing import Any, Callable, Dict
 
 import httpx
@@ -13,7 +12,6 @@ from .sandbox import SandboxInstance
 
 
 class CodeInterpreter(SandboxInstance):
-    logger = logging.getLogger(__name__)
     DEFAULT_IMAGE = "blaxel/jupyter-server"
     DEFAULT_PORTS = [
         {"name": "jupyter", "target": 8888, "protocol": "HTTP"},
@@ -280,20 +278,7 @@ class CodeInterpreter(SandboxInstance):
             body_bytes = await response.aread()
 
             if response.status_code >= 400:
-                try:
-                    body_text = body_bytes.decode("utf-8", errors="ignore")
-                except Exception:
-                    body_text = "<unavailable>"
-                method = getattr(response.request, "method", "UNKNOWN")
-                url = str(getattr(response.request, "url", "UNKNOWN"))
-                reason = getattr(response, "reason_phrase", "")
-                details = (
-                    "Create context failed\n"
-                    f"- method: {method}\n- url: {url}\n- status: {response.status_code} {reason}\n"
-                    f"- response-headers: {dict(response.headers)}\n- body:\n{body_text}"
-                )
-                self.logger.debug(details)
-                raise RuntimeError(details)
+                raise ResponseError(response)
 
             data = json.loads(body_bytes)
             return CodeInterpreter.Context.from_json(data)

--- a/src/blaxel/core/sandbox/default/interpreter.py
+++ b/src/blaxel/core/sandbox/default/interpreter.py
@@ -8,7 +8,7 @@ import httpx
 
 from ...client.models import Sandbox
 from ..transient_retry import retry_safe_stream_async
-from ..types import SandboxCreateConfiguration
+from ..types import ResponseError, SandboxCreateConfiguration
 from .sandbox import SandboxInstance
 
 
@@ -230,22 +230,8 @@ class CodeInterpreter(SandboxInstance):
             )
         ) as response:
             if response.status_code >= 400:
-                try:
-                    body_text = await response.aread()
-                    body_text = body_text.decode(errors="ignore")
-                except Exception:
-                    body_text = "<unavailable>"
-                req = getattr(response, "request", None)
-                method = getattr(req, "method", "UNKNOWN") if req else "UNKNOWN"
-                url = str(getattr(req, "url", "UNKNOWN")) if req else "UNKNOWN"
-                reason = getattr(response, "reason_phrase", "")
-                details = (
-                    "Execution failed\n"
-                    f"- method: {method}\n- url: {url}\n- status: {response.status_code} {reason}\n"
-                    f"- response-headers: {dict(response.headers)}\n- body:\n{body_text}"
-                )
-                self.logger.debug(details)
-                raise RuntimeError(details)
+                await response.aread()
+                raise ResponseError(response)
 
             async for line in response.aiter_lines():
                 if not line:

--- a/src/blaxel/core/sandbox/default/interpreter.py
+++ b/src/blaxel/core/sandbox/default/interpreter.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict
 import httpx
 
 from ...client.models import Sandbox
+from ..transient_retry import retry_safe_stream_async
 from ..types import SandboxCreateConfiguration
 from .sandbox import SandboxInstance
 
@@ -220,11 +221,13 @@ class CodeInterpreter(SandboxInstance):
             write=write_timeout,
             pool=pool_timeout,
         )
-        async with client.stream(
-            "POST",
-            "/port/8888/execute",
-            json=body,
-            timeout=timeout_cfg,
+        async with retry_safe_stream_async(
+            lambda: client.stream(
+                "POST",
+                "/port/8888/execute",
+                json=body,
+                timeout=timeout_cfg,
+            )
         ) as response:
             if response.status_code >= 400:
                 try:

--- a/src/blaxel/core/sandbox/default/process.py
+++ b/src/blaxel/core/sandbox/default/process.py
@@ -6,7 +6,7 @@ import httpx
 from ...common.settings import settings
 from ..client.models import ProcessResponse, SuccessResponse
 from ..client.models.process_request import ProcessRequest
-from ..transient_retry import retry_on_transient_reset_async
+from ..transient_retry import retry_on_transient_reset_async, retry_safe_stream_async
 from ..types import (
     AsyncStreamHandle,
     ProcessRequestWithLog,
@@ -156,7 +156,9 @@ class SandboxProcess(SandboxAction):
 
             try:
                 async with httpx.AsyncClient(timeout=None) as client_instance:
-                    async with client_instance.stream("GET", url, headers=headers) as response:
+                    async with retry_safe_stream_async(
+                        lambda: client_instance.stream("GET", url, headers=headers)
+                    ) as response:
                         if response.status_code != 200:
                             raise Exception(f"Failed to stream logs: {await response.aread()}")
 
@@ -298,16 +300,18 @@ class SandboxProcess(SandboxAction):
         )
 
         async with httpx.AsyncClient() as client_instance:
-            async with client_instance.stream(
-                "POST",
-                f"{self.url}/process",
-                headers={
-                    **headers,
-                    "Content-Type": "application/json",
-                    "Accept": "text/event-stream",
-                },
-                json=process_request.to_dict(),
-                timeout=None,
+            async with retry_safe_stream_async(
+                lambda: client_instance.stream(
+                    "POST",
+                    f"{self.url}/process",
+                    headers={
+                        **headers,
+                        "Content-Type": "application/json",
+                        "Accept": "text/event-stream",
+                    },
+                    json=process_request.to_dict(),
+                    timeout=None,
+                )
             ) as response:
                 if response.status_code >= 400:
                     error_text = await response.aread()

--- a/src/blaxel/core/sandbox/default/process.py
+++ b/src/blaxel/core/sandbox/default/process.py
@@ -1,9 +1,8 @@
 import asyncio
 from typing import Any, Callable, Dict, Literal, Union
 
-import httpx
-
 from ...common.settings import settings
+from ..client.client import AsyncSandboxHTTPClient
 from ..client.models import ProcessResponse, SuccessResponse
 from ..client.models.process_request import ProcessRequest
 from ..transient_retry import retry_on_transient_reset_async, retry_safe_stream_async
@@ -155,7 +154,7 @@ class SandboxProcess(SandboxAction):
             headers = {**settings.headers, **self.sandbox_config.headers}
 
             try:
-                async with httpx.AsyncClient(timeout=None) as client_instance:
+                async with AsyncSandboxHTTPClient(timeout=None) as client_instance:
                     async with retry_safe_stream_async(
                         lambda: client_instance.stream("GET", url, headers=headers)
                     ) as response:
@@ -299,7 +298,7 @@ class SandboxProcess(SandboxAction):
             else {**settings.headers, **self.sandbox_config.headers}
         )
 
-        async with httpx.AsyncClient() as client_instance:
+        async with AsyncSandboxHTTPClient() as client_instance:
             async with retry_safe_stream_async(
                 lambda: client_instance.stream(
                     "POST",

--- a/src/blaxel/core/sandbox/default/process.py
+++ b/src/blaxel/core/sandbox/default/process.py
@@ -314,6 +314,7 @@ class SandboxProcess(SandboxAction):
                 )
             ) as response:
                 if response.status_code >= 400:
+                    await response.aread()
                     raise ResponseError(response)
 
                 content_type = response.headers.get("Content-Type", "")

--- a/src/blaxel/core/sandbox/default/process.py
+++ b/src/blaxel/core/sandbox/default/process.py
@@ -160,7 +160,8 @@ class SandboxProcess(SandboxAction):
                         lambda: client_instance.stream("GET", url, headers=headers)
                     ) as response:
                         if response.status_code != 200:
-                            raise Exception(f"Failed to stream logs: {await response.aread()}")
+                            await response.aread()
+                            raise ResponseError(response)
 
                         buffer = ""
                         async for chunk in response.aiter_text():

--- a/src/blaxel/core/sandbox/default/process.py
+++ b/src/blaxel/core/sandbox/default/process.py
@@ -10,6 +10,7 @@ from ..types import (
     AsyncStreamHandle,
     ProcessRequestWithLog,
     ProcessResponseWithLog,
+    ResponseError,
     SandboxConfiguration,
 )
 from .action import SandboxAction
@@ -313,8 +314,7 @@ class SandboxProcess(SandboxAction):
                 )
             ) as response:
                 if response.status_code >= 400:
-                    error_text = await response.aread()
-                    raise Exception(f"Failed to execute process: {error_text}")
+                    raise ResponseError(response)
 
                 content_type = response.headers.get("Content-Type", "")
                 is_streaming = "application/x-ndjson" in content_type

--- a/src/blaxel/core/sandbox/sync/action.py
+++ b/src/blaxel/core/sandbox/sync/action.py
@@ -2,6 +2,7 @@ import httpx
 
 from ...common.internal import get_forced_url, get_global_unique_hash
 from ...common.settings import settings
+from ..client.client import SandboxHTTPClient
 from ..types import ResponseError, SandboxConfiguration
 
 
@@ -50,11 +51,11 @@ class SyncSandboxAction:
 
     def get_client(self) -> httpx.Client:
         if self.sandbox_config.force_url:
-            return httpx.Client(
+            return SandboxHTTPClient(
                 base_url=self.sandbox_config.force_url,
                 headers=self.sandbox_config.headers,
             )
-        return httpx.Client(
+        return SandboxHTTPClient(
             base_url=self.url,
             headers={**settings.headers, **self.sandbox_config.headers},
         )

--- a/src/blaxel/core/sandbox/sync/filesystem.py
+++ b/src/blaxel/core/sandbox/sync/filesystem.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Dict, List, Union
 import httpx
 
 from ...common.settings import settings
+from ..client.client import SandboxHTTPClient
 from ..client.models import Directory, FileRequest, SuccessResponse
 from ..transient_retry import retry_on_transient_reset, retry_safe_request, retry_safe_stream
 from ..types import (
@@ -223,7 +224,7 @@ class SyncSandboxFileSystem(SyncSandboxAction):
                 params["ignore"] = ",".join(options["ignore"])
             url = f"{self.url}/watch/filesystem/{path}"
             headers = {**settings.headers, **self.sandbox_config.headers}
-            with httpx.Client() as client_instance:
+            with SandboxHTTPClient() as client_instance:
                 with retry_safe_stream(
                     lambda: client_instance.stream("GET", url, params=params, headers=headers)
                 ) as response:

--- a/src/blaxel/core/sandbox/sync/filesystem.py
+++ b/src/blaxel/core/sandbox/sync/filesystem.py
@@ -10,7 +10,7 @@ import httpx
 
 from ...common.settings import settings
 from ..client.models import Directory, FileRequest, SuccessResponse
-from ..transient_retry import retry_on_transient_reset
+from ..transient_retry import retry_on_transient_reset, retry_safe_request, retry_safe_stream
 from ..types import (
     CopyResponse,
     SandboxConfiguration,
@@ -66,16 +66,20 @@ class SyncSandboxFileSystem(SyncSandboxAction):
         headers = {**settings.headers, **self.sandbox_config.headers}
 
         def put_once() -> SuccessResponse:
-            files = {
-                "file": (
-                    "binary-file.bin",
-                    io.BytesIO(content),
-                    "application/octet-stream",
-                ),
-            }
-            data = {"permissions": "0644", "path": path}
-            with self.get_client() as client_instance:
-                response = client_instance.put(url, files=files, data=data, headers=headers)
+            def request_once() -> httpx.Response:
+                files = {
+                    "file": (
+                        "binary-file.bin",
+                        io.BytesIO(content),
+                        "application/octet-stream",
+                    ),
+                }
+                data = {"permissions": "0644", "path": path}
+                with self.get_client() as client_instance:
+                    return client_instance.put(url, files=files, data=data, headers=headers)
+
+            response = retry_safe_request(request_once)
+            try:
                 if not response.is_success:
                     raise Exception(
                         f"Failed to write binary: {response.status_code} {response.text}"
@@ -83,6 +87,8 @@ class SyncSandboxFileSystem(SyncSandboxAction):
                 result = SuccessResponse.from_dict(response.json())
                 assert result is not None
                 return result
+            finally:
+                response.close()
 
         return retry_on_transient_reset(put_once, retries=settings.fs_part_retries)
 
@@ -218,7 +224,9 @@ class SyncSandboxFileSystem(SyncSandboxAction):
             url = f"{self.url}/watch/filesystem/{path}"
             headers = {**settings.headers, **self.sandbox_config.headers}
             with httpx.Client() as client_instance:
-                with client_instance.stream("GET", url, params=params, headers=headers) as response:
+                with retry_safe_stream(
+                    lambda: client_instance.stream("GET", url, params=params, headers=headers)
+                ) as response:
                     if not response.is_success:
                         raise Exception(f"Failed to start watching: {response.status_code}")
                     buffer = ""
@@ -290,11 +298,17 @@ class SyncSandboxFileSystem(SyncSandboxAction):
         params = {"partNumber": part_number}
 
         def put_once() -> Dict[str, Any]:
-            files = {"file": ("part", io.BytesIO(data), "application/octet-stream")}
-            with self.get_client() as client_instance:
-                response = client_instance.put(url, files=files, params=params, headers=headers)
+            def request_once() -> httpx.Response:
+                files = {"file": ("part", io.BytesIO(data), "application/octet-stream")}
+                with self.get_client() as client_instance:
+                    return client_instance.put(url, files=files, params=params, headers=headers)
+
+            response = retry_safe_request(request_once)
+            try:
                 self.handle_response_error(response)
                 return response.json()
+            finally:
+                response.close()
 
         return retry_on_transient_reset(put_once, retries=settings.fs_part_retries)
 

--- a/src/blaxel/core/sandbox/sync/filesystem.py
+++ b/src/blaxel/core/sandbox/sync/filesystem.py
@@ -14,6 +14,7 @@ from ..client.models import Directory, FileRequest, SuccessResponse
 from ..transient_retry import retry_on_transient_reset, retry_safe_request, retry_safe_stream
 from ..types import (
     CopyResponse,
+    ResponseError,
     SandboxConfiguration,
     SandboxFilesystemFile,
     WatchEvent,
@@ -81,10 +82,7 @@ class SyncSandboxFileSystem(SyncSandboxAction):
 
             response = retry_safe_request(request_once)
             try:
-                if not response.is_success:
-                    raise Exception(
-                        f"Failed to write binary: {response.status_code} {response.text}"
-                    )
+                self.handle_response_error(response)
                 result = SuccessResponse.from_dict(response.json())
                 assert result is not None
                 return result
@@ -229,7 +227,8 @@ class SyncSandboxFileSystem(SyncSandboxAction):
                     lambda: client_instance.stream("GET", url, params=params, headers=headers)
                 ) as response:
                     if not response.is_success:
-                        raise Exception(f"Failed to start watching: {response.status_code}")
+                        response.read()
+                        raise ResponseError(response)
                     buffer = ""
                     for chunk in response.iter_text():
                         if closed.is_set():

--- a/src/blaxel/core/sandbox/sync/interpreter.py
+++ b/src/blaxel/core/sandbox/sync/interpreter.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, Optional, Union
 import httpx
 
 from ...client.models import Sandbox
+from ..transient_retry import retry_safe_stream
 from ..types import SandboxCreateConfiguration
 from .sandbox import SyncSandboxInstance
 
@@ -233,11 +234,13 @@ class SyncCodeInterpreter(SyncSandboxInstance):
                 write=write_timeout,
                 pool=pool_timeout,
             )
-            with client.stream(
-                "POST",
-                "/port/8888/execute",
-                json=body,
-                timeout=timeout_cfg,
+            with retry_safe_stream(
+                lambda: client.stream(
+                    "POST",
+                    "/port/8888/execute",
+                    json=body,
+                    timeout=timeout_cfg,
+                )
             ) as response:
                 if response.status_code >= 400:
                     details = self._format_http_error("Execution", response)

--- a/src/blaxel/core/sandbox/sync/interpreter.py
+++ b/src/blaxel/core/sandbox/sync/interpreter.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from typing import Any, Callable, Dict, Optional, Union
 
 import httpx
@@ -11,7 +10,6 @@ from .sandbox import SyncSandboxInstance
 
 
 class SyncCodeInterpreter(SyncSandboxInstance):
-    logger = logging.getLogger(__name__)
     DEFAULT_IMAGE = "blaxel/jupyter-server"
     DEFAULT_PORTS = [
         {"name": "jupyter", "target": 8888, "protocol": "HTTP"},
@@ -170,28 +168,6 @@ class SyncCodeInterpreter(SyncSandboxInstance):
 
         return None
 
-    def _format_http_error(self, where: str, response: httpx.Response) -> str:
-        try:
-            body_text = response.text
-        except Exception:
-            body_text = "<unavailable>"
-        # Limit very large bodies
-        max_len = 4000
-        if len(body_text) > max_len:
-            body_text = body_text[:max_len] + "...<truncated>"
-        req = getattr(response, "request", None)
-        method = getattr(req, "method", "UNKNOWN") if req else "UNKNOWN"
-        url = str(getattr(req, "url", "UNKNOWN")) if req else "UNKNOWN"
-        reason = getattr(response, "reason_phrase", "")
-        return (
-            f"{where} failed\n"
-            f"- method: {method}\n"
-            f"- url: {url}\n"
-            f"- status: {response.status_code} {reason}\n"
-            f"- response-headers: {dict(response.headers)}\n"
-            f"- body:\n{body_text}"
-        )
-
     def run_code(
         self,
         code: str,
@@ -291,8 +267,6 @@ class SyncCodeInterpreter(SyncSandboxInstance):
                 timeout=request_timeout or 10.0,
             )
             if response.status_code >= 400:
-                details = self._format_http_error("Create context", response)
-                self.logger.debug(details)
-                raise RuntimeError(details)
+                raise ResponseError(response)
             data = response.json()
             return SyncCodeInterpreter.Context.from_json(data)

--- a/src/blaxel/core/sandbox/sync/interpreter.py
+++ b/src/blaxel/core/sandbox/sync/interpreter.py
@@ -6,7 +6,7 @@ import httpx
 
 from ...client.models import Sandbox
 from ..transient_retry import retry_safe_stream
-from ..types import SandboxCreateConfiguration
+from ..types import ResponseError, SandboxCreateConfiguration
 from .sandbox import SyncSandboxInstance
 
 
@@ -243,9 +243,8 @@ class SyncCodeInterpreter(SyncSandboxInstance):
                 )
             ) as response:
                 if response.status_code >= 400:
-                    details = self._format_http_error("Execution", response)
-                    self.logger.debug(details)
-                    raise RuntimeError(details)
+                    response.read()
+                    raise ResponseError(response)
 
                 for line in response.iter_lines():
                     if not line:

--- a/src/blaxel/core/sandbox/sync/process.py
+++ b/src/blaxel/core/sandbox/sync/process.py
@@ -10,6 +10,7 @@ from ..transient_retry import retry_on_transient_reset, retry_safe_stream
 from ..types import (
     ProcessRequestWithLog,
     ProcessResponseWithLog,
+    ResponseError,
     SandboxConfiguration,
     StreamHandle,
 )
@@ -259,8 +260,7 @@ class SyncSandboxProcess(SyncSandboxAction):
                 )
             ) as response:
                 if response.status_code >= 400:
-                    error_text = response.read()
-                    raise Exception(f"Failed to execute process: {error_text}")
+                    raise ResponseError(response)
 
                 content_type = response.headers.get("Content-Type", "")
                 is_streaming = "application/x-ndjson" in content_type

--- a/src/blaxel/core/sandbox/sync/process.py
+++ b/src/blaxel/core/sandbox/sync/process.py
@@ -7,7 +7,7 @@ import httpx
 from ...common.settings import settings
 from ..client.models import ProcessResponse, SuccessResponse
 from ..client.models.process_request import ProcessRequest
-from ..transient_retry import retry_on_transient_reset
+from ..transient_retry import retry_on_transient_reset, retry_safe_stream
 from ..types import (
     ProcessRequestWithLog,
     ProcessResponseWithLog,
@@ -125,7 +125,9 @@ class SyncSandboxProcess(SyncSandboxAction):
             headers = {**settings.headers, **self.sandbox_config.headers}
             try:
                 with httpx.Client() as client_instance:
-                    with client_instance.stream("GET", url, headers=headers) as response:
+                    with retry_safe_stream(
+                        lambda: client_instance.stream("GET", url, headers=headers)
+                    ) as response:
                         if response.status_code != 200:
                             raise Exception(f"Failed to stream logs: {response.text}")
                         buffer = ""
@@ -244,16 +246,18 @@ class SyncSandboxProcess(SyncSandboxAction):
         )
 
         with httpx.Client() as client_instance:
-            with client_instance.stream(
-                "POST",
-                f"{self.url}/process",
-                headers={
-                    **headers,
-                    "Content-Type": "application/json",
-                    "Accept": "text/event-stream",
-                },
-                json=process_request.to_dict(),
-                timeout=None,
+            with retry_safe_stream(
+                lambda: client_instance.stream(
+                    "POST",
+                    f"{self.url}/process",
+                    headers={
+                        **headers,
+                        "Content-Type": "application/json",
+                        "Accept": "text/event-stream",
+                    },
+                    json=process_request.to_dict(),
+                    timeout=None,
+                )
             ) as response:
                 if response.status_code >= 400:
                     error_text = response.read()

--- a/src/blaxel/core/sandbox/sync/process.py
+++ b/src/blaxel/core/sandbox/sync/process.py
@@ -260,6 +260,7 @@ class SyncSandboxProcess(SyncSandboxAction):
                 )
             ) as response:
                 if response.status_code >= 400:
+                    response.read()
                     raise ResponseError(response)
 
                 content_type = response.headers.get("Content-Type", "")

--- a/src/blaxel/core/sandbox/sync/process.py
+++ b/src/blaxel/core/sandbox/sync/process.py
@@ -2,9 +2,8 @@ import threading
 import time
 from typing import Any, Callable, Dict, Literal, Union
 
-import httpx
-
 from ...common.settings import settings
+from ..client.client import SandboxHTTPClient
 from ..client.models import ProcessResponse, SuccessResponse
 from ..client.models.process_request import ProcessRequest
 from ..transient_retry import retry_on_transient_reset, retry_safe_stream
@@ -124,7 +123,7 @@ class SyncSandboxProcess(SyncSandboxAction):
             url = f"{self.url}/process/{identifier}/logs/stream"
             headers = {**settings.headers, **self.sandbox_config.headers}
             try:
-                with httpx.Client() as client_instance:
+                with SandboxHTTPClient() as client_instance:
                     with retry_safe_stream(
                         lambda: client_instance.stream("GET", url, headers=headers)
                     ) as response:
@@ -245,7 +244,7 @@ class SyncSandboxProcess(SyncSandboxAction):
             else {**settings.headers, **self.sandbox_config.headers}
         )
 
-        with httpx.Client() as client_instance:
+        with SandboxHTTPClient() as client_instance:
             with retry_safe_stream(
                 lambda: client_instance.stream(
                     "POST",

--- a/src/blaxel/core/sandbox/sync/process.py
+++ b/src/blaxel/core/sandbox/sync/process.py
@@ -129,7 +129,8 @@ class SyncSandboxProcess(SyncSandboxAction):
                         lambda: client_instance.stream("GET", url, headers=headers)
                     ) as response:
                         if response.status_code != 200:
-                            raise Exception(f"Failed to stream logs: {response.text}")
+                            response.read()
+                            raise ResponseError(response)
                         buffer = ""
                         for chunk in response.iter_text():
                             if closed.is_set():

--- a/src/blaxel/core/sandbox/transient_retry.py
+++ b/src/blaxel/core/sandbox/transient_retry.py
@@ -103,12 +103,15 @@ def _has_safe_retry_headers(response: httpx.Response) -> bool:
 
 def is_safe_to_retry_response(response: httpx.Response) -> bool:
     """True only when the gateway proves the request was not dispatched."""
-    if not _has_safe_retry_headers(response):
+    if response.status_code != 404 or not _has_safe_retry_headers(response):
         return False
     try:
-        error = response.json().get("error", {})
+        payload = response.json()
     except (TypeError, ValueError):
         return False
+    if not isinstance(payload, dict):
+        return False
+    error = payload.get("error", {})
     return (
         isinstance(error, dict)
         and error.get("code") == "WORKLOAD_UNAVAILABLE"
@@ -133,30 +136,34 @@ def is_replayable_request(kwargs: dict[str, object]) -> bool:
 async def retry_safe_request_async(
     fn: Callable[[], Awaitable[httpx.Response]],
 ) -> httpx.Response:
-    elapsed = 0.0
+    started = time.monotonic()
+    slept = 0.0
     delay = SAFE_RETRY_INITIAL_DELAY_SECONDS
     while True:
         response = await fn()
+        elapsed = max(time.monotonic() - started, slept)
         if not is_safe_to_retry_response(response) or elapsed >= SAFE_RETRY_BUDGET_SECONDS:
             return response
         await response.aclose()
         sleep_for = min(delay, SAFE_RETRY_BUDGET_SECONDS - elapsed)
         await asyncio.sleep(sleep_for)
-        elapsed += sleep_for
+        slept += sleep_for
         delay = min(delay * 2, SAFE_RETRY_MAX_DELAY_SECONDS)
 
 
 def retry_safe_request(fn: Callable[[], httpx.Response]) -> httpx.Response:
-    elapsed = 0.0
+    started = time.monotonic()
+    slept = 0.0
     delay = SAFE_RETRY_INITIAL_DELAY_SECONDS
     while True:
         response = fn()
+        elapsed = max(time.monotonic() - started, slept)
         if not is_safe_to_retry_response(response) or elapsed >= SAFE_RETRY_BUDGET_SECONDS:
             return response
         response.close()
         sleep_for = min(delay, SAFE_RETRY_BUDGET_SECONDS - elapsed)
         time.sleep(sleep_for)
-        elapsed += sleep_for
+        slept += sleep_for
         delay = min(delay * 2, SAFE_RETRY_MAX_DELAY_SECONDS)
 
 
@@ -164,35 +171,39 @@ def retry_safe_request(fn: Callable[[], httpx.Response]) -> httpx.Response:
 async def retry_safe_stream_async(
     fn: Callable[[], AsyncContextManager[httpx.Response]],
 ):
-    elapsed = 0.0
+    started = time.monotonic()
+    slept = 0.0
     delay = SAFE_RETRY_INITIAL_DELAY_SECONDS
     while True:
         async with fn() as response:
             if _has_safe_retry_headers(response):
                 await response.aread()
+            elapsed = max(time.monotonic() - started, slept)
             if not is_safe_to_retry_response(response) or elapsed >= SAFE_RETRY_BUDGET_SECONDS:
                 yield response
                 return
         sleep_for = min(delay, SAFE_RETRY_BUDGET_SECONDS - elapsed)
         await asyncio.sleep(sleep_for)
-        elapsed += sleep_for
+        slept += sleep_for
         delay = min(delay * 2, SAFE_RETRY_MAX_DELAY_SECONDS)
 
 
 @contextmanager
 def retry_safe_stream(fn: Callable[[], ContextManager[httpx.Response]]):
-    elapsed = 0.0
+    started = time.monotonic()
+    slept = 0.0
     delay = SAFE_RETRY_INITIAL_DELAY_SECONDS
     while True:
         with fn() as response:
             if _has_safe_retry_headers(response):
                 response.read()
+            elapsed = max(time.monotonic() - started, slept)
             if not is_safe_to_retry_response(response) or elapsed >= SAFE_RETRY_BUDGET_SECONDS:
                 yield response
                 return
         sleep_for = min(delay, SAFE_RETRY_BUDGET_SECONDS - elapsed)
         time.sleep(sleep_for)
-        elapsed += sleep_for
+        slept += sleep_for
         delay = min(delay * 2, SAFE_RETRY_MAX_DELAY_SECONDS)
 
 

--- a/src/blaxel/core/sandbox/transient_retry.py
+++ b/src/blaxel/core/sandbox/transient_retry.py
@@ -107,7 +107,7 @@ def is_safe_to_retry_response(response: httpx.Response) -> bool:
         return False
     try:
         payload = response.json()
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, RecursionError):
         return False
     if not isinstance(payload, dict):
         return False

--- a/src/blaxel/core/sandbox/transient_retry.py
+++ b/src/blaxel/core/sandbox/transient_retry.py
@@ -2,7 +2,8 @@ import asyncio
 import random
 import time
 from collections.abc import Awaitable, Callable, Iterator
-from typing import TypeVar
+from contextlib import asynccontextmanager, contextmanager
+from typing import AsyncContextManager, ContextManager, TypeVar
 
 import httpx
 
@@ -33,6 +34,9 @@ TRANSIENT_ERROR_CODES = {
 
 DEFAULT_BASE_DELAY_SECONDS = 0.2
 DEFAULT_MAX_DELAY_SECONDS = 2.0
+SAFE_RETRY_INITIAL_DELAY_SECONDS = 0.5
+SAFE_RETRY_MAX_DELAY_SECONDS = 30.0
+SAFE_RETRY_BUDGET_SECONDS = 60.0
 
 
 def _walk_error_chain(error: BaseException) -> Iterator[BaseException]:
@@ -85,6 +89,111 @@ def is_transient_reset_error(error: BaseException) -> bool:
     if any(code in TRANSIENT_ERROR_CODES for code in codes):
         return True
     return any(marker in message for message in messages for marker in TRANSIENT_RESET_MARKERS)
+
+
+def _has_safe_retry_headers(response: httpx.Response) -> bool:
+    if response.headers.get("X-Blaxel-Source") != "platform":
+        return False
+    if response.headers.get("X-Blaxel-Error-Code") != "WORKLOAD_UNAVAILABLE":
+        return False
+    if response.headers.get("X-Blaxel-Dispatch-State") != "not_dispatched":
+        return False
+    return True
+
+
+def is_safe_to_retry_response(response: httpx.Response) -> bool:
+    """True only when the gateway proves the request was not dispatched."""
+    if not _has_safe_retry_headers(response):
+        return False
+    try:
+        error = response.json().get("error", {})
+    except (TypeError, ValueError):
+        return False
+    return (
+        isinstance(error, dict)
+        and error.get("code") == "WORKLOAD_UNAVAILABLE"
+        and error.get("origin") == "platform"
+        and error.get("retryable") is True
+        and error.get("dispatch_state") == "not_dispatched"
+        and error.get("safe_to_retry_request") is True
+    )
+
+
+def is_replayable_request(kwargs: dict[str, object]) -> bool:
+    """Whether httpx can rebuild the same request body for another attempt."""
+    if kwargs.get("files") is not None:
+        return False
+    content = kwargs.get("content")
+    if content is not None and not isinstance(content, bytes | str):
+        return False
+    data = kwargs.get("data")
+    return data is None or isinstance(data, bytes | str | dict | list | tuple)
+
+
+async def retry_safe_request_async(
+    fn: Callable[[], Awaitable[httpx.Response]],
+) -> httpx.Response:
+    elapsed = 0.0
+    delay = SAFE_RETRY_INITIAL_DELAY_SECONDS
+    while True:
+        response = await fn()
+        if not is_safe_to_retry_response(response) or elapsed >= SAFE_RETRY_BUDGET_SECONDS:
+            return response
+        await response.aclose()
+        sleep_for = min(delay, SAFE_RETRY_BUDGET_SECONDS - elapsed)
+        await asyncio.sleep(sleep_for)
+        elapsed += sleep_for
+        delay = min(delay * 2, SAFE_RETRY_MAX_DELAY_SECONDS)
+
+
+def retry_safe_request(fn: Callable[[], httpx.Response]) -> httpx.Response:
+    elapsed = 0.0
+    delay = SAFE_RETRY_INITIAL_DELAY_SECONDS
+    while True:
+        response = fn()
+        if not is_safe_to_retry_response(response) or elapsed >= SAFE_RETRY_BUDGET_SECONDS:
+            return response
+        response.close()
+        sleep_for = min(delay, SAFE_RETRY_BUDGET_SECONDS - elapsed)
+        time.sleep(sleep_for)
+        elapsed += sleep_for
+        delay = min(delay * 2, SAFE_RETRY_MAX_DELAY_SECONDS)
+
+
+@asynccontextmanager
+async def retry_safe_stream_async(
+    fn: Callable[[], AsyncContextManager[httpx.Response]],
+):
+    elapsed = 0.0
+    delay = SAFE_RETRY_INITIAL_DELAY_SECONDS
+    while True:
+        async with fn() as response:
+            if _has_safe_retry_headers(response):
+                await response.aread()
+            if not is_safe_to_retry_response(response) or elapsed >= SAFE_RETRY_BUDGET_SECONDS:
+                yield response
+                return
+        sleep_for = min(delay, SAFE_RETRY_BUDGET_SECONDS - elapsed)
+        await asyncio.sleep(sleep_for)
+        elapsed += sleep_for
+        delay = min(delay * 2, SAFE_RETRY_MAX_DELAY_SECONDS)
+
+
+@contextmanager
+def retry_safe_stream(fn: Callable[[], ContextManager[httpx.Response]]):
+    elapsed = 0.0
+    delay = SAFE_RETRY_INITIAL_DELAY_SECONDS
+    while True:
+        with fn() as response:
+            if _has_safe_retry_headers(response):
+                response.read()
+            if not is_safe_to_retry_response(response) or elapsed >= SAFE_RETRY_BUDGET_SECONDS:
+                yield response
+                return
+        sleep_for = min(delay, SAFE_RETRY_BUDGET_SECONDS - elapsed)
+        time.sleep(sleep_for)
+        elapsed += sleep_for
+        delay = min(delay * 2, SAFE_RETRY_MAX_DELAY_SECONDS)
 
 
 def _backoff_delay_seconds(

--- a/src/blaxel/core/sandbox/transient_retry.py
+++ b/src/blaxel/core/sandbox/transient_retry.py
@@ -1,7 +1,7 @@
 import asyncio
 import random
 import time
-from collections.abc import Awaitable, Callable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from typing import AsyncContextManager, ContextManager, TypeVar
 
@@ -124,13 +124,32 @@ def is_safe_to_retry_response(response: httpx.Response) -> bool:
 
 def is_replayable_request(kwargs: dict[str, object]) -> bool:
     """Whether httpx can rebuild the same request body for another attempt."""
-    if kwargs.get("files") is not None:
+    files = kwargs.get("files")
+    if files is not None and not _is_replayable_files(files):
         return False
     content = kwargs.get("content")
     if content is not None and not isinstance(content, bytes | str):
         return False
     data = kwargs.get("data")
     return data is None or isinstance(data, bytes | str | dict | list | tuple)
+
+
+def _is_replayable_files(files: object) -> bool:
+    if isinstance(files, dict):
+        values = files.values()
+    elif isinstance(files, list | tuple):
+        if not all(isinstance(item, tuple) and len(item) == 2 for item in files):
+            return False
+        values = (item[1] for item in files)
+    else:
+        return False
+    return all(_is_replayable_file(value) for value in values)
+
+
+def _is_replayable_file(value: object) -> bool:
+    if isinstance(value, bytes):
+        return True
+    return isinstance(value, tuple) and len(value) >= 2 and isinstance(value[1], bytes)
 
 
 async def retry_safe_request_async(
@@ -170,13 +189,13 @@ def retry_safe_request(fn: Callable[[], httpx.Response]) -> httpx.Response:
 @asynccontextmanager
 async def retry_safe_stream_async(
     fn: Callable[[], AsyncContextManager[httpx.Response]],
-):
+) -> AsyncIterator[httpx.Response]:
     started = time.monotonic()
     slept = 0.0
     delay = SAFE_RETRY_INITIAL_DELAY_SECONDS
     while True:
         async with fn() as response:
-            if _has_safe_retry_headers(response):
+            if response.status_code == 404 and _has_safe_retry_headers(response):
                 await response.aread()
             elapsed = max(time.monotonic() - started, slept)
             if not is_safe_to_retry_response(response) or elapsed >= SAFE_RETRY_BUDGET_SECONDS:
@@ -189,13 +208,15 @@ async def retry_safe_stream_async(
 
 
 @contextmanager
-def retry_safe_stream(fn: Callable[[], ContextManager[httpx.Response]]):
+def retry_safe_stream(
+    fn: Callable[[], ContextManager[httpx.Response]],
+) -> Iterator[httpx.Response]:
     started = time.monotonic()
     slept = 0.0
     delay = SAFE_RETRY_INITIAL_DELAY_SECONDS
     while True:
         with fn() as response:
-            if _has_safe_retry_headers(response):
+            if response.status_code == 404 and _has_safe_retry_headers(response):
                 response.read()
             elapsed = max(time.monotonic() - started, slept)
             if not is_safe_to_retry_response(response) or elapsed >= SAFE_RETRY_BUDGET_SECONDS:

--- a/tests/core/test_sandbox_transient_retry.py
+++ b/tests/core/test_sandbox_transient_retry.py
@@ -1,5 +1,7 @@
 import asyncio
+import io
 import json
+from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
 import httpx
@@ -149,7 +151,8 @@ def response_handler(
     status: str,
     content: bytes,
     headers: tuple[bytes, ...] = (),
-):
+    content_type: bytes = b"application/json",
+) -> Callable[[asyncio.StreamReader, asyncio.StreamWriter], Awaitable[None]]:
     async def send(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         try:
             await read_request(reader)
@@ -157,7 +160,9 @@ def response_handler(
             pass
         writer.write(
             f"HTTP/1.1 {status}\r\n".encode()
-            + b"Content-Type: application/json\r\n"
+            + b"Content-Type: "
+            + content_type
+            + b"\r\n"
             + b"".join(header + b"\r\n" for header in headers)
             + f"Content-Length: {len(content)}\r\n".encode()
             + b"Connection: close\r\n\r\n"
@@ -204,6 +209,38 @@ send_completed_process = response_handler(
             "workingDir": "/tmp",
         }
     ).encode(),
+)
+send_streamed_process_with_reserved_headers = response_handler(
+    "200 OK",
+    (
+        json.dumps(
+            {
+                "type": "result",
+                "data": json.dumps(
+                    {
+                        "command": "echo ok",
+                        "completedAt": "now",
+                        "exitCode": 0,
+                        "logs": "ok",
+                        "name": "test",
+                        "pid": "1",
+                        "startedAt": "now",
+                        "status": "completed",
+                        "stderr": "",
+                        "stdout": "ok",
+                        "workingDir": "/tmp",
+                    }
+                ),
+            }
+        )
+        + "\n"
+    ).encode(),
+    (
+        b"X-Blaxel-Source: platform",
+        b"X-Blaxel-Error-Code: WORKLOAD_UNAVAILABLE",
+        b"X-Blaxel-Dispatch-State: not_dispatched",
+    ),
+    b"application/x-ndjson",
 )
 send_file_written = response_handler(
     "200 OK",
@@ -260,7 +297,7 @@ def test_classifier_rejects_application_responses():
 
 
 @pytest.mark.asyncio
-async def test_async_drive_list_retries_trusted_pre_dispatch_response():
+async def test_async_drive_list_retries_trusted_pre_dispatch_response() -> None:
     async with LoopbackFaultServer(
         send_safe_workload_unavailable,
         send_empty_drive_list,
@@ -273,7 +310,7 @@ async def test_async_drive_list_retries_trusted_pre_dispatch_response():
 
 
 @pytest.mark.asyncio
-async def test_async_process_exec_retries_trusted_pre_dispatch_response():
+async def test_async_process_exec_retries_trusted_pre_dispatch_response() -> None:
     async with LoopbackFaultServer(
         send_safe_workload_unavailable,
         send_completed_process,
@@ -287,7 +324,7 @@ async def test_async_process_exec_retries_trusted_pre_dispatch_response():
 
 
 @pytest.mark.asyncio
-async def test_sync_drive_list_retries_trusted_pre_dispatch_response():
+async def test_sync_drive_list_retries_trusted_pre_dispatch_response() -> None:
     async with LoopbackFaultServer(
         send_safe_workload_unavailable,
         send_empty_drive_list,
@@ -300,7 +337,7 @@ async def test_sync_drive_list_retries_trusted_pre_dispatch_response():
 
 
 @pytest.mark.asyncio
-async def test_sync_process_exec_retries_trusted_pre_dispatch_response():
+async def test_sync_process_exec_retries_trusted_pre_dispatch_response() -> None:
     async with LoopbackFaultServer(
         send_safe_workload_unavailable,
         send_completed_process,
@@ -317,7 +354,7 @@ async def test_sync_process_exec_retries_trusted_pre_dispatch_response():
 
 
 @pytest.mark.asyncio
-async def test_async_filesystem_read_retries_trusted_pre_dispatch_response():
+async def test_async_filesystem_read_retries_trusted_pre_dispatch_response() -> None:
     async with LoopbackFaultServer(
         send_safe_workload_unavailable,
         send_file_content,
@@ -330,7 +367,7 @@ async def test_async_filesystem_read_retries_trusted_pre_dispatch_response():
 
 
 @pytest.mark.asyncio
-async def test_sync_fetch_retries_trusted_pre_dispatch_response():
+async def test_sync_fetch_retries_trusted_pre_dispatch_response() -> None:
     async with LoopbackFaultServer(
         send_safe_workload_unavailable,
         send_ok_response,
@@ -344,7 +381,7 @@ async def test_sync_fetch_retries_trusted_pre_dispatch_response():
 
 
 @pytest.mark.asyncio
-async def test_async_fetch_does_not_replay_one_shot_body():
+async def test_async_fetch_does_not_replay_one_shot_body() -> None:
     async def body():
         yield b"payload"
 
@@ -361,7 +398,65 @@ async def test_async_fetch_does_not_replay_one_shot_body():
 
 
 @pytest.mark.asyncio
-async def test_async_drive_list_does_not_retry_untrusted_response():
+async def test_async_fetch_retries_bytes_backed_multipart_body() -> None:
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_ok_response,
+    ) as server:
+        network = SandboxNetwork(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        response = await network.fetch(
+            3000,
+            "/upload",
+            method="POST",
+            files={"file": ("payload.txt", b"payload")},
+        )
+
+    assert response.status_code == 200
+    assert server.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_fetch_retries_bytes_backed_multipart_body() -> None:
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_ok_response,
+    ) as server:
+        network = SyncSandboxNetwork(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        response = await asyncio.to_thread(
+            network.fetch,
+            3000,
+            "/upload",
+            "POST",
+            files={"file": ("payload.txt", b"payload")},
+        )
+
+    assert response.status_code == 200
+    assert server.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_does_not_replay_file_object() -> None:
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_ok_response,
+    ) as server:
+        network = SandboxNetwork(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        response = await network.fetch(
+            3000,
+            "/upload",
+            method="POST",
+            files={"file": ("payload.txt", io.BytesIO(b"payload"))},
+        )
+
+    assert response.status_code == 404
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_async_drive_list_does_not_retry_untrusted_response() -> None:
     async with LoopbackFaultServer(send_untrusted_workload_unavailable) as server:
         drive = SandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
 
@@ -372,7 +467,7 @@ async def test_async_drive_list_does_not_retry_untrusted_response():
 
 
 @pytest.mark.asyncio
-async def test_async_drive_list_preserves_malformed_trusted_response():
+async def test_async_drive_list_preserves_malformed_trusted_response() -> None:
     async with LoopbackFaultServer(send_malformed_workload_unavailable) as server:
         drive = SandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
 
@@ -384,7 +479,7 @@ async def test_async_drive_list_preserves_malformed_trusted_response():
 
 
 @pytest.mark.asyncio
-async def test_async_drive_list_does_not_retry_wrong_status():
+async def test_async_drive_list_does_not_retry_wrong_status() -> None:
     async with LoopbackFaultServer(send_wrong_status_workload_unavailable) as server:
         drive = SandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
 
@@ -396,7 +491,7 @@ async def test_async_drive_list_does_not_retry_wrong_status():
 
 
 @pytest.mark.asyncio
-async def test_async_drive_list_preserves_final_retryable_error(monkeypatch):
+async def test_async_drive_list_preserves_final_retryable_error(monkeypatch) -> None:
     monkeypatch.setattr(
         "blaxel.core.sandbox.transient_retry.SAFE_RETRY_BUDGET_SECONDS",
         0,
@@ -414,7 +509,7 @@ async def test_async_drive_list_preserves_final_retryable_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_async_streaming_process_exec_retries_before_dispatch():
+async def test_async_streaming_process_exec_retries_before_dispatch() -> None:
     async with LoopbackFaultServer(
         send_safe_workload_unavailable,
         send_completed_process,
@@ -434,7 +529,24 @@ async def test_async_streaming_process_exec_retries_before_dispatch():
 
 
 @pytest.mark.asyncio
-async def test_sync_streaming_process_exec_retries_before_dispatch():
+async def test_async_streaming_process_does_not_consume_non_404_response() -> None:
+    async with LoopbackFaultServer(send_streamed_process_with_reserved_headers) as server:
+        process = SandboxProcess(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        result = await process.exec(
+            {
+                "command": "echo ok",
+                "wait_for_completion": True,
+                "on_log": lambda _: None,
+            }
+        )
+
+    assert result.logs == "ok"
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_streaming_process_exec_retries_before_dispatch() -> None:
     async with LoopbackFaultServer(
         send_safe_workload_unavailable,
         send_completed_process,
@@ -455,7 +567,7 @@ async def test_sync_streaming_process_exec_retries_before_dispatch():
 
 
 @pytest.mark.asyncio
-async def test_async_streaming_process_preserves_final_retryable_error(monkeypatch):
+async def test_async_streaming_process_preserves_final_retryable_error(monkeypatch) -> None:
     monkeypatch.setattr(
         "blaxel.core.sandbox.transient_retry.SAFE_RETRY_BUDGET_SECONDS",
         0,
@@ -478,7 +590,7 @@ async def test_async_streaming_process_preserves_final_retryable_error(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_streaming_process_preserves_non_retryable_error():
+async def test_streaming_process_preserves_non_retryable_error() -> None:
     async with LoopbackFaultServer(send_bad_request) as server:
         process = SandboxProcess(SandboxConfiguration(cast(Any, None), force_url=server.url))
 
@@ -497,7 +609,7 @@ async def test_streaming_process_preserves_non_retryable_error():
 
 
 @pytest.mark.asyncio
-async def test_async_write_binary_rebuilds_body_for_safe_retry():
+async def test_async_write_binary_rebuilds_body_for_safe_retry() -> None:
     async with LoopbackFaultServer(
         send_safe_workload_unavailable,
         send_file_written,
@@ -511,7 +623,7 @@ async def test_async_write_binary_rebuilds_body_for_safe_retry():
 
 
 @pytest.mark.asyncio
-async def test_sync_write_binary_rebuilds_body_for_safe_retry():
+async def test_sync_write_binary_rebuilds_body_for_safe_retry() -> None:
     async with LoopbackFaultServer(
         send_safe_workload_unavailable,
         send_file_written,
@@ -527,7 +639,7 @@ async def test_sync_write_binary_rebuilds_body_for_safe_retry():
 
 
 @pytest.mark.asyncio
-async def test_sync_retry_uses_bounded_exponential_backoff(monkeypatch):
+async def test_sync_retry_uses_bounded_exponential_backoff(monkeypatch) -> None:
     sleeps = []
     monkeypatch.setattr("blaxel.core.sandbox.transient_retry.time.sleep", sleeps.append)
     async with LoopbackFaultServer(
@@ -544,7 +656,7 @@ async def test_sync_retry_uses_bounded_exponential_backoff(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_sync_retry_returns_final_error_when_budget_expires(monkeypatch):
+async def test_sync_retry_returns_final_error_when_budget_expires(monkeypatch) -> None:
     sleeps = []
     monkeypatch.setattr("blaxel.core.sandbox.transient_retry.time.sleep", sleeps.append)
     monkeypatch.setattr(
@@ -562,7 +674,7 @@ async def test_sync_retry_returns_final_error_when_budget_expires(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_async_retry_respects_cancellation():
+async def test_async_retry_respects_cancellation() -> None:
     async with LoopbackFaultServer(send_safe_workload_unavailable) as server:
         drive = SandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
         task = asyncio.create_task(drive.list())
@@ -578,7 +690,7 @@ async def test_async_retry_respects_cancellation():
 
 
 @pytest.mark.asyncio
-async def test_sync_process_exec_does_not_retry_ambiguous_transport_failure():
+async def test_sync_process_exec_does_not_retry_ambiguous_transport_failure() -> None:
     async with LoopbackFaultServer(close_without_response) as server:
         process = SyncSandboxProcess(SandboxConfiguration(cast(Any, None), force_url=server.url))
 

--- a/tests/core/test_sandbox_transient_retry.py
+++ b/tests/core/test_sandbox_transient_retry.py
@@ -11,10 +11,12 @@ from blaxel.core.common.settings import settings
 from blaxel.core.sandbox.client import errors as sandbox_errors
 from blaxel.core.sandbox.default.drive import SandboxDrive
 from blaxel.core.sandbox.default.filesystem import SandboxFileSystem
+from blaxel.core.sandbox.default.interpreter import CodeInterpreter
 from blaxel.core.sandbox.default.network import SandboxNetwork
 from blaxel.core.sandbox.default.process import SandboxProcess
 from blaxel.core.sandbox.sync.drive import SyncSandboxDrive
 from blaxel.core.sandbox.sync.filesystem import SyncSandboxFileSystem
+from blaxel.core.sandbox.sync.interpreter import SyncCodeInterpreter
 from blaxel.core.sandbox.sync.network import SyncSandboxNetwork
 from blaxel.core.sandbox.sync.process import SyncSandboxProcess
 from blaxel.core.sandbox.transient_retry import (
@@ -668,6 +670,43 @@ async def test_sync_write_binary_preserves_final_retryable_error(monkeypatch) ->
 
         with pytest.raises(ResponseError) as exc_info:
             await asyncio.to_thread(filesystem.write_binary, "/file.bin", b"payload")
+
+    assert exc_info.value.response.status_code == 404
+    assert exc_info.value.data["error"]["code"] == "WORKLOAD_UNAVAILABLE"
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_async_create_context_preserves_final_retryable_error(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "blaxel.core.sandbox.transient_retry.SAFE_RETRY_BUDGET_SECONDS",
+        0,
+    )
+    async with LoopbackFaultServer(send_safe_workload_unavailable) as server:
+        interpreter = CodeInterpreter(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        with pytest.raises(ResponseError) as exc_info:
+            await interpreter.create_code_context()
+        await interpreter.process.get_client().aclose()
+
+    assert exc_info.value.response.status_code == 404
+    assert exc_info.value.data["error"]["code"] == "WORKLOAD_UNAVAILABLE"
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_create_context_preserves_final_retryable_error(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "blaxel.core.sandbox.transient_retry.SAFE_RETRY_BUDGET_SECONDS",
+        0,
+    )
+    async with LoopbackFaultServer(send_safe_workload_unavailable) as server:
+        interpreter = SyncCodeInterpreter(
+            SandboxConfiguration(cast(Any, None), force_url=server.url)
+        )
+
+        with pytest.raises(ResponseError) as exc_info:
+            await asyncio.to_thread(interpreter.create_code_context)
 
     assert exc_info.value.response.status_code == 404
     assert exc_info.value.data["error"]["code"] == "WORKLOAD_UNAVAILABLE"

--- a/tests/core/test_sandbox_transient_retry.py
+++ b/tests/core/test_sandbox_transient_retry.py
@@ -1,19 +1,25 @@
 import asyncio
+import json
 from typing import Any, cast
 
 import httpx
 import pytest
 
 from blaxel.core.common.settings import settings
+from blaxel.core.sandbox.client import errors as sandbox_errors
+from blaxel.core.sandbox.default.drive import SandboxDrive
 from blaxel.core.sandbox.default.filesystem import SandboxFileSystem
+from blaxel.core.sandbox.default.network import SandboxNetwork
 from blaxel.core.sandbox.default.process import SandboxProcess
+from blaxel.core.sandbox.sync.drive import SyncSandboxDrive
 from blaxel.core.sandbox.sync.filesystem import SyncSandboxFileSystem
+from blaxel.core.sandbox.sync.process import SyncSandboxProcess
 from blaxel.core.sandbox.transient_retry import (
     is_transient_reset_error,
     retry_on_transient_reset,
     retry_on_transient_reset_async,
 )
-from blaxel.core.sandbox.types import ResponseError
+from blaxel.core.sandbox.types import ResponseError, SandboxConfiguration
 
 
 class LoopbackFaultServer:
@@ -85,6 +91,19 @@ class SyncSequenceClient:
         return result
 
 
+SAFE_WORKLOAD_UNAVAILABLE_BODY = json.dumps(
+    {
+        "error": {
+            "code": "WORKLOAD_UNAVAILABLE",
+            "origin": "platform",
+            "retryable": True,
+            "dispatch_state": "not_dispatched",
+            "safe_to_retry_request": True,
+        }
+    }
+).encode()
+
+
 def ok_json_response(data):
     return httpx.Response(
         200,
@@ -114,18 +133,79 @@ async def close_without_response(
     await writer.wait_closed()
 
 
-async def send_ok_response(
-    reader: asyncio.StreamReader,
-    writer: asyncio.StreamWriter,
-) -> None:
-    try:
-        await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=1.0)
-    except (TimeoutError, asyncio.IncompleteReadError, asyncio.LimitOverrunError):
-        pass
-    writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
-    await writer.drain()
-    writer.close()
-    await writer.wait_closed()
+async def read_request(reader: asyncio.StreamReader) -> None:
+    headers = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=1.0)
+    content_length = 0
+    for line in headers.decode(errors="ignore").split("\r\n"):
+        if line.lower().startswith("content-length:"):
+            content_length = int(line.split(":", 1)[1].strip())
+            break
+    if content_length:
+        await asyncio.wait_for(reader.readexactly(content_length), timeout=1.0)
+
+
+def response_handler(
+    status: str,
+    content: bytes,
+    headers: tuple[bytes, ...] = (),
+):
+    async def send(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            await read_request(reader)
+        except (TimeoutError, asyncio.IncompleteReadError, asyncio.LimitOverrunError):
+            pass
+        writer.write(
+            f"HTTP/1.1 {status}\r\n".encode()
+            + b"Content-Type: application/json\r\n"
+            + b"".join(header + b"\r\n" for header in headers)
+            + f"Content-Length: {len(content)}\r\n".encode()
+            + b"Connection: close\r\n\r\n"
+            + content
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    return send
+
+
+send_ok_response = response_handler("200 OK", b"ok")
+send_safe_workload_unavailable = response_handler(
+    "404 Not Found",
+    SAFE_WORKLOAD_UNAVAILABLE_BODY,
+    (
+        b"X-Blaxel-Source: platform",
+        b"X-Blaxel-Error-Code: WORKLOAD_UNAVAILABLE",
+        b"X-Blaxel-Dispatch-State: not_dispatched",
+    ),
+)
+send_untrusted_workload_unavailable = response_handler(
+    "404 Not Found",
+    SAFE_WORKLOAD_UNAVAILABLE_BODY,
+)
+send_empty_drive_list = response_handler("200 OK", b'{"mounts":[]}')
+send_completed_process = response_handler(
+    "200 OK",
+    json.dumps(
+        {
+            "command": "echo ok",
+            "completedAt": "now",
+            "exitCode": 0,
+            "logs": "ok",
+            "name": "test",
+            "pid": "1",
+            "startedAt": "now",
+            "status": "completed",
+            "stderr": "",
+            "stdout": "ok",
+            "workingDir": "/tmp",
+        }
+    ).encode(),
+)
+send_file_written = response_handler(
+    "200 OK",
+    b'{"message":"written","path":"/file.bin"}',
+)
 
 
 @pytest.fixture(autouse=True)
@@ -156,6 +236,231 @@ def test_classifier_accepts_httpx_transport_drops():
 
 def test_classifier_rejects_application_responses():
     assert not is_transient_reset_error(app_error_response())
+
+
+@pytest.mark.asyncio
+async def test_async_drive_list_retries_trusted_pre_dispatch_response():
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_empty_drive_list,
+    ) as server:
+        drive = SandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        assert await drive.list() == []
+
+    assert server.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_async_process_exec_retries_trusted_pre_dispatch_response():
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_completed_process,
+    ) as server:
+        process = SandboxProcess(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        result = await process.exec({"command": "echo ok", "wait_for_completion": True})
+
+    assert result.logs == "ok"
+    assert server.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_drive_list_retries_trusted_pre_dispatch_response():
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_empty_drive_list,
+    ) as server:
+        drive = SyncSandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        assert await asyncio.to_thread(drive.list) == []
+
+    assert server.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_process_exec_retries_trusted_pre_dispatch_response():
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_completed_process,
+    ) as server:
+        process = SyncSandboxProcess(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        result = await asyncio.to_thread(
+            process.exec,
+            {"command": "echo ok", "wait_for_completion": True},
+        )
+
+    assert result.logs == "ok"
+    assert server.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_does_not_replay_one_shot_body():
+    async def body():
+        yield b"payload"
+
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_ok_response,
+    ) as server:
+        network = SandboxNetwork(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        response = await network.fetch(3000, "/upload", method="POST", content=body())
+
+    assert response.status_code == 404
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_async_drive_list_does_not_retry_untrusted_response():
+    async with LoopbackFaultServer(send_untrusted_workload_unavailable) as server:
+        drive = SandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        with pytest.raises(sandbox_errors.UnexpectedStatus):
+            await drive.list()
+
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_async_drive_list_preserves_final_retryable_error(monkeypatch):
+    monkeypatch.setattr(
+        "blaxel.core.sandbox.transient_retry.SAFE_RETRY_BUDGET_SECONDS",
+        0,
+    )
+    async with LoopbackFaultServer(send_safe_workload_unavailable) as server:
+        drive = SandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        with pytest.raises(sandbox_errors.APIStatusError) as exc_info:
+            await drive.list()
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.error_code == "WORKLOAD_UNAVAILABLE"
+    assert exc_info.value.retryable is True
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_process_exec_retries_before_dispatch():
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_completed_process,
+    ) as server:
+        process = SandboxProcess(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        result = await process.exec(
+            {
+                "command": "echo ok",
+                "wait_for_completion": True,
+                "on_log": lambda _: None,
+            }
+        )
+
+    assert result.logs == "ok"
+    assert server.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_streaming_process_exec_retries_before_dispatch():
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_completed_process,
+    ) as server:
+        process = SyncSandboxProcess(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        result = await asyncio.to_thread(
+            process.exec,
+            {
+                "command": "echo ok",
+                "wait_for_completion": True,
+                "on_log": lambda _: None,
+            },
+        )
+
+    assert result.logs == "ok"
+    assert server.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_async_write_binary_rebuilds_body_for_safe_retry():
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_file_written,
+    ) as server:
+        filesystem = SandboxFileSystem(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        result = await filesystem.write_binary("/file.bin", b"payload")
+
+    assert result.path == "/file.bin"
+    assert server.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_write_binary_rebuilds_body_for_safe_retry():
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_file_written,
+    ) as server:
+        filesystem = SyncSandboxFileSystem(
+            SandboxConfiguration(cast(Any, None), force_url=server.url)
+        )
+
+        result = await asyncio.to_thread(filesystem.write_binary, "/file.bin", b"payload")
+
+    assert result.path == "/file.bin"
+    assert server.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_retry_uses_bounded_exponential_backoff(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("blaxel.core.sandbox.transient_retry.time.sleep", sleeps.append)
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_safe_workload_unavailable,
+        send_empty_drive_list,
+    ) as server:
+        drive = SyncSandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        assert await asyncio.to_thread(drive.list) == []
+
+    assert sleeps == [0.5, 1.0]
+    assert server.requests == 3
+
+
+@pytest.mark.asyncio
+async def test_sync_retry_returns_final_error_when_budget_expires(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("blaxel.core.sandbox.transient_retry.time.sleep", sleeps.append)
+    monkeypatch.setattr(
+        "blaxel.core.sandbox.transient_retry.SAFE_RETRY_BUDGET_SECONDS",
+        1.0,
+    )
+    async with LoopbackFaultServer(send_safe_workload_unavailable) as server:
+        drive = SyncSandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        with pytest.raises(sandbox_errors.APIStatusError):
+            await asyncio.to_thread(drive.list)
+
+    assert sleeps == [0.5, 0.5]
+    assert server.requests == 3
+
+
+@pytest.mark.asyncio
+async def test_async_retry_respects_cancellation():
+    async with LoopbackFaultServer(send_safe_workload_unavailable) as server:
+        drive = SandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
+        task = asyncio.create_task(drive.list())
+        while server.requests == 0:
+            await asyncio.sleep(0)
+        await asyncio.sleep(0.05)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert server.requests == 1
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_sandbox_transient_retry.py
+++ b/tests/core/test_sandbox_transient_retry.py
@@ -623,6 +623,23 @@ async def test_async_write_binary_rebuilds_body_for_safe_retry() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_write_binary_preserves_final_retryable_error(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "blaxel.core.sandbox.transient_retry.SAFE_RETRY_BUDGET_SECONDS",
+        0,
+    )
+    async with LoopbackFaultServer(send_safe_workload_unavailable) as server:
+        filesystem = SandboxFileSystem(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        with pytest.raises(ResponseError) as exc_info:
+            await filesystem.write_binary("/file.bin", b"payload")
+
+    assert exc_info.value.response.status_code == 404
+    assert exc_info.value.data["error"]["code"] == "WORKLOAD_UNAVAILABLE"
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
 async def test_sync_write_binary_rebuilds_body_for_safe_retry() -> None:
     async with LoopbackFaultServer(
         send_safe_workload_unavailable,
@@ -636,6 +653,25 @@ async def test_sync_write_binary_rebuilds_body_for_safe_retry() -> None:
 
     assert result.path == "/file.bin"
     assert server.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_write_binary_preserves_final_retryable_error(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "blaxel.core.sandbox.transient_retry.SAFE_RETRY_BUDGET_SECONDS",
+        0,
+    )
+    async with LoopbackFaultServer(send_safe_workload_unavailable) as server:
+        filesystem = SyncSandboxFileSystem(
+            SandboxConfiguration(cast(Any, None), force_url=server.url)
+        )
+
+        with pytest.raises(ResponseError) as exc_info:
+            await asyncio.to_thread(filesystem.write_binary, "/file.bin", b"payload")
+
+    assert exc_info.value.response.status_code == 404
+    assert exc_info.value.data["error"]["code"] == "WORKLOAD_UNAVAILABLE"
+    assert server.requests == 1
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_sandbox_transient_retry.py
+++ b/tests/core/test_sandbox_transient_retry.py
@@ -454,6 +454,29 @@ async def test_sync_streaming_process_exec_retries_before_dispatch():
 
 
 @pytest.mark.asyncio
+async def test_async_streaming_process_preserves_final_retryable_error(monkeypatch):
+    monkeypatch.setattr(
+        "blaxel.core.sandbox.transient_retry.SAFE_RETRY_BUDGET_SECONDS",
+        0,
+    )
+    async with LoopbackFaultServer(send_safe_workload_unavailable) as server:
+        process = SandboxProcess(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        with pytest.raises(ResponseError) as exc_info:
+            await process.exec(
+                {
+                    "command": "echo nope",
+                    "wait_for_completion": True,
+                    "on_log": lambda _: None,
+                }
+            )
+
+    assert exc_info.value.response.status_code == 404
+    assert exc_info.value.data["error"]["code"] == "WORKLOAD_UNAVAILABLE"
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
 async def test_async_write_binary_rebuilds_body_for_safe_retry():
     async with LoopbackFaultServer(
         send_safe_workload_unavailable,

--- a/tests/core/test_sandbox_transient_retry.py
+++ b/tests/core/test_sandbox_transient_retry.py
@@ -13,6 +13,7 @@ from blaxel.core.sandbox.default.network import SandboxNetwork
 from blaxel.core.sandbox.default.process import SandboxProcess
 from blaxel.core.sandbox.sync.drive import SyncSandboxDrive
 from blaxel.core.sandbox.sync.filesystem import SyncSandboxFileSystem
+from blaxel.core.sandbox.sync.network import SyncSandboxNetwork
 from blaxel.core.sandbox.sync.process import SyncSandboxProcess
 from blaxel.core.sandbox.transient_retry import (
     is_transient_reset_error,
@@ -184,6 +185,7 @@ send_untrusted_workload_unavailable = response_handler(
     SAFE_WORKLOAD_UNAVAILABLE_BODY,
 )
 send_empty_drive_list = response_handler("200 OK", b'{"mounts":[]}')
+send_file_content = response_handler("200 OK", b'{"content":"hello"}')
 send_completed_process = response_handler(
     "200 OK",
     json.dumps(
@@ -205,6 +207,24 @@ send_completed_process = response_handler(
 send_file_written = response_handler(
     "200 OK",
     b'{"message":"written","path":"/file.bin"}',
+)
+send_malformed_workload_unavailable = response_handler(
+    "404 Not Found",
+    b"[]",
+    (
+        b"X-Blaxel-Source: platform",
+        b"X-Blaxel-Error-Code: WORKLOAD_UNAVAILABLE",
+        b"X-Blaxel-Dispatch-State: not_dispatched",
+    ),
+)
+send_wrong_status_workload_unavailable = response_handler(
+    "503 Service Unavailable",
+    SAFE_WORKLOAD_UNAVAILABLE_BODY,
+    (
+        b"X-Blaxel-Source: platform",
+        b"X-Blaxel-Error-Code: WORKLOAD_UNAVAILABLE",
+        b"X-Blaxel-Dispatch-State: not_dispatched",
+    ),
 )
 
 
@@ -296,6 +316,33 @@ async def test_sync_process_exec_retries_trusted_pre_dispatch_response():
 
 
 @pytest.mark.asyncio
+async def test_async_filesystem_read_retries_trusted_pre_dispatch_response():
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_file_content,
+    ) as server:
+        filesystem = SandboxFileSystem(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        assert await filesystem.read("/file.txt") == "hello"
+
+    assert server.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_fetch_retries_trusted_pre_dispatch_response():
+    async with LoopbackFaultServer(
+        send_safe_workload_unavailable,
+        send_ok_response,
+    ) as server:
+        network = SyncSandboxNetwork(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        response = await asyncio.to_thread(network.fetch, 3000, "/health")
+
+    assert response.status_code == 200
+    assert server.requests == 2
+
+
+@pytest.mark.asyncio
 async def test_async_fetch_does_not_replay_one_shot_body():
     async def body():
         yield b"payload"
@@ -320,6 +367,30 @@ async def test_async_drive_list_does_not_retry_untrusted_response():
         with pytest.raises(sandbox_errors.UnexpectedStatus):
             await drive.list()
 
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_async_drive_list_preserves_malformed_trusted_response():
+    async with LoopbackFaultServer(send_malformed_workload_unavailable) as server:
+        drive = SandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        with pytest.raises(sandbox_errors.APIStatusError) as exc_info:
+            await drive.list()
+
+    assert exc_info.value.content == b"[]"
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_async_drive_list_does_not_retry_wrong_status():
+    async with LoopbackFaultServer(send_wrong_status_workload_unavailable) as server:
+        drive = SandboxDrive(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        with pytest.raises(sandbox_errors.APIStatusError) as exc_info:
+            await drive.list()
+
+    assert exc_info.value.status_code == 503
     assert server.requests == 1
 
 
@@ -459,6 +530,17 @@ async def test_async_retry_respects_cancellation():
 
         with pytest.raises(asyncio.CancelledError):
             await task
+
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_process_exec_does_not_retry_ambiguous_transport_failure():
+    async with LoopbackFaultServer(close_without_response) as server:
+        process = SyncSandboxProcess(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        with pytest.raises(httpx.TransportError):
+            await asyncio.to_thread(process.exec, {"command": "echo nope"})
 
     assert server.requests == 1
 

--- a/tests/core/test_sandbox_transient_retry.py
+++ b/tests/core/test_sandbox_transient_retry.py
@@ -186,6 +186,7 @@ send_untrusted_workload_unavailable = response_handler(
 )
 send_empty_drive_list = response_handler("200 OK", b'{"mounts":[]}')
 send_file_content = response_handler("200 OK", b'{"content":"hello"}')
+send_bad_request = response_handler("400 Bad Request", b'{"error":"bad request"}')
 send_completed_process = response_handler(
     "200 OK",
     json.dumps(
@@ -473,6 +474,25 @@ async def test_async_streaming_process_preserves_final_retryable_error(monkeypat
 
     assert exc_info.value.response.status_code == 404
     assert exc_info.value.data["error"]["code"] == "WORKLOAD_UNAVAILABLE"
+    assert server.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_process_preserves_non_retryable_error():
+    async with LoopbackFaultServer(send_bad_request) as server:
+        process = SandboxProcess(SandboxConfiguration(cast(Any, None), force_url=server.url))
+
+        with pytest.raises(ResponseError) as exc_info:
+            await process.exec(
+                {
+                    "command": "echo nope",
+                    "wait_for_completion": True,
+                    "on_log": lambda _: None,
+                }
+            )
+
+    assert exc_info.value.response.status_code == 400
+    assert exc_info.value.data["error"] == "bad request"
     assert server.requests == 1
 
 

--- a/tests/integration/core/sandbox/test_drives.py
+++ b/tests/integration/core/sandbox/test_drives.py
@@ -250,7 +250,7 @@ class TestSandboxDriveMounting(TestDriveOperations):
         not os.environ.get("RUN_STANDBY_TESTS"),
         reason="slow standby test; set RUN_STANDBY_TESTS=1 to enable",
     )
-    async def test_mounted_drive_recovers_after_standby(self):
+    async def test_mounted_drive_recovers_after_standby(self) -> None:
         drive_name = unique_name("standby-drive")
         sandbox_name = unique_name("standby-sandbox")
         await DriveInstance.create(

--- a/tests/integration/core/sandbox/test_drives.py
+++ b/tests/integration/core/sandbox/test_drives.py
@@ -246,6 +246,41 @@ class TestDriveInstanceCRUD(TestDriveOperations):
 class TestSandboxDriveMounting(TestDriveOperations):
     """Test sandbox drive mounting operations."""
 
+    @pytest.mark.skipif(
+        not os.environ.get("RUN_STANDBY_TESTS"),
+        reason="slow standby test; set RUN_STANDBY_TESTS=1 to enable",
+    )
+    async def test_mounted_drive_recovers_after_standby(self):
+        drive_name = unique_name("standby-drive")
+        sandbox_name = unique_name("standby-sandbox")
+        await DriveInstance.create(
+            {
+                "name": drive_name,
+                "size": 10,
+                "region": "eu-dub-1",
+                "labels": default_labels,
+            }
+        )
+        self.created_drives.append(drive_name)
+        sandbox = await SandboxInstance.create(
+            {
+                "name": sandbox_name,
+                "image": default_image,
+                "memory": 2048,
+                "region": "eu-dub-1",
+                "labels": default_labels,
+            }
+        )
+        self.created_sandboxes.append(sandbox_name)
+        await sandbox.drives.mount(drive_name, "/mnt/drive")
+        await sandbox.fs.write("/mnt/drive/sentinel.txt", "eng2972")
+
+        await asyncio.sleep(45)
+
+        mounts = await sandbox.drives.list()
+        assert any(mount.drive_name == drive_name for mount in mounts)
+        assert await sandbox.fs.read("/mnt/drive/sentinel.txt") == "eng2972"
+
     async def test_mounts_a_drive_to_a_sandbox(self):
         """Test mounting a drive to a sandbox."""
         drive_name = unique_name("mount-drive")


### PR DESCRIPTION
## Summary

Sandbox calls can fail while a workload resumes from standby. The first call can fail, although a later call succeeds.

This PR retries only when the platform proves that the request did not run. The SDK does not replay one-use request data.

If recovery is not possible, the SDK returns the final typed error with its response details.

## Verification

* `uv run --group test pytest tests/core -q`: 456 tests passed.
* Ruff checks passed.
* Ruff format checks passed.
* The targeted Pyright check passed.
* `git diff --check` passed.
* The Standards review passed.
* The Spec review passed.
* The live standby test has an environment gate. The SDK has no command that forces a sandbox into standby.

## Related PR

PR [#196](<https://github.com/blaxel-ai/sdk-python/issues/196>) retries when response data contains `retryable: true`. It does not require proof that the request did not run.

This PR requires the status, platform headers, response data, and replay rule to agree.

## Review Guide

### Why This PR Exists

[ENG-2972](https://linear.app/blaxel/issue/ENG-2972/sdk-intermittent-sandboxagent-drive-api-failures-after-standbyresume) reports that the first sandbox Drive, process, or filesystem request can fail after standby or resume, while a later request succeeds. This PR makes the SDK retry only when the platform says the sandbox was still starting and the request did not run. It also keeps the final error useful when the retry cannot continue.

### Behavior

The sandbox HTTP client now checks whether httpx can send the request body again before it enables the platform-response retry. Bytes, strings, JSON-like data, and bytes-backed multipart files can be sent again. One-use streams and file objects cannot be sent again.

The SDK retries a response only when the platform proves all of these facts: the status is 404, the response headers identify the platform and `WORKLOAD_UNAVAILABLE`, the dispatch state is `not_dispatched`, and the JSON body says `safe_to_retry_request` is true. The SDK then closes or reads the response, waits with bounded backoff, and sends the same request again while the 60 second retry time remains.

Other HTTP responses stay on the normal error path. Generated sandbox calls raise typed sandbox status errors for undocumented statuses. Streaming and direct sandbox actions raise their normal `ResponseError`. The final retryable platform response is not hidden when retry time ends.

Connection failures before a response are different. Only operations that already use the transient connection retry wrapper wait and try again, such as drive list, filesystem read/list/search paths, and process get/list/logs. Process exec and other calls without that wrapper return the connection error.

### Execution Flow

```mermaid
flowchart LR
  A[Caller starts a sandbox operation] --> B[SDK checks whether the request body can be sent again]

  B -- "body can be rebuilt" --> C[SDK sends the request with platform-response retry enabled]
  B -- "body is one-use data" --> D[SDK sends one request without platform-response retry]

  C --> E[SDK receives a response or connection error]
  D --> E

  E -- "normal success response arrives" --> F[Return the result]

  E -- "platform says sandbox was still starting and request did not run" --> G[Close the response and wait]
  G -- "body can be rebuilt and retry time remains" --> C
  G -- "retry time is used" --> H[Return the normal typed error]

  E -- "another error response arrives" --> H

  E -- "connection fails before any response" --> I[SDK checks whether this operation has a connection retry wrapper]
  I -- "drive list, filesystem read or list, or process get/list/logs has retry attempts left" --> J[Wait with connection backoff]
  J --> C
  I -- "operation has no connection retry wrapper or attempts are used" --> K[Return the connection error]
```

### Invariants And Failure Paths

The SDK must not replay a request body that httpx cannot rebuild. A platform retry requires both the special headers and the matching JSON body, so an application 404 or malformed response is not enough. The retry loop has a fixed time budget and returns the last response when the budget ends. Transport retry rejects errors that already have an HTTP response, so application errors do not become connection retries. Error text does not include raw response bodies; stable fields such as status, error code, retryability, and retry-after remain available.

### Reading Order

1. `src/blaxel/core/sandbox/transient_retry.py` - Read the replay check, platform-response classifier, retry loops, and connection-failure classifier.
2. `src/blaxel/core/sandbox/client/client.py` - See where sandbox sync and async HTTP clients enable the response retry only for replayable requests.
3. `src/blaxel/core/sandbox/default/process.py` - See process exec, stream, get, list, and logs call the correct retry path.
4. `src/blaxel/core/sandbox/default/filesystem.py` - See filesystem read/list/search, binary upload, and watch stream retry use.
5. `src/blaxel/core/sandbox/client/errors.py` and `tests/core/test_sandbox_transient_retry.py` - See final typed errors and the public behavior tests.

---

> \[!NOTE\] **Medium Risk**  <br>Retries touch all sandbox HTTP traffic and could duplicate side effects if classification were wrong; mitigations are strict platform signals and skipping non-replayable bodies. Error type changes (`APIStatusError`, `ResponseError`) may affect callers that caught older exception shapes.
>
> **Overview**  <br>Adds **bounded automatic retries** when the platform gateway returns a trusted `WORKLOAD_UNAVAILABLE` 404, so sandbox calls can survive standby/resume instead of failing immediately.
>
> **Core behavior** lives in `transient_retry`: strict classification via `X-Blaxel-*` headers and JSON body flags, **0.5s-30s exponential backoff** capped at **60s**, and **replay only when the httpx request body can be reconstructed**. New `SandboxHTTPClient` / `AsyncSandboxHTTPClient` wrap `request()` with that logic; streaming paths use `retry_safe_stream` / `retry_safe_stream_async`.
>
> **Wiring** swaps plain httpx clients for the sandbox wrappers across async/sync actions, filesystem multipart uploads, process log/exec streams, filesystem watch, and code interpreter execute streams. Several call sites now raise `ResponseError` instead of ad-hoc `RuntimeError` / generic exceptions; `from_response` returns `APIStatusError` with retry metadata instead of bare `UnexpectedStatus` for generic status errors.
>
> **Tests** expand loopback coverage for trusted vs untrusted responses, replay safety, streaming edge cases, backoff/cancellation, and a gated integration standby smoke test for mounted drives.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit f2390dc85f5ed8c5c3dec397f2ffd7e476c24b32.

---

> [!NOTE]
> Adds bounded exponential backoff retry for trusted `WORKLOAD_UNAVAILABLE` 404 responses from the platform gateway. Retries only when the response carries specific headers and body metadata proving the request never ran. Applies to both request-level and stream-level operations. Non-replayable bodies are excluded from retry. Standardizes error handling to use `ResponseError` across streaming paths.
>
> Written by [Mendral](<https://mendral.com>) for commit f2390dc85f5ed8c5c3dec397f2ffd7e476c24b32.