### PR TITLE
ENG-4847: send stable image build context hashes

### DIFF
--- a/src/blaxel/core/image/image.py
+++ b/src/blaxel/core/image/image.py
@@ -786,7 +786,7 @@ class ImageInstance:
         build_dir = build_dir.resolve()
         zip_buffer = io.BytesIO()
         with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-            for file_path in build_dir.rglob("*"):
+            for file_path in sorted(build_dir.rglob("*")):
                 if file_path.is_file():
                     # Resolve to handle symlinks and get the real path
                     resolved_path = file_path.resolve()
@@ -799,10 +799,21 @@ class ImageInstance:
                             f"Path traversal detected: {file_path} resolves outside build directory"
                         )
 
-                    arcname = file_path.relative_to(build_dir)
-                    zf.write(resolved_path, arcname)
+                    # ZIP headers normally include source mtimes and traversal order,
+                    # making byte-identical contexts produce different archives. Pin
+                    # those fields so the archive checksum is a stable content key.
+                    arcname = file_path.relative_to(build_dir).as_posix()
+                    info = zipfile.ZipInfo(arcname, date_time=(1980, 1, 1, 0, 0, 0))
+                    info.compress_type = zipfile.ZIP_DEFLATED
+                    info.external_attr = (resolved_path.stat().st_mode & 0xFFFF) << 16
+                    with resolved_path.open("rb") as source, zf.open(info, "w") as target:
+                        shutil.copyfileobj(source, target, length=1024 * 1024)
         zip_buffer.seek(0)
         return zip_buffer.getvalue()
+
+    @staticmethod
+    def _context_hash(zip_content: bytes) -> str:
+        return f"sha256-{hashlib.sha256(zip_content).hexdigest()}"
 
     def _create_sandbox_payload(self, name: str, memory: int = 4096) -> Sandbox:
         """
@@ -829,7 +840,7 @@ class ImageInstance:
         return Sandbox(metadata=metadata, spec=spec)
 
     def _create_sandbox_with_upload_sync(
-        self, sandbox: Sandbox
+        self, sandbox: Sandbox, context_hash: str | None = None
     ) -> tuple[Response[Sandbox], str | None]:
         """
         Create or update a sandbox with the upload query parameter.
@@ -842,6 +853,9 @@ class ImageInstance:
         """
         name = sandbox.metadata.name if sandbox.metadata else ""
         body = sandbox.to_dict()
+        params = {"upload": "true"}
+        if context_hash:
+            params["contextHash"] = context_hash
 
         # Try PUT first (update), fall back to POST (create)
         http_client = client.get_httpx_client()
@@ -851,7 +865,7 @@ class ImageInstance:
             method="put",
             url=f"/sandboxes/{name}",
             json=body,
-            params={"upload": "true"},
+            params=params,
             headers={"Content-Type": "application/json"},
         )
 
@@ -861,7 +875,7 @@ class ImageInstance:
                 method="post",
                 url="/sandboxes",
                 json=body,
-                params={"upload": "true"},
+                params=params,
                 headers={"Content-Type": "application/json"},
             )
 
@@ -887,7 +901,7 @@ class ImageInstance:
         return result, upload_url
 
     async def _create_sandbox_with_upload(
-        self, sandbox: Sandbox
+        self, sandbox: Sandbox, context_hash: str | None = None
     ) -> tuple[Response[Sandbox], str | None]:
         """
         Create or update a sandbox with the upload query parameter (async).
@@ -900,6 +914,9 @@ class ImageInstance:
         """
         name = sandbox.metadata.name if sandbox.metadata else ""
         body = sandbox.to_dict()
+        params = {"upload": "true"}
+        if context_hash:
+            params["contextHash"] = context_hash
 
         # Try PUT first (update), fall back to POST (create)
         http_client = client.get_async_httpx_client()
@@ -909,7 +926,7 @@ class ImageInstance:
             method="put",
             url=f"/sandboxes/{name}",
             json=body,
-            params={"upload": "true"},
+            params=params,
             headers={"Content-Type": "application/json"},
         )
 
@@ -919,7 +936,7 @@ class ImageInstance:
                 method="post",
                 url="/sandboxes",
                 json=body,
-                params={"upload": "true"},
+                params=params,
                 headers={"Content-Type": "application/json"},
             )
 
@@ -1175,12 +1192,15 @@ class ImageInstance:
         try:
             # Create zip
             zip_content = self._create_zip(build_dir)
+            context_hash = self._context_hash(zip_content)
 
             # Create sandbox payload
             sandbox_payload = self._create_sandbox_payload(name, memory)
 
             # Create/update sandbox and get upload URL
-            response, upload_url = self._create_sandbox_with_upload_sync(sandbox_payload)
+            response, upload_url = self._create_sandbox_with_upload_sync(
+                sandbox_payload, context_hash
+            )
 
             if response.status_code.value >= 400:
                 raise RuntimeError(
@@ -1258,12 +1278,15 @@ class ImageInstance:
         try:
             # Create zip (sync, as it's file I/O)
             zip_content = self._create_zip(build_dir)
+            context_hash = self._context_hash(zip_content)
 
             # Create sandbox payload
             sandbox_payload = self._create_sandbox_payload(name, memory)
 
             # Create/update sandbox and get upload URL
-            response, upload_url = await self._create_sandbox_with_upload(sandbox_payload)
+            response, upload_url = await self._create_sandbox_with_upload(
+                sandbox_payload, context_hash
+            )
 
             if response.status_code.value >= 400:
                 raise RuntimeError(

--- a/tests/core/test_image.py
+++ b/tests/core/test_image.py
@@ -1,14 +1,18 @@
 """Tests for Image builder functionality."""
 
+import importlib
 import json
 import os
 import shutil
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from blaxel.core.image import ImageBuildContext, ImageInstance, LocalFile
+
+image_module = importlib.import_module("blaxel.core.image.image")
 
 
 @pytest.fixture
@@ -1256,3 +1260,52 @@ class TestSandboxApiPreparation:
         assert entrypoint_idx > run_idx
         # Entrypoint should be last
         assert entrypoint_idx > copy_idx
+
+
+def test_build_archive_and_context_hash_are_content_stable(temp_dir):
+    first = temp_dir / "first"
+    second = temp_dir / "second"
+    first.mkdir()
+    second.mkdir()
+    for directory in (first, second):
+        (directory / "b.txt").write_text("second")
+        (directory / "a.txt").write_text("first")
+
+    os.utime(first / "a.txt", (1_700_000_000, 1_700_000_000))
+    os.utime(second / "a.txt", (1_800_000_000, 1_800_000_000))
+
+    image = ImageInstance.from_registry("python:3.11")
+    first_zip = image._create_zip(first)
+    second_zip = image._create_zip(second)
+
+    assert first_zip == second_zip
+    assert image._context_hash(first_zip) == image._context_hash(second_zip)
+    assert image._context_hash(first_zip).startswith("sha256-")
+    assert len(image._context_hash(first_zip)) == 71
+
+
+def test_upload_request_carries_context_hash(monkeypatch):
+    calls = []
+
+    class FakeClient:
+        def request(self, **kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(
+                status_code=200,
+                headers={"x-blaxel-upload-url": "https://upload.example"},
+                content=b"{}",
+                json=lambda: {},
+            )
+
+    monkeypatch.setattr(type(image_module.client), "get_httpx_client", lambda _self: FakeClient())
+    image = ImageInstance.from_registry("python:3.11")
+    sandbox = image._create_sandbox_payload("cached")
+    context_hash = f"sha256-{'a' * 64}"
+
+    _, upload_url = image._create_sandbox_with_upload_sync(sandbox, context_hash)
+
+    assert upload_url == "https://upload.example"
+    assert calls[0]["params"] == {
+        "upload": "true",
+        "contextHash": context_hash,
+    }


### PR DESCRIPTION
## Summary
- make generated image-context ZIPs byte-stable across traversal order and source mtimes
- compute `sha256-<digest>` from the actual uploaded archive
- pass that context hash through synchronous and asynchronous sandbox upload requests
- preserve compatibility with older controlplanes, which ignore the additional query parameter

## Dependency
Companion controlplane PR: https://github.com/blaxel-ai/controlplane/pull/5215

## Validation
- `uv run ruff format --check src/blaxel/core/image/image.py tests/core/test_image.py`
- `uv run ruff check src/blaxel/core/image/image.py tests/core/test_image.py`
- `uv run --group test pytest tests/core/test_image.py -q` (133 passed)
- `uv run --group test pytest --import-mode=importlib tests -q` (684 passed, 36 skipped)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox deploy/upload request params and archive construction used for image builds. Hash/ZIP changes could skip or force rebuilds if the controlplane interprets `contextHash` incorrectly, but the extra query param is backward-compatible.
> 
> **Overview**
> Makes sandbox image-context ZIPs **byte-stable** so identical content produces the same archive checksum, then sends that checksum as `contextHash` on create/update upload requests.
> 
> `_create_zip` now sorts files, uses POSIX arcnames, pins ZIP timestamps, and writes entries via `ZipInfo` (file modes still preserved). `_context_hash` hashes the uploaded bytes as `sha256-<digest>` and both sync and async sandbox upload paths pass it as a query param. Older controlplanes can ignore the extra param.
> 
> Tests cover ZIP/hash stability across mtime and traversal order, and that the upload request includes `contextHash`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aaa496b49ad643f22d4e8c1052134e6451cc812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Makes image build context ZIP archives byte-stable by sorting file traversal order and pinning mtimes to a fixed epoch, then computes a SHA-256 hash of the archive and sends it as a `contextHash` query parameter alongside sandbox upload requests.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8aaa496b49ad643f22d4e8c1052134e6451cc812.</sup>
<!-- /MENDRAL_SUMMARY -->