### PR TITLE
fix(sandbox): return immediately for terminal processes

### DIFF
--- a/src/blaxel/core/common/autoload.py
+++ b/src/blaxel/core/common/autoload.py
@@ -21,11 +21,17 @@ def telemetry() -> None:
 def autoload() -> None:
     client.with_base_url(settings.base_url)
     client.with_auth(settings.auth)
-    # Send the Blaxel-Version header on every control-plane request so list
-    # endpoints return cursor-paginated `{data, meta}` responses (>= 2026-04-28).
-    # Without it the API falls back to legacy bare-array listings and pagination
-    # (limit/cursor/next_page) is silently ignored.
-    client.with_headers({"Blaxel-Version": settings.api_version})
+    # Send SDK-identifying headers on every control-plane request so backend
+    # observability can classify Python SDK traffic and list endpoints return
+    # cursor-paginated `{data, meta}` responses (>= 2026-04-28). Without the
+    # User-Agent httpx falls back to `python-httpx/<version>`, which is tracked
+    # as a generic API request instead of SDK usage.
+    client.with_headers(
+        {
+            "Blaxel-Version": settings.api_version,
+            "User-Agent": settings.headers["User-Agent"],
+        }
+    )
 
     # Register response interceptors for authentication error handling
     # Access the underlying httpx clients and add event hooks

--- a/src/blaxel/core/sandbox/default/process.py
+++ b/src/blaxel/core/sandbox/default/process.py
@@ -399,8 +399,8 @@ class SandboxProcess(SandboxAction):
     ) -> ProcessResponse:
         """Wait for a process to complete."""
         start_time = asyncio.get_running_loop().time() * 1000  # Convert to milliseconds
-        status = "running"
         data = await self.get(identifier)
+        status = data.status or "running"
 
         while status == "running":
             await asyncio.sleep(interval / 1000)  # Convert to seconds

--- a/src/blaxel/core/sandbox/sync/process.py
+++ b/src/blaxel/core/sandbox/sync/process.py
@@ -341,8 +341,8 @@ class SyncSandboxProcess(SyncSandboxAction):
 
     def wait(self, identifier: str, max_wait: int = 60000, interval: int = 1000) -> ProcessResponse:
         start_time = time.monotonic() * 1000
-        status = "running"
         data = self.get(identifier)
+        status = data.status or "running"
         while status == "running":
             time.sleep(interval / 1000)
             try:

--- a/tests/core/test_environment.py
+++ b/tests/core/test_environment.py
@@ -123,6 +123,19 @@ def test_autoload_functionality():
             raise
 
 
+def test_autoload_sets_control_plane_user_agent():
+    """Control-plane requests should carry the Python SDK User-Agent."""
+    from blaxel.core.client import client
+    from blaxel.core.common.autoload import autoload
+    from blaxel.core.common.settings import settings
+
+    autoload()
+
+    assert client._headers["Blaxel-Version"] == settings.api_version
+    assert client._headers["User-Agent"] == settings.headers["User-Agent"]
+    assert client._headers["User-Agent"].startswith("blaxel/sdk/python/")
+
+
 def test_settings_properties():
     """Test that settings has the expected properties."""
     from blaxel.core.common.settings import settings

--- a/tests/core/test_sandbox_process.py
+++ b/tests/core/test_sandbox_process.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from blaxel.core.sandbox.default.process import SandboxProcess
+from blaxel.core.sandbox.sync.process import SyncSandboxProcess
+
+
+@pytest.mark.asyncio
+async def test_async_wait_returns_immediately_for_terminal_initial_status(monkeypatch):
+    process = object.__new__(SandboxProcess)
+    completed = SimpleNamespace(status="completed")
+    get = AsyncMock(return_value=completed)
+    sleep = AsyncMock()
+    monkeypatch.setattr(process, "get", get)
+    monkeypatch.setattr("blaxel.core.sandbox.default.process.asyncio.sleep", sleep)
+
+    assert await process.wait("process-id", interval=5000) is completed
+    get.assert_awaited_once_with("process-id")
+    sleep.assert_not_awaited()
+
+
+def test_sync_wait_returns_immediately_for_terminal_initial_status(monkeypatch):
+    process = object.__new__(SyncSandboxProcess)
+    completed = SimpleNamespace(status="completed")
+    get = Mock(return_value=completed)
+    sleep = Mock()
+    monkeypatch.setattr(process, "get", get)
+    monkeypatch.setattr("blaxel.core.sandbox.sync.process.time.sleep", sleep)
+
+    assert process.wait("process-id", interval=5000) is completed
+    get.assert_called_once_with("process-id")
+    sleep.assert_not_called()


### PR DESCRIPTION
Fixes ENG-4803

## Summary
- Use the initial process status in async and sync `wait()` calls.
- Return immediately when the first lookup is terminal instead of sleeping for one polling interval.
- Add regression coverage for both SDK variants.

## Testing
- Targeted unit tests: `2 passed`
- Ruff format and lint passed
- Real Blaxel E2E: async Python `wait(interval=5000)` returned in 147 ms after confirming a process was terminal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral fixes and header wiring in non-critical paths; limited scope with targeted tests.
>
> **Overview**
> **Sandbox `wait()`** no longer assumes a process is still running before the first poll. Async and sync implementations read status from the initial `get()` and exit the loop when it is already terminal (e.g. `completed`), avoiding an unnecessary sleep for one polling interval.
>
> **Control-plane autoload** now sends the Python SDK `User-Agent` from `settings.headers` together with `Blaxel-Version`, so backend traffic is attributed to the SDK instead of generic `python-httpx`.
>
> Regression tests cover immediate return for terminal status on both process clients and assert autoload sets the expected headers on the control-plane client.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b562cc749851ebecd30e0810129031d1944d0a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Uses the initial process status from `get()` in both async and sync `wait()` methods to skip the polling loop entirely when the process is already terminal. Also adds a `User-Agent` header to control-plane requests for SDK traffic classification.
>
> <sup>Written by [Mendral](https://mendral.com) for commit 1b562cc749851ebecd30e0810129031d1944d0a3.</sup>
<!-- /MENDRAL_SUMMARY -->