### PR TITLE
feat(core): settings.integration appends an integration product token to the User-Agent

### DIFF
--- a/src/blaxel/core/common/autoload.py
+++ b/src/blaxel/core/common/autoload.py
@@ -18,6 +18,15 @@ def telemetry() -> None:
     telemetry_manager.initialize(settings)
 
 
+def _set_user_agent(request) -> None:
+    # Resolved per request so a later `settings.integration = ...` is honored.
+    request.headers["User-Agent"] = settings.user_agent
+
+
+async def _set_user_agent_async(request) -> None:
+    _set_user_agent(request)
+
+
 def autoload() -> None:
     client.with_base_url(settings.base_url)
     client.with_auth(settings.auth)
@@ -31,9 +40,11 @@ def autoload() -> None:
     # Access the underlying httpx clients and add event hooks
     # Use sync interceptors for sync clients and async interceptors for async clients
     httpx_client = client.get_httpx_client()
+    httpx_client.event_hooks["request"] = [_set_user_agent]
     httpx_client.event_hooks["response"] = response_interceptors_sync
 
     httpx_async_client = client.get_async_httpx_client()
+    httpx_async_client.event_hooks["request"] = [_set_user_agent_async]
     httpx_async_client.event_hooks["response"] = response_interceptors_async
 
     httpx_sandbox_client = client_sandbox.get_httpx_client()

--- a/src/blaxel/core/common/settings.py
+++ b/src/blaxel/core/common/settings.py
@@ -155,15 +155,20 @@ class Settings:
         self._integration = value
 
     @property
-    def headers(self) -> Dict[str, str]:
-        """Get the headers for API requests."""
-        headers = self.auth.get_headers()
+    def user_agent(self) -> str:
+        """User-Agent sent on every request: SDK token, then the integration token if set."""
         os_arch = _get_os_arch()
         user_agent = f"blaxel/sdk/python/{self.version} ({os_arch}) blaxel/{self.commit}"
         integration = self.integration
         if integration:
             user_agent = f"{user_agent} {integration}"
-        headers["User-Agent"] = user_agent
+        return user_agent
+
+    @property
+    def headers(self) -> Dict[str, str]:
+        """Get the headers for API requests."""
+        headers = self.auth.get_headers()
+        headers["User-Agent"] = self.user_agent
         headers["Blaxel-Version"] = self.api_version
         return headers
 

--- a/src/blaxel/core/common/settings.py
+++ b/src/blaxel/core/common/settings.py
@@ -1,5 +1,7 @@
+import logging
 import os
 import platform
+import re
 from pathlib import Path
 from typing import Dict
 
@@ -9,6 +11,12 @@ from ..authentication import BlaxelAuth, auth
 from .logger import init_logger
 
 BLAXEL_API_VERSION = "2026-04-28"
+
+# An integration built on this SDK identifies itself with one User-Agent product
+# token: "<name>/<semver>", lowercase name, e.g. "deepseek-harness-blaxel-sandbox/0.1.2".
+INTEGRATION_TOKEN_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
+
+logger = logging.getLogger(__name__)
 
 
 def _get_int_env(name: str, default: int) -> int:
@@ -56,6 +64,7 @@ class Settings:
         init_logger(self.log_level)
         self.auth = auth(self.env, self.base_url)
         self._headers = None
+        self._integration: str | None = None
 
     @property
     def env(self) -> str:
@@ -118,11 +127,43 @@ class Settings:
         return _get_int_env("BL_SANDBOX_READ_RETRIES", 5)
 
     @property
+    def integration(self) -> str:
+        """Product token identifying the integration built on this SDK, or "".
+
+        Set programmatically (``settings.integration = "my-integration/1.2.0"``) or
+        through ``BL_INTEGRATION``. The token is appended to the User-Agent so Blaxel
+        can attribute traffic to the integration. Format: ``<name>/<semver>`` with a
+        lowercase name. An invalid value is ignored with a warning.
+        """
+        value = (
+            self._integration
+            if self._integration is not None
+            else os.environ.get("BL_INTEGRATION", "")
+        )
+        if not value:
+            return ""
+        if not INTEGRATION_TOKEN_PATTERN.match(value):
+            logger.warning(
+                "Ignoring invalid Blaxel integration token %r: expected <name>/<semver> with a lowercase name",
+                value,
+            )
+            return ""
+        return value
+
+    @integration.setter
+    def integration(self, value: str | None) -> None:
+        self._integration = value
+
+    @property
     def headers(self) -> Dict[str, str]:
         """Get the headers for API requests."""
         headers = self.auth.get_headers()
         os_arch = _get_os_arch()
-        headers["User-Agent"] = f"blaxel/sdk/python/{self.version} ({os_arch}) blaxel/{self.commit}"
+        user_agent = f"blaxel/sdk/python/{self.version} ({os_arch}) blaxel/{self.commit}"
+        integration = self.integration
+        if integration:
+            user_agent = f"{user_agent} {integration}"
+        headers["User-Agent"] = user_agent
         headers["Blaxel-Version"] = self.api_version
         return headers
 

--- a/tests/core/test_settings_integration.py
+++ b/tests/core/test_settings_integration.py
@@ -1,0 +1,73 @@
+"""Tests for the integration product token appended to the User-Agent."""
+
+import os
+import re
+
+import pytest
+
+from blaxel.core.common.settings import settings
+
+SDK_USER_AGENT = re.compile(r"^blaxel/sdk/python/\S+ \([^)]+\) blaxel/\S+")
+
+
+@pytest.fixture(autouse=True)
+def _reset_integration():
+    settings.integration = None
+    os.environ.pop("BL_INTEGRATION", None)
+    yield
+    settings.integration = None
+    os.environ.pop("BL_INTEGRATION", None)
+
+
+def test_user_agent_has_no_token_by_default():
+    user_agent = settings.headers["User-Agent"]
+    assert SDK_USER_AGENT.fullmatch(user_agent), user_agent
+    assert settings.integration == ""
+
+
+def test_programmatic_token_is_appended_once():
+    settings.integration = "deepseek-harness-blaxel-sandbox/0.1.2"
+    user_agent = settings.headers["User-Agent"]
+    assert user_agent.endswith(" deepseek-harness-blaxel-sandbox/0.1.2")
+    assert SDK_USER_AGENT.match(user_agent)
+    assert user_agent.count("deepseek-harness-blaxel-sandbox") == 1
+
+
+def test_env_token_is_used_when_not_set_programmatically():
+    os.environ["BL_INTEGRATION"] = "herdr/1.4.0-rc.1"
+    assert settings.headers["User-Agent"].endswith(" herdr/1.4.0-rc.1")
+
+
+def test_programmatic_token_wins_over_env():
+    os.environ["BL_INTEGRATION"] = "herdr/1.4.0-rc.1"
+    settings.integration = "deepseek-harness-blaxel-sandbox/0.1.2"
+    assert settings.headers["User-Agent"].endswith(" deepseek-harness-blaxel-sandbox/0.1.2")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Deepseek/0.1.2",
+        "deepseek-harness",
+        "deepseek/0.1",
+        "a/1.0.0 b/1.0.0",
+        "deepseek/0.1.2 (extra)",
+        " x/1.0.0",
+    ],
+)
+def test_invalid_token_is_ignored(value, caplog):
+    settings.integration = value
+    with caplog.at_level("WARNING"):
+        user_agent = settings.headers["User-Agent"]
+    assert SDK_USER_AGENT.fullmatch(user_agent), user_agent
+    assert "invalid Blaxel integration token" in caplog.text
+
+
+def test_other_headers_are_untouched():
+    settings.integration = "deepseek-harness-blaxel-sandbox/0.1.2"
+    with_token = dict(settings.headers)
+    settings.integration = None
+    without_token = dict(settings.headers)
+    with_token.pop("User-Agent")
+    without_token.pop("User-Agent")
+    assert with_token == without_token

--- a/tests/core/test_settings_integration.py
+++ b/tests/core/test_settings_integration.py
@@ -71,3 +71,20 @@ def test_other_headers_are_untouched():
     with_token.pop("User-Agent")
     without_token.pop("User-Agent")
     assert with_token == without_token
+
+
+def test_control_plane_client_sends_sdk_user_agent(monkeypatch):
+
+    from blaxel.core.client.client import client
+    from blaxel.core.common.autoload import autoload
+
+    monkeypatch.setenv("BL_INTEGRATION", "my-integration/1.2.0")
+    autoload()
+    httpx_client = client.get_httpx_client()
+    request = httpx_client.build_request("GET", "https://example.invalid/v0/sandboxes")
+    for hook in httpx_client.event_hooks["request"]:
+        hook(request)
+    ua = request.headers["User-Agent"]
+    assert ua.startswith("blaxel/sdk/python/")
+    assert ua.endswith(" my-integration/1.2.0")
+    assert "python-httpx" not in ua


### PR DESCRIPTION
## Why

Every Blaxel integration built on this SDK should be attributable in PostHog, Sentry, and SigNoz at a base level. The convention (ENG-1681) is one product token appended to the SDK User-Agent:

```
blaxel/sdk/python/0.2.0 (linux/amd64) blaxel/4b5045a herdr/1.4.0-rc.1
```

## What

- `settings.integration` (setter) or `BL_INTEGRATION`, programmatic value first. Format `<name>/<semver>`, lowercase name, prerelease allowed. An invalid value is ignored with a `logging` warning so it can never break a request.
- `settings.headers` appends the token to `User-Agent`. No other header changes. Exactly one token.
- Fix found while verifying on dev: the control-plane httpx client never received the SDK `User-Agent` (only `Blaxel-Version`), so every Python API call arrived as `python-httpx/<v>` and was classified as raw API traffic. A request hook in `autoload` now sets `User-Agent` from the new `settings.user_agent` on each request, so the SDK token and the integration token both reach the control plane, including a `settings.integration` set after import.
- `tests/core/test_settings_integration.py`: default, programmatic, env, precedence, six invalid shapes, header isolation, control-plane client sends the SDK User-Agent.

Control plane counterpart that parses the token into `integration` / `integration-version` tracking properties: blaxel-ai/controlplane#5349. TypeScript SDK counterpart: blaxel-ai/sdk-typescript PR linked in ENG-1681.

Refs [ENG-1681](https://linear.app/blaxel/issue/ENG-1681)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only header changes with validation that fails open; limited to User-Agent composition and client request hooks.
> 
> **Overview**
> Adds optional **integration attribution** on outbound API traffic: integrators can set `settings.integration` or `BL_INTEGRATION` with a validated `<name>/<semver>` token (lowercase name; invalid values are dropped with a warning so requests still succeed).
> 
> **User-Agent** is built in a new `settings.user_agent` property (SDK string plus at most one integration suffix) and wired through `settings.headers`. For the control-plane **httpx** clients, **autoload** registers per-request hooks so a later programmatic `settings.integration` change is reflected and the default httpx product token is overridden.
> 
> New tests cover defaults, env vs programmatic precedence, invalid token shapes, header isolation, and the autoload request hook behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5a984e825a092d4e4a032a158315437a2918ecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
